### PR TITLE
v1.1.0 - Create PDP XSD for IAP's, and add New-IapSubmissionPackage

### DIFF
--- a/Documentation/PDP.md
+++ b/Documentation/PDP.md
@@ -9,6 +9,7 @@
 *   [Sections](#sections)
     *   [Screenshots and Captions](#screenshots-and-captions)
         *   [Folder Structure](#folder-structure)
+    *   [Icons](#icons)
 *   [Schemas And Samples](#schemas-and-samples)
 *   [Loc Attributes and Comments](#loc-attributes-and-comments)
     *   [Marking A String To Not Be Localized](#marking-a-string-to-not-be-localized)
@@ -43,6 +44,8 @@ localize the relevant content.
 The main sections that you'll find in the PDP (depending on which schema version is in use)
 are as follows:
 
+**For Application Submissions**
+ * AppStoreName
  * Keywords
  * Description
  * ReleaseNotes
@@ -55,11 +58,18 @@ are as follows:
  * SupportContactInfo
  * PrivacyPolicyURL
 
+**For In-App Product (IAP) ("add-on") Submissions**
+ * Title
+ * Description
+ * Icon
+
 These should map fairly clearly to the sections you're already familiar with in the DevPortal.
 For additional requirements on number of elements or length of individual elements, refer to
 the schema (or sample file).
 
 ### Screenshots and Captions
+
+> Only relevant for Application submissions
 
 It's worth a little bit of additional time to explain how screenshots and captions work.
 
@@ -103,16 +113,32 @@ where:
     looking recusively for the specific filename
  * `img.png`: the filename that you specified in the caption's platform-specific image attribute
 
+### Icons
+
+> Only relevant for In-App Product (IAP) ("add-on") submissions
+
+Unlike screenshots, icons have no associated captions with them.  However, it is possible that
+your IAP may need to use a different icon based on the region (maybe a different symbol or color
+is needed based on that region's culture), and so the icon is part of the PDP.
+
+The only thing that can be specified for the Icon is the filename of that icon.  It is expected
+that the filename will be found within the defined [folder structure](#folder-structure).
 
 ----------
 
 ## Schemas and Samples
 
-At this time, StoreBroker only has a single PDP schema in use:
+At this time, StoreBroker has two PDP schemas in use:
 
+### Application Submissions
  * **Uri**: `http://schemas.microsoft.com/appx/2012/ProductDescription`
  * **XSD**: [PDP\ProductDescription.xsd](..\PDP\ProductDescription.xsd)
  * **Sample XML**: [PDP\ProductDescription.xml](..\PDP\ProductDescription.xml)
+
+### In-App Product (IAP) ("add-on") Submissions
+ * **Uri**: `http://schemas.microsoft.com/appx/2012/InAppProductDescription`
+ * **XSD**: [PDP\InAppProductDescription.xsd](..\PDP\InAppProductDescription.xsd)
+ * **Sample XML**: [PDP\InAppProductDescription.xml](..\PDP\InAppProductDescription.xml)
 
 ----------
 

--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -9,7 +9,7 @@
     *   [Logging](#logging)
     *   [Common Switches](#common-switches)
     *   [Accessing the Portal](#accessing-the-portal)
-*   [Creating Your Payload](#creating-your-payload)
+*   [Creating Your Application Payload](#creating-your-application-payload)
 *   [Creating A New Application Submission](#creating-a-new-application-submission)
     *    [The Easy Way](#the-easy-way)
     *    [Manual Submissions](#manual-submissions)
@@ -20,6 +20,7 @@
     *   [Flighting Commands](#flighting-commands)
 *   [In App Products](#in-app-products)
     *   [IAP Overview](#iap-overview)
+    *   [Creating Your IAP Payload](#creating-your-iap-payload)
     *   [IAP Commands](#iap-commands)
 *   [Using INT vs PROD](#using-int-vs-prod)
 *   [Telemetry](#telemetry)
@@ -95,7 +96,7 @@ to the appropriate page on the dev portal for what you're looking for, make use 
    you'll be taken to the page where you can view/edit the flight that the flight submission is
    associated with.
 
-## Creating Your Payload
+## Creating Your Application Payload
 
 In StoreBroker, a "payload" is a combination of a json file and a zip file.  The **json** file
 has the entire content of a Windows Store Submission.  This content _could_ be submitted as-is,
@@ -115,7 +116,7 @@ following the instructions in [SETUP.md](SETUP.md):
 
 Generating the submission request JSON/zip package is done with
 
-    New-SubmissionPackage <config-path> -PDPRootPath <path> [[-Release] <string>] -PDPInclude <filename> [-PDPExclude <filename>] -ImagesRootPath <path> -AppxPath <full-path>[, <additional-path>]+ -OutPath <output-dir> -OutName <output-name>  
+    New-SubmissionPackage -ConfigPath <config-path> -PDPRootPath <path> [[-Release] <string>] -PDPInclude <filename> [-PDPExclude <filename>] -ImagesRootPath <path> -AppxPath <full-path>[, <additional-path>]+ -OutPath <output-dir> -OutName <output-name>  
 
 > Items in brackets ('[]') are optional.
 
@@ -474,7 +475,7 @@ submissions).
 **Return Values**:
 `Update-ApplicationFlightSubmission` returns back two values to you at its completion:
 the new submission id, and the UploadURL.  You can use that UploadUrl to upload your submission's
-.zip with `Upload-SubmissionPackage`, in the event that you didn't specify the `PackagePath`
+.zip with `Upload-SubmissionPackage` in the event that you didn't specify the `PackagePath`
 or want to upload it again.
 
 #### Other Common Flight-related Tasks:
@@ -534,20 +535,57 @@ In-App Products (IAP's) are additional features that are offered to users of you
 In the Store, IAP's are considered siblings to Applications, as opposed to children,
 because the same IAP can be associated with more than one Application.
 
-### IAP Commands
+### Creating Your IAP Payload
 
-> As noted in [limitations](../README.md#limitations), we have full support for IAP's, but unlike
-> App Submissions and Flights, we do not yet have a [PDP](PDP.md) format for IAP
-> metadata, nor a function like `New-SubmissionPackage` to generate the json/zip payload that the
-> IAP functions require.  This is [on our backlog](https://github.com/Microsoft/StoreBroker/issues/3).
-> If you use IAP's and would like to help, please refer to [CONTRIBUTING.md](../CONTRIBUTING.md).
+> These instructions very closely mirror those for [Creating Your Application Payload](#creating-your-application-payload),
+> by design.
+
+In StoreBroker, a "payload" is a combination of a json file and a zip file.  The **json** file
+has the entire content of a Windows Store Submission.  This content _could_ be submitted as-is,
+but usually only selected portions of it are "patched" into a new submission.  The **zip** file
+usually has the icons for the localized listings, although depending on how you create your payload,
+those might be missing.
+
+To create your payload, you need to have the following (which you should already have from
+following the instructions in [SETUP.md](SETUP.md):
+ * [StoreBroker config file](SETUP.md#getting-your-iap-config)
+ * [PDP files](SETUP.md#getting-your-iap-pdps)
+ * Icons (if you use them in your listing)
+
+> In order to use New-InAppProductSubmissionPackage, it is highly recommended that you read the
+> documentation (`Get-Help New-InAppProductSubmissionPackage -Full`) and read the
+> documentation in the configuration file.
+
+Generating the submission request JSON/zip package is done with
+
+    New-InAppProductSubmissionPackage -ConfigPath <config-path> -PDPRootPath <path> [[-Release] <string>] -PDPInclude <filename> [-PDPExclude <filename>] -ImagesRootPath <path> -OutPath <output-dir> -OutName <output-name>  
+
+> Items in brackets ('[]') are optional.
+
+The `-Release` parameter is technically optional, depending on how you choose to store your PDP
+files. For more info, run:
+
+    Get-Help New-InAppProductSubmissionPackage -Parameter PdpRootPath
+    Get-Help New-InAppProductSubmissionPackage -Parameter Release
+    
+> If one of your parameters does not change often, you can specify a value in the config file and
+> leave out this parameter at runtime. In this case, you should specify the remaining parameters
+> to `New-InAppProductSubmissionPackage` with their parameter names.  As an example, it is
+> possible to leave out `OutPath` but if you don't specify the remaining parameters by name,
+> then the value of the next parameter, `OutName`, will be mapped to the `OutPath` parameter,
+> causing a failure.
+    
+As part of its input, `New-InAppProductSubmissionPackage` expects a configuration file, which
+you should have [already created](SETUP.md#getting-your-iap-config).
+
+### IAP Commands
 
 You'll find the layout of these commands to mimic those for Applications and Flights.
 For every Get-* command there is a corresponding Format-* command that you can leverage.
 
 > All IAP commands use the fully-spelled-out "InAppProduct".  Even though PowerShell supports tab
 > completion at the commandline, aliases also exist for all of these commands as well.  Any time
-> you see a command that has the phrase "InAppProduct", there exits an alias for that same command
+> you see a command that has the phrase "InAppProduct", there exists an alias for that same command
 > that replaces that phrase with "Iap" (e.g. Get-InAppProducts -> Get-Iaps).
 
 The basic syntax looks of the update command looks like this:
@@ -619,13 +657,13 @@ fully override the publication and visibility of your IAP submission.
 
 `Update-InAppProductSubmission` is a convenience method that wraps a number of individual
 commands into a single command.  If you want to understand exactly what it does, refer to the
-previous section on ["manual submissions."](#manual-submissions) (similar methods exist for IAP
-submissions).
+previous section on ["manual submissions"](#manual-submissions) for applications (similarly-named
+methods exist for IAP submissions).
 
 **Return Values**:
 `Update-InAppProductSubmission` returns back two values to you at its completion:
 the new submission id, and the UploadURL.  You can use that UploadUrl to upload your submission's
-.zip with `Upload-SubmissionPackage`, in the event that you didn't specify the `PackagePath`
+.zip with `Upload-SubmissionPackage` in the event that you didn't specify the `PackagePath`
 or want to upload it again.
 
 #### Other Common IAP-related Tasks:
@@ -648,10 +686,15 @@ To create a new IAP:
     New-InAppProduct -ProductId <productId> -ProductType <productType> -ApplicationIds <applicationIds>
 
 where
- * **`<applicationIds>`** is a comma-separated list of ApplicationIds that should be able to offer
-   this IAP.
  * **`<productId>`** is a unique name that you provide to refer to this IAP in this API and in your
    actual application sourcecode.
+ * **`<productType>`** is either `Consumable` for a "Developer managed consumable", or
+   `Durable` for a "durable managed consumable".  Please note that at this time, although the
+   Developer Web Portal supports the creation of "Store Managed Consumables", the Store Submission
+   API _does not_.  For more information on these types, see the online
+   [documentation](http://go.microsoft.com/fwlink/?LinkId=787042).
+ * **`<applicationIds>`** is a comma-separated list of ApplicationIds that should be able to offer
+   this IAP.
 
 To delete an IAP:
 

--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -1,0 +1,606 @@
+﻿# Copyright (C) Microsoft Corporation.  All rights reserved.
+
+<#
+    .SYNOPSIS
+        Script for converting an existing In-AppProduct (IAP) submission in the Store
+        to the January 2017 PDP schema.
+
+    .DESCRIPTION
+        Script for converting an existing In-AppProduct (IAP) submission in the Store
+        to the January 2017 PDP schema.
+
+        The Git-repo for the StoreBroker module can be found here: http://aka.ms/StoreBroker
+
+    .PARAMETER IapId
+        The ID of the IAP that the PDP's will be getting created for.
+        The most recent submission for this IAP will be used unless a SubmissionId is
+        explicitly specified.
+
+    .PARAMETER SubmissionId
+        The ID of the application submission that the PDP's will be getting created for.
+        The most recent submission for IapId will be used unless a value for this parameter is
+        provided.
+
+    .PARAMETER Release
+        The release to use.  This value will be placed in each new PDP and used in conjunction with '-OutPath'.
+        Some examples could be "1601" for a January 2016 release, "March 2016", or even just "1".
+
+    .PARAMETER PdpFileName
+        The name of the PDP file that will be generated for each region.
+
+    .PARAMETER OutPath
+        The output directory.
+        This script will create two subfolders of OutPath:
+           <OutPath>\PDPs\<Release>\
+           <OutPath>\Images\<Release>\
+        Each of these sub-folders will have region-specific subfolders for their file content.
+
+    .EXAMPLE
+        .\ConvertFrom-ExistingSubmission -IapId 0ABCDEF12345 -Release "March Release" -OutPath "C:\NewPDPs"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $IapId,
+
+    [string] $SubmissionId = $null,
+
+    [Parameter(Mandatory)]
+    [string] $Release,
+
+    [string] $PdpFileName = "PDP.xml",
+
+    [Parameter(Mandatory)]
+    [string] $OutPath
+)
+
+# Import Write-Log
+$rootDir = Split-Path -Path $PSScriptRoot -Parent
+$helpers = "$rootDir\StoreBroker\Helpers.ps1"
+if (-not (Test-Path -Path $helpers -PathType Leaf))
+{
+    throw "Script execution requires Helpers.ps1 which is part of the git repo.  Please execute this script from within your cloned repo."
+}
+. $helpers
+
+#region Comment Constants
+$script:LocIdAttribute = "_locID"
+$script:LocIdFormat = "Iap_{0}"
+$script:CommentFormat = " _locComment_text=`"{{MaxLength={0}}} {1}`" "
+#endregion Comment Constants
+
+function Add-ToElement
+{
+<#
+    .SYNOPSIS
+        Adds an arbitrary number of comments and attributes to an XmlElement.
+
+    .PARAMETER Element
+        The XmlElement to be modified.
+
+    .PARAMETER Comment
+        An array of comments to add to the element.
+
+    .PARAMETER Attribute
+        A hashtable where the keys are the attribute names and the values are the attribute values.
+
+    .NOTES
+        If a provided attribute already exists on the Element, the Element will NOT be modified.
+        It will ONLY be modified if the Element does not have that attribute.
+
+    .EXAMPLE
+        PS C:\>$xml = [xml] (Get-Content $filePath)
+        PS C:\>$root = $xml.DocumentElement
+        PS C:\>Add-ToElement -Element $root -Comment "Comment1", "Comment2" -Attribute @{ "Attrib1"="Val1"; "Attrib2"="Val2" }
+
+        Adds two comments and two attributes to the root element of the XML document.
+        
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlElement] $Element,
+
+        [string[]] $Comment,
+
+        [hashtable] $Attribute
+    )
+
+    if ($Comment.Count -gt 1)
+    {
+        # Reverse 'Comment' array in order to preserve order because of nature of 'Prepend'
+        # Input array is modified in place, no need to capture result
+        [Array]::Reverse($Comment)
+    }
+
+    foreach ($text in $Comment)
+    {
+        if (-not [String]::IsNullOrWhiteSpace($text))
+        {
+            $elem = $Element.OwnerDocument.CreateComment($text)
+            $Element.PrependChild($elem) | Out-Null
+        }
+    }
+
+    foreach ($key in $Attribute.Keys)
+    {
+        if ($null -eq $Element.$key)
+        {
+            $Element.SetAttribute($key, $Attribute[$key])
+        }
+        else
+        {
+            $out = "For element $($Element.LocalName), did not create attribute '$key' with value '$($Attribute[$key])' because the attribute already exists."
+            Write-Log $out -Level Warning
+        }
+    }
+}
+
+function Ensure-RootChild
+{
+<#
+    .SYNOPSIS
+        Creates the specified element as a child of the XML root node, only if that element does not exist already.
+
+    .PARAMETER Xml
+        The XmlDocument to (potentially) modify.
+
+    .PARAMETER Element
+        The name of the element to existence check.
+
+    .OUTPUTS
+        XmlElement. Returns a reference to the (possibly newly created) element requested.
+
+    .EXAMPLE
+        PS C:\>$xml = [xml] (Get-Content $filePath)
+        PS C:\>Ensure-RootChild -Xml $xml -Element "SomeElement"
+
+        $xml.DocumentElement.SomeElement now exists and is an XmlElement object.
+#>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification="Best description for purpose")]
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [string] $Element
+    )
+
+    # ProductDescription node
+    $root = $Xml.DocumentElement
+
+    if ($root.GetElementsByTagName($Element).Count -eq 0)
+    {
+        $elem = $Xml.CreateElement($Element, $Xml.DocumentElement.NamespaceURI)
+        $root.AppendChild($elem) | Out-Null
+    }
+
+    return $root.GetElementsByTagName($Element)[0]
+}
+
+function Add-Title
+{
+<#
+    .SYNOPSIS
+        Creates the Title node.
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "Title"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.title
+
+    # Add comment to parent
+    $maxChars = 100
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
+        "Comment" = @($script:CommentFormat -f $maxChars, "IAP $elementName"; " [required] ")
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-Description
+{
+<#
+    .SYNOPSIS
+        Creates the description node
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "Description"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.description
+
+    # Add comment to parent
+    $maxChars = 200
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
+        "Comment" = @("$script:CommentFormat" -f $maxChars, "IAP $elementName"; " [optional] ")
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-Icon
+{
+<#
+    .SYNOPSIS
+        Creates the icon node.
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+
+    .OUTPUTS
+        [String] The path specified for the icon (if available)
+
+    .NOTES
+        This function is implemented a bit differently than the others.
+        Icon is an optional element, but if it's specified, the Filename attribute must
+        be included with a non-empty value.  This is fine if the Listing has an icon defined,
+        but if it doesn't, then we want to include the element, but commented out so that users
+        know later what they need to add if they wish to include an icon at some future time.
+        We will create/add the icon node the way we do in all other cases so that we have its XML, 
+        but if we then determine that there is no icon for that listing, we'll convert the element
+        to its XML string representation that we can add as a comment, and then remove the actual
+        node.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    # For this element, we want the comment above, rather than inside, the element.
+    $comment = $Xml.CreateComment(' [optional] Specifying an icon is optional. If provided, the icon must be a 300 x 300 png file. ')
+    $Xml.DocumentElement.AppendChild($comment ) | Out-Null
+
+    $iconFilename = $Listing.icon.fileName
+
+    $elementName = "Icon"
+    [System.Xml.XmlElement] $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+
+    $maxChars = 200
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ 'Filename' = $iconFilename };
+    }
+
+    Add-ToElement @paramSet
+
+    if ($null -eq $iconFilename)
+    {
+        # We'll just comment this out for now since it's not being used.
+        # We do a tiny bit of extra processing to remove the unnecessary xmlns attribute that
+        # is added to the node when we get the OuterXml.
+        $iconElementXml = $elementNode.OuterXml -replace 'xmlns="[^"]+"', ""
+        $comment = $Xml.CreateComment(" $iconElementXml ")
+        $Xml.DocumentElement.RemoveChild($elementNode) | Out-Null
+        $Xml.DocumentElement.AppendChild($comment ) | Out-Null
+    }
+
+    return $iconFilename
+}
+
+function ConvertFrom-Listing
+{
+<#
+    .SYNOPSIS
+        Converts a base listing for an existing submission into a PDP file that conforms with
+        the January 2017 PDP schema.
+
+    .PARAMETER Listing
+        The base listing from the submission for the indicated Lang.
+
+    .PARAMETER Lang
+        The language / region code for the PDP (e.g. "en-us")
+
+    .PARAMETER Release
+        The release to use.  This value will be placed in each new PDP.
+        Some examples could be "1601" for a January 2016 release, "March 2016", or even just "1".
+
+    .PARAMETER PdpRootPath
+        The root / base path that all of the language sub-folders will go for the PDP files.
+
+    .PARAMETER FileName
+        The name of the PDP file that will be generated.
+
+    .OUTPUTS
+        [String[]] Array of image names that the PDP references
+
+    .EXAMPLE
+        ConvertFrom-Listing -Listing ($sub.listings."en-us".baseListing) -Lang "en-us" -Release "1701" -PdpRootPath "C:\PDPs\" -FileName "PDP.xml"
+
+        Converts the given "en-us" base listing to the current PDP schema,
+        and saves it to "c:\PDPs\en-us\PDP.xml"
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing,
+
+        [Parameter(Mandatory)]
+        [string] $Lang,
+
+        [Parameter(Mandatory)]
+        [string] $Release,
+
+        [Parameter(Mandatory)]
+        [string] $PdpRootPath,
+
+        [Parameter(Mandatory)]
+        [string] $FileName
+    )
+
+    $xml = [xml]([String]::Format('<?xml version="1.0" encoding="utf-8"?>
+    <InAppProductDescription language="en-us"
+        xmlns="http://schemas.microsoft.com/appx/2012/InAppProductDescription"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xml:lang="{0}"
+        Release="{1}"/>', $Lang, $Release))
+
+    Add-Title -Xml $Xml -Listing $Listing    
+    Add-Description -Xml $Xml -Listing $Listing
+    $icon = Add-Icon -Xml $Xml -Listing $Listing
+
+    $imageNames = @()
+    $imageNames += $icon
+
+    # Save XML object to file
+    $filePath = Ensure-PdpFilePath -PdpRootPath $PdpRootPath -Lang $Lang -FileName $FileName
+    $xml.Save($filePath)
+
+    # Post-process the file to ensure CRLF (sometimes is only LF).
+    $content = Get-Content -Encoding UTF8 -Path $filePath
+    $content -join [Environment]::NewLine | Out-File -Force -Encoding utf8 -FilePath $filePath
+
+    return $imageNames
+}
+
+function Ensure-PdpFilePath
+{
+<#
+    .SYNOPSIS
+        Ensures that the containing folder for a PDP file that will be generated exists so that
+        it can successfully be written.
+
+    .DESCRIPTION
+        Ensures that the containing folder for a PDP file that will be generated exists so that
+        it can successfully be written.
+
+    .PARAMETER PdpRootPath
+        The root / base path that all of the language sub-folders will go for the PDP files.
+
+    .PARAMETER Lang
+        The language / region code for the PDP (e.g. "en-us")
+
+    .PARAMETER FileName
+        The name of the PDP file that will be generated.
+
+    .EXAMPLE
+        Ensure-PdpFilePath -PdpRootPath "C:\PDPs\" -Lang "en-us" -FileName "PDP.xml"
+
+        Ensures that the path c:\PDPs\en-us\ exists, creating any sub-folder along the way as
+        necessary, and then returns the path "c:\PDPs\en-us\PDP.xml"
+
+    .OUTPUTS
+        [String] containing the full path to the PDP file.
+#>
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification="Best description for purpose")]
+    param(
+        [Parameter(Mandatory)]
+        [string] $PdpRootPath,
+
+        [string] $Lang,
+
+        [string] $FileName
+    )
+
+    $dropFolder = Join-Path -Path $PdpRootPath -ChildPath $Lang
+    if (-not (Test-Path -PathType Container -Path $dropFolder))
+    {
+        New-Item -Force -ItemType Directory -Path $dropFolder | Out-Null
+    }
+
+    return (Join-Path -Path $dropFolder -ChildPath $FileName)
+}
+
+function Show-ImageFileNames
+{
+<#
+    .SYNOPSIS
+        Informs the user what the image filenames are that they need to make available to StoreBroker.
+
+    .DESCRIPTION
+        Informs the user what the image filenames are that they need to make available to StoreBroker.
+
+    .PARAMETER LangImageNames
+        A hashtable, indexed by langcode, containing an array of image names that the listing
+        for that langcode references.
+
+    .PARAMETER Release
+        The release name that was added to the PDP files.
+
+    .EXAMPLE
+        Show-ImageFileNames -LangImageNames $langImageNames -Release "1701"
+#>
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="The most common scenario is that there will be multiple images, not a singular image.")]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $LangImageNames,
+
+        [Parameter(Mandatory)]
+        [string] $Release
+    )
+
+    # If there are no screenshots, nothing to do here
+    if ($LangImageNames.Count -eq 0)
+    {
+        return
+    }
+
+    # If there are no images being used at all, then we can also early return
+    $imageCount = 0;
+    foreach ($lang in $LangImageNames.GetEnumerator())
+    {
+        $imageCount += $lang.Value.Count
+    }
+
+    if ($imageCount.Count -eq 0)
+    {
+        return
+    }
+
+    $output = @()
+    $output += "You now need to find all of your images and place them here: <ImagesRootPath>\$Release\<langcode>\..."
+    $output += "  where <ImagesRootPath> is the path defined in your config file,"
+    $output += "  and <langcode> is the same langcode for the directory of the PDP file referencing those images."
+    Write-Log $($output -join [Environment]::NewLine)
+
+    # Quick analysis to help teams out if they need to do anything special with their PDP's
+
+    $langs = $LangImageNames.Keys | ConvertTo-Array
+    $seenImages = $LangImageNames[$langs[0]]
+    $imagesDiffer = $false
+    for ($i = 1; ($i -lt $langs.Count) -and (-not $imagesDiffer); $i++)
+    {
+        if (($LangImageNames[$langs[$i]].Count -ne $seenImages.Count))
+        {
+            $imagesDiffer = $true
+            break
+        }
+
+        foreach ($image in $LangImageNames[$langs[$i]])
+        {
+            if ($seenImages -notcontains $image)
+            {
+                $imagesDiffer = $true
+                break
+            }
+        }
+    }
+
+    # Now show the user the image filenames
+    if ($imagesDiffer)
+    {
+        $output = @()
+        $output += "It appears that you don't have consistent images across all languages."
+        $output += "While StoreBroker supports this scenario, some localization systems may"
+        $output += "not support this without additional work.  Please refer to the FAQ in"
+        $output += "the documentation for more info on how to best handle this scenario."
+        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+
+        $output = @()
+        $output += "The currently referenced image filenames, per langcode, are as follows:"
+        foreach ($langCode in ($LangImageNames.Keys.GetEnumerator() | Sort-Object))
+        {
+            $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
+        }
+    
+        Write-Log $($output -join [Environment]::NewLine)
+    }
+    else
+    {
+        $output = @()
+        $output += "Every language that has a PDP references the following images:"
+        $output += "`t$($seenImages -join `"`n`t`")"
+        Write-Log $($output -join [Environment]::NewLine)
+    }
+}
+
+# function Main is invoked at the bottom of the file
+function Main
+{
+    [CmdletBinding()]
+    param()
+
+    if ($null -eq (Get-Module StoreBroker))
+    {
+        $message = "The StoreBroker module is not available in this PowerShell session.  Please import the module, authenticate correctly using Set-StoreBrokerAuthentication, and try again."
+        throw $message
+    }
+
+    if ([String]::IsNullOrEmpty($SubmissionId))
+    {
+        $iap = Get-InAppProduct -IapId $IapId
+        $SubmissionId = $iap.lastPublishedInAppProductSubmission.id
+        if ([String]::IsNullOrEmpty($SubmissionId))
+        {
+            $SubmissionId = $iap.pendingInAppProductSubmission.id
+            Write-Log "No published submission exists for this In-App Product.  Using the current pending submission." -Level Warning
+        }
+    }
+
+    $sub = Get-InAppProductSubmission -IapId $IapId -SubmissionId $SubmissionId
+
+    $langImageNames = @{}
+    $langs = ($sub.listings | Get-Member -type NoteProperty)
+    $pdpsGenerated = 0
+    $langs |
+        ForEach-Object {
+            $lang = $_.Name
+            Write-Log "Creating PDP for $lang" -Level Verbose
+            Write-Progress -Activity "Generating PDP" -Status $lang -PercentComplete $(($pdpsGenerated / $langs.Count) * 100)
+            try
+            {
+                $imageNames = ConvertFrom-Listing -Listing ($sub.listings.$lang) -Lang $lang -Release $Release -PdpRootPath $OutPath -FileName $PdpFileName
+                $langImageNames[$lang] = $imageNames
+                $pdpsGenerated++
+            }
+            catch
+            {
+                Write-Log "Error creating [$lang] PDP: $($Error[0].Exception.Message )" -Level Error
+                throw
+            }
+        }
+
+    if ($pdpsGenerated -gt 0)
+    {
+        Write-Log "PDP's have been created here: $OutPath"
+        Show-ImageFileNames -LangImageNames $langImageNames -Release $Release
+    }
+    else
+    {
+        $output = @()
+        $output += "No PDPs were generated."
+        $output += "Please verify that this existing In-App Product has one or more language listings that this extension can convert,"
+        $output += "otherwise you can start fresh using the sample PDP\InAppProductDescription.xml as a starting point."
+        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+    }
+}
+
+
+# function Main invocation
+Main

--- a/PDP/InAppProductDescription.xml
+++ b/PDP/InAppProductDescription.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<InAppProductDescription language="en-us"
+    xmlns="http://schemas.microsoft.com/appx/2012/InAppProductDescription"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    Release="1611">
+
+  <!-- Valid length: 100 character limit -->
+  <Title _locID="Iap_Title">
+    <!-- _locComment_text="{MaxLength=100} IAP Title"-->
+    <!-- [required] -->My Localized App Add-on IAP
+  </Title>
+
+   <!-- Valid length: 200 character limit -->
+   <Description _locID="Iap_Description">
+     <!-- _locComment_text="{MaxLength=200} IAP Description" -->
+     <!-- [optional] -->This add-on will provide you with 200 extra coins.
+   </Description>
+
+  <!-- [optional] Specifying an icon is optional. If provided, the icon must be a 300 x 300 png file. -->
+  <Icon Filename="icon.png"/>
+
+</InAppProductDescription>

--- a/PDP/InAppProductDescription.xsd
+++ b/PDP/InAppProductDescription.xsd
@@ -1,0 +1,105 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xs:schema 
+  attributeFormDefault="unqualified" 
+  elementFormDefault="qualified" 
+  targetNamespace="http://schemas.microsoft.com/appx/2012/InAppProductDescription" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:tns="http://schemas.microsoft.com/appx/2012/InAppProductDescription">
+
+  <xs:simpleType name="NonNullNormalizedString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:minLength value="1" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="LocIdAttribute">
+    <xs:attribute name="_locID" type="xs:string" use="optional"/>
+  </xs:attributeGroup>
+
+  <xs:simpleType name="TitleString">
+    <xs:restriction base="tns:NonNullNormalizedString">
+      <xs:pattern value="\s*(\S(.){0,100}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="DescriptionString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,200}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="IconAttribute">
+    <xs:attribute name="Filename" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="\s*(\S(.){0,96}\.png\s*)?"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:simpleType name="ReleaseString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,254}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="InAppProductDescription">
+    <xs:annotation>
+      <xs:documentation>
+        Root element of InAppProductDescription document type. For content guidance on all required and optional fields in the product description, see http://go.microsoft.com/fwlink/p/?linkid=221134.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+
+        <!-- COMMON section-->
+
+        <xs:element name="Title" minOccurs="1" maxOccurs="1">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Required, the title for the add-on listing. May not exceed 100 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:TitleString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="Description" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional, the description for the add-on listing. May not exceed 200 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:DescriptionString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="Icon" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional, the icon for the listing.
+                The icon should be a 300 x 300 png file.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:attributeGroup ref="tns:IconAttribute"/>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:all>
+      <xs:attribute name="language" type="xs:language" use="required" />
+      <xs:attribute name="Release" type="tns:ReleaseString" use="required" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/README.md
+++ b/README.md
@@ -81,13 +81,6 @@ At this time, we don't have support for these newest additions to the API, but t
   - Package Rollout
   - Mandatory Update
 
-Also of note:
-
-We have full support for IAP's, but unlike App Submissions and Flights, we do not yet have
-a [PDP](Documentation/PDP.md) format for IAP metadata, nor a function like `New-SubmissionPackage`
-to generate the json/zip payload that the IAP functions require.  This is
-[on our backlog](https://github.com/Microsoft/StoreBroker/issues/3) as well.
-
 ### Prerequisites
 
 This module requires PowerShell [version 4](https://en.wikipedia.org/wiki/PowerShell#PowerShell_4.0)

--- a/StoreBroker.pssproj
+++ b/StoreBroker.pssproj
@@ -43,13 +43,17 @@
     <Compile Include="Documentation\PDP.md" />
     <Compile Include="Documentation\RESTPROXY.md" />
     <Compile Include="Documentation\SETUP.md" />
+    <Compile Include="Extensions\ConvertFrom-ExistingIapSubmission.ps1" />
     <Compile Include="Extensions\ConvertFrom-ExistingSubmission.ps1" />
     <Compile Include="LICENSE" />
+    <Compile Include="PDP\InAppProductDescription.xml" />
+    <Compile Include="PDP\InAppProductDescription.xsd" />
     <Compile Include="PDP\ProductDescription.xml" />
     <Compile Include="PDP\ProductDescription.xsd" />
     <Compile Include="README.md" />
     <Compile Include="StoreBroker\AppConfigTemplate.json" />
     <Compile Include="StoreBroker\Helpers.ps1" />
+    <Compile Include="StoreBroker\IapConfigTemplate.json" />
     <Compile Include="StoreBroker\NugetTools.ps1" />
     <Compile Include="StoreBroker\PackageTool.ps1" />
     <Compile Include="StoreBroker\StoreBroker.psd1" />

--- a/StoreBroker/AppConfigTemplate.json
+++ b/StoreBroker/AppConfigTemplate.json
@@ -149,7 +149,7 @@
         // This isn't required, but adding this will help protect you from submitting something
         // to the wrong application when working at the commandline.
         //
-        // Ex: "AppId": "0ABCDEF12345"
+        // Ex: "appId": "0ABCDEF12345"
         "appId": "",
 
         /////////////////////////////////

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -303,6 +303,51 @@ function Get-SHA512Hash
     return [System.BitConverter]::ToString($sha512.ComputeHash($utf8.GetBytes($PlainText))) -replace '-', ''
 }
 
+function ConvertTo-Array
+{
+<#
+    .SYNOPSIS
+        Converts a value (or pipeline input) into an array.
+
+    .DESCRIPTION
+        Converts a value (or pipeline input) into an array.
+
+        The Git repo for this module can be found here: http://aka.ms/StoreBroker
+
+    .PARAMETER Value
+        The value to convert into an array
+
+    .EXAMPLE
+        $foo = @{ "a" = 1; "b" = 2}; $foo.Keys | ConvertTo-Array
+
+        Returns back an array of the keys (as opposed to a KeyCollection)
+
+    .OUTPUTS
+        [Object[]]
+#>
+    param(
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline)]
+        [Object] $Value
+    )
+
+    Begin
+    {
+        $output = @(); 
+    }
+
+    Process
+    {
+        $output += $_; 
+    }
+
+    End
+    {
+        return ,$output; 
+    }
+}
+
 function Write-Log
 {
 <#

--- a/StoreBroker/IapConfigTemplate.json
+++ b/StoreBroker/IapConfigTemplate.json
@@ -1,0 +1,249 @@
+// Copyright (C) Microsoft Corporation.  All rights reserved.
+
+// This configuration file is for use with the StoreBroker PowerShell module.
+// Configure details of the In-App Product ("add on") here, as well as the location of resources
+// used by the packaging tool.
+
+// Inline Comments can be placed in this file using the '//' delimiter.
+// The delimiter and any remaining text on that line will be removed.
+
+{
+    // New-InAppProductSubmissionPackage parameters
+    //
+    // If you notice one of the parameters you specify to New-InAppProductSubmissionPackage does not change, you can specify it here
+    // in order to avoid providing it at runtime.  If New-InAppProductSubmissionPackage does not have a parameter it needs, it will
+    // check the provided config file for a non-null, non-empty value.  The exception to this is -ConfigPath which must
+    // always be provided.  For information on these parameters see the README.md or run `help New-InAppProductSubmissionPackage -ShowWindow`
+    //
+    // WARNING: Specifying a parameter at runtime will ignore any value placed in the config file.
+
+    "packageParameters": {
+
+        // There are two supported layouts for your PDP files:
+        //     1. <PDPRootPath>\<lang-code>\...\PDP.xml
+        //     2. <PDPRootPath>\<Release>\<lang-code>\...\PDP.xml
+        // The only difference between these two is that there is a <Release> directory after the
+        // <PDPRootPath> and before the <lang-code> sub-directories.
+        //
+        // The first layout is generally used when your localization system will be downloading
+        // the localized PDP files during your build.  In that situation, it's always retrieving
+        // the latest version.  Alternatively, if the latest localized versions of your PDP
+        // files are always stored in the same location, this layout is also for you.
+        //
+        // On the other hand, if you will be archiving the localized PDP's based on each release
+        // to the Store, then the second layout is the one that you should use.  In this scenario,
+        // you will specify the value of "<Release>" immediately below, or at the commandline.
+        //
+        // Only specify 'PDPRootPath' here if it does not change.
+        // DO NOT use environment variables in the config.  If you need to use an environment
+        // variable to get to the right path, then you need to specify that path at the commandline
+        // instead.
+        //
+        // File separator '\' must be escaped, i.e. '\\'
+        // Ex: \\\\filehare\\Public\\AppPDPs\\MyApp
+
+        "PDPRootPath": "",
+
+        // If your PDP files are being placed in a directory structure like this:
+        //     <PDPRootPath>\<Release>\<lang-code>\...\PDP.xml
+        // then specify the correct 'Release' here or at runtime.
+
+        "Release": "",
+
+        // Filenames that SHOULD be processed.
+        // Wildcards are allowed, eg "InAppProductDescription*.xml".
+        // It is fine to specify both "PDPInclude" and "PDPExclude".
+        //
+        // Ex: "PDPInclude": [
+        //         "IapPDP*.xml",               <- Comma to separate items
+        //         "InAppProductDescription.xml"  <- No comma for last item, or JSON deserialization will fail
+        //     ]
+
+        "PDPInclude": [
+        ],
+
+        // Filenames that SHOULD NOT be processed.
+        // Wildcards are allowed, eg "InAppProductDescription*.xml".
+        // It is fine to specify both "PDPInclude" and "PDPExclude".
+        // It is NOT necessary to specify something here, but you can to be more explicit.
+        //
+        // Ex: "PDPExclude": [
+        //         "*.xml.lss",  <- Comma to separate items
+        //         "*.xml.lct"   <- No comma for last item, or JSON deserialization will fail
+        //     ]
+
+        "PDPExclude": [
+        ],
+
+        // Languages to be excluded from processing by New-InAppProductSubmissionPackage.
+        // New-InAppProductSubmissionPackage will use the filepath of a PDP XML file
+        // to identify the language of the metadata.  If it sees a match
+        // with a lang-code in this list, it will skip processing the file.
+        //
+        // Ex: "LanguageExclude": [
+        //         "default",  <- Comma to separate items
+        //         "qps-ploc"  <- No comma for last item, or JSON deserialization will fail
+        //     ],
+
+        "LanguageExclude": [
+            "default"
+        ],
+
+        // Your store screenshots must be placed with this structure:
+        //     <ImagesRootPath>\<Release>\<lang-code>\...\img.png
+        // Specify 'ImagesRootPath' here.
+        //
+        // IMPORTANT: The 'Release' that will be used here is *NOT* the value specified to
+        // New-InAppProductSubmissionPackage (nor is it the Release value specified earlier in this config file),
+        // but rather the 'Release' attribute at the top of the corresponding PDP file.
+        //
+        // File separator '\' must be escaped, i.e. '\\'
+        // Ex: \\\\fileshare\\Public\\Screenshots\\MyApp
+
+        "ImagesRootPath": "",
+
+        // Full path to a directory where the Packaging Tool can write the .json submission request
+        //     body and .zip package to upload.
+        //
+        // File separator '\' must be escaped, i.e. '\\'
+        // Ex: "OutPath": "C:\\app\\output"
+
+        "OutPath": "",
+
+        // Common name to give to the .json and .zip files outputted by the Packaging Tool.
+
+        "OutName": ""
+    },
+
+    // Configure details of the IAP Submission
+
+    "iapSubmission": {
+
+        // If known, this is the IapId given to your in-app application ("add on") by the Windows Store.
+        // This isn't required, but adding this will help protect you from submitting something
+        // to the wrong product when working at the commandline.
+        //
+        // Ex: "iapId": "0ABCDEF12345"
+        "iapId": "",
+
+        /////////////////////////////////
+        //                             //
+        // PUBLISH MODE AND VISIBILITY //
+        //                             //
+        /////////////////////////////////
+
+        // Publish mode of the submission. One of ["NotSet", "Immediate", "Manual", "SpecificDate"]
+
+        "targetPublishMode": "NotSet",
+
+        // Publish date-time of the submission if the "targetPublishMode" is specified as "SpecificDate".
+        // Date-time format should follow the ISO 8601 standard.
+        // Ex: "2000-01-30T00:00:00-08:00"
+
+        "targetPublishDate": null,
+
+        // Visibility of the add-on. One of ["NotSet", "Public", "Private", "Hidden"]
+        //
+        // Public: Anyone can find your add-on in the Store.
+        // Private: Hide this add-on in the Store. Customers with a direct link to the add-on's listing can still download
+        //     it, except on Windows 8 and Windows 8.1.
+        // Hidden: Hide this add-on and prevent acquisition. Customers with a promotional code can still download it on
+        //     Windows 10 devices.
+
+        "visibility": "NotSet",
+
+        ///////////////////////
+        //                   //
+        // PROPERTIES        //
+        //                   //
+        ///////////////////////
+
+        // lifetime
+        //  one of:
+        // ["Forever", "OneDay", "ThreeDays", "FiveDays", "OneWeek", "TwoWeeks", "OneMonth", "TwoMonths", "ThreeMonths", "SixMonths", "OneYear"]
+
+        "lifetime": "Forever",
+
+        // contentType - Regardless of your add-on's product type, you'll also need to indicate the
+        // type of content you're offering. For most add-ons, the content type should be "OnlineDownload".
+        // If another option from the list seems to describe your add-on better (for example, if you
+        // are offering a music download or an e-book), select that option instead.
+        //
+        //  one of:
+        // ["NotSet", "BookDownload", "EMagazine", "ENewspaper", "MusicDownload", "MusicStream",
+        //  "OnlineDataStorage", "VideoDownload", "VideoStream", "Asp", "OnlineDownload"]
+
+        "contentType": "NotSet",
+
+        // Your app can then query for add-ons that match these words.
+        // This feature lets you build screens in your app that can load add-ons without you having to
+        // directly specify the product ID in your app's code. You can then change the add-on's keywords
+        // anytime, without having to make code changes in your app or submit the app again.
+        // Maximum: 10 keywords of up to 30 characters each
+        "keywords": [
+        ],
+
+        // The custom developer data for the add-on (this information was previously called the 'tag').
+        // You can use this to provide extra context for your in-app product.
+        // Your app can query this value dynamically, and you can adjust the value at any time by
+        // updating the info in the add-on's Custom developer data field, without having to make code
+        // changes in your app or submit the app again.
+        // Maximum: 3000 characters
+        // The contents must be provided on one line, but it is possible to specify multiline content using "\r\n".
+        // Ex: "tag": "These\r\nare\r\nfour\r\nlines"
+        "tag": "",
+
+        //////////////////////////////
+        //                          //
+        // PRICING AND AVAILABILITY //
+        //                          //
+        //////////////////////////////
+
+        // Pricing
+        //
+        // Your add-on will be priced according to the price tier set for "priceId" and will be marketed at
+        // that tier for ALL available markets.  To set a different price for a specific market, use the
+        // "marketSpecificPricings" object.  You can also use the "marketSpecificPricings" object to make
+        // your add-on "NotAvailable" to a specific market.
+        //
+        // It is not currently possible to programmatically access or set sales information via the
+        // Windows Store Submission API for add-on submissions at this time.
+
+        "pricing": {
+
+            // Price
+            //
+            // Set the price of the add-on.
+            // The value provided should be a "Tier" and NOT an actual price
+            // For a mapping of "Tiers" to prices, see TODO: add reference
+            // Can also be "Free" or "NotAvailable"
+
+            "priceId": "NotAvailable",
+
+            // Market Specific Pricing
+            //
+            // By default, your add-on will be marketed at the price tier set for "priceId" for all possible markets.
+            // To set a different price tier for a specific region, add the ("region": "Tier") key-value pair.
+            //
+            // For a list of supported regions, see https://msdn.microsoft.com/en-us/library/windows/apps/mt148563.aspx
+
+            "marketSpecificPricings": {
+            }
+        },
+
+        /////////////////////////////
+        //                         //
+        // NOTES FOR CERTIFICATION //
+        //                         //
+        /////////////////////////////
+
+        // String. Information that helps testers use and understand this submission.
+        // Customers won't see this info.
+        // Can include information such as test account credentials, steps to access and verify features, etc.
+        //
+        // The notes must be provided on one line, but it is possible to specify multiline notes using "\r\n".
+        // Ex: "notesForCertification": "These\r\nare\r\nfour\r\nlines"
+
+        "notesForCertification": ""
+    }
+}

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -3,6 +3,7 @@
 
 # Default file name of the AppConfig in the module folder
 $script:defaultConfigFileName = "AppConfigTemplate.json"
+$script:defaultIapConfigFileName = "IapConfigTemplate.json"
 
 # Images will be placed in the .zip folder under the $packageImageFolderName subfolder
 $script:packageImageFolderName = "Assets"
@@ -23,6 +24,180 @@ $script:s_OutPath = "OutPath"
 $script:s_OutName = "OutName"
 $script:s_DisableAutoPackageNameFormatting = "DisableAutoPackageNameFormatting"
 
+function Get-StoreBrokerConfigFileContentForIapId
+{
+<#
+    .SYNOPSIS
+        Updates the default IAP configuration file template with the values from the
+        indicated IAP's most recent submission.
+
+    .DESCRIPTION
+        Updates the default IAP configuration file template with the values from the
+        indicated IAP's most recent submission.
+
+        The Git repo for this module can be found here: http://aka.ms/StoreBroker
+
+    .PARAMETER ConfigContent
+        The content of the config file template as a simple string.
+
+    .PARAMETER IapId
+        The IapId whose most recent submission should be retrieved and used to fill
+        in the default values of the template content.
+
+    .EXAMPLE
+        Get-StoreBrokerConfigFileContentForIapId -ConfigContent $template -IapId 0ABCDEF12345
+
+        Assuming that $template has the content of the template file read in from disk and
+        merged into a single string, this then gets the most recent IAP submission for
+        IapId 0ABCDEF12345 and replaces the default values in the template with those from
+        that submission. 
+
+    .OUTPUTS
+        System.String - The template content modified with the values from the
+                        most recent IAP submission.
+
+    .NOTES
+        We use regular expression matching within the implementation rather than operating
+        on the content as a JSON object, because we want to retain all of the comments that
+        are part of the template content.
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $ConfigContent,
+
+        [Parameter(Mandatory)]
+        [string] $IapId
+    )
+
+    $updated = $ConfigContent
+
+    try
+    {
+        $iap = Get-InAppProduct -IapId $IapId
+
+        $submissionId = $iap.lastPublishedInAppProductSubmission.id
+        if ([String]::IsNullOrEmpty($submissionId))
+        {
+            $submissionId = $iap.pendingInAppProductSubmission.id
+            Write-Log "No published submission exists for this In-App Product.  Using the current pending submission." -Level Warning
+        }
+
+        $sub = Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId
+
+        $updated = $updated -replace '"iapId": "",', "`"iapId`": `"$IapId`","
+
+        # PUBLISH MODE AND VISIBILITY
+        $updated = $updated -replace '"targetPublishMode": ".*",', "`"targetPublishMode`": `"$($sub.targetPublishMode)`","
+        $updated = $updated -replace '"targetPublishDate": .*,', "`"targetPublishDate`": `"$($sub.targetPublishDate)`","
+        $updated = $updated -replace '"visibility": ".*",', "`"visibility`": `"$($sub.visibility)`","
+
+        # PRICING AND AVAILABILITY
+        $updated = $updated -replace '"priceId": ".*",', "`"priceId`": `"$($sub.pricing.priceId)`","
+
+        $marketSpecificPricings = $sub.pricing.marketSpecificPricings | ConvertTo-Json -Depth $script:jsonConversionDepth
+        $updated = $updated -replace '(\s+)"marketSpecificPricings": {.*(\r|\n)+\s*}', "`$1`"marketSpecificPricings`": $marketSpecificPricings"
+
+        # PROPERTIES
+        $updated = $updated -replace '"lifetime": ".*",', "`"lifetime`": `"$($sub.lifetime)`","
+        $updated = $updated -replace '"contentType": ".*",', "`"contentType`": `"$($sub.contentType)`","
+
+        # Need to replace actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
+        $tag = $sub.tag -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
+        $updated = $updated -replace '"tag": ""', "`"tag`": `"$tag`""
+
+        $keywords = $sub.keywords | ConvertTo-Json -Depth $script:jsonConversionDepth
+        if ($null -eq $keywords) { $keywords = "[ ]" }
+        $updated = $updated -replace '(\s+)"keywords": \[.*(\r|\n)+\s*\]', "`$1`"keywords`": $keywords"
+
+        # NOTES FOR CERTIFICATION
+        # Need to replace actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
+        $notesForCertification = $sub.notesForCertification -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
+        $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": `"$notesForCertification`""
+
+        return $updated
+    }
+    catch
+    {
+        Write-Log "Encountered problems getting current In-App Product submission values: $($_.Exception.Message)" -Level Error
+        throw
+    }
+}
+
+function New-StoreBrokerInAppProductConfigFile
+{
+<#
+    .SYNOPSIS
+        Creates a new configuration file as a template for an In-App Product submission.
+
+    .DESCRIPTION
+        Creates a new configuration file as a template for an In-App Product submission.
+        The full path to the new file can be provided by the -Path parameter.
+
+        The Git repo for this module can be found here: http://aka.ms/StoreBroker
+
+    .PARAMETER Path
+        A full path specifying where the new config file will go and what it will be
+        named.  It is recommended to use the .json file extension.
+
+    .PARAMETER IapId
+        If specified, this will pre-populate the Iap config portion of the
+        configuration file with the values from the most recent submission for this
+        IapId.
+
+    .EXAMPLE
+        New-StoreBrokerConfigFile -Path "C:\users\alias\NewIapConfig.json"
+
+        Creates the config file template "NewIapConfig.json" under "C:\users\alias"
+
+    .EXAMPLE
+        New-StoreBrokerInAppProductConfigFile -Path "C:\users\alias\NewIapConfig.json" -WhatIf
+
+        This example is the same as Example 1 except no config file will be created.  The
+        function will report on the actions it would have taken, instead.
+
+    .EXAMPLE
+        New-StoreBrokerInAppProductConfigFile -Path "C:\users\alias\NewIapConfig.json" -AppId 0ABCDEF12345
+
+        Creates the config file template "NewIapConfig.json" under "C:\users\alias", but sets
+        the values for the app config portion to be those from the most recent submission for
+        IapId 0ABCDEF12345.
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [Alias('New-StoreBrokerIapConfigFile')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({ if ((Split-Path -Leaf $_) -like "*.*") { $true } else { throw "Path must include filename." } })]
+        [string] $Path,
+
+        [string] $IapId = ""
+    )
+
+    $dir = Split-Path -Parent -Path $Path
+    if (-not (Test-Path -PathType Container -Path $dir))
+    {
+        Write-Log "Creating directory: $dir" -Level Verbose
+        New-Item -Force -ItemType Directory -Path $dir | Out-Null
+    }
+
+    $sourcePath = Join-Path -Path $PSScriptRoot -ChildPath $script:defaultIapConfigFileName
+
+    # Get-Content returns an array of lines.... using Out-String gives us back the linefeeds.
+    $template = (Get-Content -Path $sourcePath -Encoding UTF8) | Out-String
+
+    if (-not ([String]::IsNullOrEmpty($IapId)))
+    {
+        $template = Get-StoreBrokerConfigFileContentForIapId -ConfigContent $template -IapId $IapId
+    }
+
+    Write-Log "Copying (Item: $sourcePath) to (Target: $Path)." -Level Verbose
+    Set-Content -Path $Path -Value $template -Encoding UTF8 -Force
+
+    $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::IapId = $IapId }
+    Set-TelemetryEvent -EventName New-StoreBrokerIapConfigFile -Properties $telemetryProperties
+}
+
 function Get-StoreBrokerConfigFileContentForAppId
 {
 <#
@@ -33,8 +208,6 @@ function Get-StoreBrokerConfigFileContentForAppId
     .DESCRIPTION
         Updates the default configuration file template with the values from the
         indicated App's most recent published submission.
-
-        This function supports the common switches Verbose, WhatIf, and Confirm.
 
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
 
@@ -155,8 +328,6 @@ function New-StoreBrokerConfigFile
         Creates a new configuration file as a template for an app submission.
         The full path to the new file can be provided by the -Path parameter.
 
-        This function supports the common switches Verbose, WhatIf, and Confirm.
-
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
 
     .PARAMETER Path
@@ -164,7 +335,7 @@ function New-StoreBrokerConfigFile
         named.  It is recommended to use the .json file extension.
 
     .PARAMETER AppId
-        [optional] If specified, this will pre-populate the app config portion of the
+        If specified, this will pre-populate the app config portion of the
         configuration file with the values from the most recent submission for this
         AppId.
 
@@ -204,25 +375,18 @@ function New-StoreBrokerConfigFile
         New-Item -Force -ItemType Directory -Path $dir | Out-Null
     }
 
-    $sourcePath = Join-Path $PSScriptRoot $script:defaultConfigFileName
+    $sourcePath = Join-Path -Path $PSScriptRoot -ChildPath $script:defaultConfigFileName
 
     # Get-Content returns an array of lines.... using Out-String gives us back the linefeeds.
-    $template = (Get-Content $sourcePath) | Out-String
+    $template = (Get-Content -Path $sourcePath -Encoding UTF8) | Out-String
 
     if (-not ([String]::IsNullOrEmpty($AppId)))
     {
-        try
-        {
-            $template = Get-StoreBrokerConfigFileContentForAppId -ConfigContent $template -AppId $AppId
-        }
-        catch
-        {
-            throw
-        }
+        $template = Get-StoreBrokerConfigFileContentForAppId -ConfigContent $template -AppId $AppId
     }
 
     Write-Log "Copying (Item: $sourcePath) to (Target: $Path)." -Level Verbose
-    Set-Content -Path $Path -Value $template -Force
+    Set-Content -Path $Path -Value $template -Encoding UTF8 -Force
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
     Set-TelemetryEvent -EventName New-StoreBrokerConfigFile -Properties $telemetryProperties
@@ -274,7 +438,8 @@ function Get-XsdPath
     )
 
     $namespaces = @{
-        'http://schemas.microsoft.com/appx/2012/ProductDescription' = (Join-Path -Path $PSScriptRoot -ChildPath '..\PDP\ProductDescription.xsd')
+        'http://schemas.microsoft.com/appx/2012/ProductDescription'      = (Join-Path -Path $PSScriptRoot -ChildPath '..\PDP\ProductDescription.xsd')
+        'http://schemas.microsoft.com/appx/2012/InAppProductDescription' = (Join-Path -Path $PSScriptRoot -ChildPath '..\PDP\InAppProductDescription.xsd')
     }
 
     $xsdPath = $namespaces[$NamespaceUri]
@@ -430,7 +595,7 @@ function Convert-ListingToObject
                         return
                     }
 
-                    $xml = [xml] (Get-Content -Encoding UTF8 -Path $xmlFilePath)
+                    $xml = [xml] (Get-Content -Path $xmlFilePath -Encoding UTF8)
 
                     # ProductDescription node contains the metadata
                     $ProductDescriptionNode = $xml.ProductDescription
@@ -651,6 +816,248 @@ function Convert-ListingsMetadata
     return $listings
 }
 
+function Convert-InAppProductListingToObject
+{
+<#
+    .SYNOPSIS
+        Consumes a single localized .xml file into an In-App Product listing object.
+        
+    .DESCRIPTION
+        Consumes a single localized .xml file into an In-App Product listing object.
+        If a node has only content, then that content is assigned.
+        If a node has children, it's children are pooled into an array and assigned.
+
+    .PARAMETER PDPRootPath
+        The root path of all the PDPs.  'XmlFilePath' should begin with 'PDPRootPath',
+        so this function splits 'XmlFilePath' using 'PDPRootPath'.  The result
+        should begin with the lang-code of the file being processed.
+
+    .PARAMETER LanguageExclude
+        Array of lang-code strings that SHOULD NOT be processed.
+
+    .PARAMETER ImagesRootPath
+        A path to the root path containing the new submission's images.  Currently, an IAP can have
+        an optional icon associated with it. Each relative path is appended to ImagesRootPath to
+        create a full path to the image.
+
+    .PARAMETER XmlFilePath
+        A full path to the localized .xml file to be parsed.
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string] $PDPRootPath,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string[]] $LanguageExclude,
+
+        [Parameter(Mandatory)]
+        [string] $ImagesRootPath,
+
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline)]
+        [string[]] $XmlFilePaths
+    )
+
+    PROCESS
+    {
+        foreach ($xmlFilePath in $XmlFilePaths)
+        {
+            if ($PSCmdlet.ShouldProcess($xmlFilePath, "Convert-InAppProductListingToObject"))
+            {
+                try
+                {
+                    # Identify lang-code of the file to process.
+                    # $array[-1] == $array[$array.Count-1]
+                    if ($PDPRootPath[-1] -ne '\') { $PDPRootPath = "$PDPRootPath\" }
+
+                    $split = $xmlFilePath -split $PDPRootPath, 0, "SimpleMatch" |
+                             Where-Object { -not [String]::IsNullOrWhiteSpace($_) } |
+                             Select-Object -First 1
+                    $language = $split -split "\", 0, "SimpleMatch" |
+                                Where-Object { -not [String]::IsNullOrWhiteSpace($_) } |
+                                Select-Object -First 1
+
+                    # Skip processing if language is marked for exclusion
+                    if ($language -in $LanguageExclude)
+                    {
+                        $out = "Skipping file '$xmlFilePath' because its lang-code '$language' is in the language exclusion list."
+                        Write-Log $out -Level Verbose
+
+                        return
+                    }
+
+                    $xml = [xml] (Get-Content -Path $xmlFilePath -Encoding UTF8)
+
+                    # InAppProductDescription node contains the metadata
+                    $InAppProductDescriptionNode = $xml.InAppProductDescription
+
+                    # Verify xml conforms to schema
+                    Test-Xml -XsdFile (Get-XsdPath -NamespaceUri $InAppProductDescriptionNode.xmlns) -XmlFile $xmlFilePath
+
+                    # Assemble the Listing object
+                    # Nodes with one item can be immediately assigned
+                    $listing = @{
+                        "title"                     = $InAppProductDescriptionNode.Title;
+                        "description"               = $InAppProductDescriptionNode.Description;
+                    }
+
+                    # Identify the keys whose values are non-null and trim the values.
+                    # Must be done in two steps because $listings can't be modified
+                    # while enumerating its keys.
+                    $trimKeys = $listing.Keys |
+                        Where-Object { ($null -ne $listing[$_].InnerText) -or ($listing[$_] -is [String]) } 
+
+                    $trimKeys | ForEach-Object { 
+                        if ($null -ne $listing[$_].InnerText)
+                        {
+                            $listing[$_] = $listing[$_].InnerText
+                        }
+                        
+                        $listing[$_] = $listing[$_].Trim()
+                    }
+
+                    # For title specifically, we need to ensure that it's set to $null if there's
+                    # no value.  An empty string value is not the same as $null.
+                    if ([String]::IsNullOrWhiteSpace($listing['title']))
+                    {
+                        $listing['title'] = $null
+                    }
+        
+                    # Icon node is special, needs to be consumed separately
+                    $packageImagePath = Join-Path -Path $script:tempFolderPath -ChildPath (Join-Path -Path $script:packageImageFolderName -ChildPath $language)
+                    if (-not (Test-Path -PathType Container -Path $packageImagePath))
+                    {
+                        New-Item -ItemType directory -Path $packageImagePath | Out-Null
+                    }
+
+                    $imageFileName = $InAppProductDescriptionNode.icon.fileName
+                    if (-not [System.String]::IsNullOrWhiteSpace($imageFileName))
+                    { 
+                        #imageContainerPath = <imagesRootPath>/<release>/<lang-code>/
+                        $imageContainerPath = [System.IO.Path]::Combine($ImagesRootPath, $InAppProductDescriptionNode.Release, $language)
+
+                        if (Test-Path -Path $imageContainerPath -PathType Container)
+                        {
+                            $image = Get-ChildItem -Recurse -File -Path $imageContainerPath -Include $imageFileName | Select-Object -First 1
+                            if ($null -eq $image)
+                            {
+                                Write-Log "Could not find image '$($imageFileName)' in any subdirectory of '$imageContainerPath'." -Level Error
+                                throw "Halt Execution"
+                            }
+                        
+                            $destinationInPackage = Join-Path -Path $packageImagePath -ChildPath $image.Name
+                            if (-not (Test-Path -PathType Leaf $destinationInPackage))
+                            {
+                                Copy-Item -Path $image.FullName -Destination $destinationInPackage
+                            }
+
+                            $iconListing += @{
+                                "fileName"     = [System.IO.Path]::Combine($script:packageImageFolderName, $language, $image.Name)
+                                "fileStatus"   = "PendingUpload";
+                            }
+
+                            $listing['icon'] = $iconListing
+                        }
+                        else
+                        {
+                            Write-Log "Provided image directory was not found: $imageContainerPath" -Level Error
+                            throw "Halt Execution"
+                        }
+                    }
+
+                    Write-Output @{ "lang" = $language.ToLowerInvariant(); "listing" = $listing }
+                }
+                catch [System.InvalidCastException]
+                {
+                    Write-Log "Provided .xml file is not a valid .xml document: $xmlFilePath" -Level Error
+                    throw "Halt Execution"
+                }
+            }
+        }
+    }
+}
+
+function Convert-InAppProductListingsMetadata
+{
+<#
+    .SYNOPSIS
+        Top-level function for consuming localized metadata about the In-App Product submission.
+        Each language's .xml file, in a subfolder under XmlListingsRootPath, is parsed and
+        added to the listings object with the language as the key.
+
+    .PARAMETER PDPRootPath
+        The root path to the directory containing language-specific subfolders holding the
+        localized metadata.
+
+    .PARAMETER PDPInclude
+        The name of the XML file to be parsed (same for every language). Wildcards are allowed.
+        It is okay to specify both 'PDPInclude' and 'PDPExclude'.
+
+    .PARAMETER PDPExclude
+        XML filenames to be excluded from parsing. Wildcards are allowed. It is okay to specify
+        both 'PDPInclude' and 'PDPExclude'.
+
+    .PARAMETER LanguageExclude
+        Array of lang-code strings that SHOULD NOT be processed.
+
+    .PARAMETER ImagesRootPath
+        The root path to the directory where this submission's images are located.
+
+    .OUTPUTS
+        Hashtable  A hastable with each key being a language and the corresponding value, an object
+                   containing localized data for the app (Title, Description, Icon, etc.)
+
+    .EXAMPLE
+        Convert-InAppProductListingsMetadata -PDPRootPath 'C:\PDP\' -PDPInclude 'InAppProductDescription.xml' -ImagesRootPath 'C:\IapIcons'
+
+        Assumes the folder structure:
+        C:\PDP\language1\...\InAppProductDescription.xml
+        C:\PDP\language2\...\InAppProductDescription.xml
+#>
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({
+            if (Test-Path -PathType Container -Path $_) { $true } 
+            else { throw "'$_' is not a directory or cannot be found." } })]
+        [string] $PDPRootPath,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string[]] $PDPInclude,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string[]] $PDPExclude,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string[]] $LanguageExclude,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ 
+            if (Test-Path -PathType Container -Path $_) { $true }
+            else { throw "'$_' is not a directory or cannot be found." } })]
+        [string] $ImagesRootPath
+    )
+
+    $listings = @{}
+
+    (Get-ChildItem -File $PDPRootPath -Recurse -Include $PDPInclude -Exclude $PDPExclude).FullName |
+        Convert-InAppProductListingToObject -PDPRootPath $PDPRootPath -LanguageExclude $LanguageExclude -ImagesRootPath $ImagesRootPath |
+        ForEach-Object { $listings[$_."lang"] = $_."listing" }
+
+    return $listings
+}
+
 function Get-AppxIdentity
 {
 <#
@@ -738,7 +1145,7 @@ function Get-AppxIdentity
 
                     # Get AppxManifest.xml
                     $appxManifest = Get-ChildItem -Recurse -Path $expandedAppxPath -Include 'AppxManifest.xml'
-                    $xmlAppxManifest = [xml] (Get-Content $appxManifest.FullName)
+                    $xmlAppxManifest = [xml] (Get-Content -Path $appxManifest.FullName -Encoding UTF8)
 
                     $identityNode = $xmlAppxManifest.Package.Identity
         
@@ -970,7 +1377,7 @@ function Get-FormattedAppxContainerFileName
                     {
                         Write-Log "Opening `"$bundleManifestPath`"." -Level Verbose
 
-                        $xmlBundleManifest = [xml] (Get-Content $bundleManifestPath)
+                        $xmlBundleManifest = [xml] (Get-Content -Path $bundleManifestPath -Encoding UTF8)
 
                         # When using -Confirm, PS will ask user to confirm selecting 'FileName'.
                         # Explicitly set -Confirm:$false to prevent this dialog from reaching the user.
@@ -1006,7 +1413,7 @@ function Get-FormattedAppxContainerFileName
 
             if ($appxFilePaths.Count -eq 0)
             {
-                throw
+                throw "No supported files were found for examination."
             }
 
             if ($formattedIdentity -eq $fileName)
@@ -1233,13 +1640,13 @@ function Get-SubmissionRequestBody
         is mutually exclusive with the remaining three path types.
 
     .EXAMPLE
-        Get-SubmissionRequestBody "C:\App\Appx.appxupload" (Get-Content $ConfigPath | ConvertFrom-Json)
+        Get-SubmissionRequestBody "C:\App\Appx.appxupload" (Get-Content $ConfigPath -Encoding UTF8 | ConvertFrom-Json)
 
         Retrieves the submission request generated using the config file at $ConfigPath and the
         appxupload located at "C:\App\Appx.appxupload".
 
     .EXAMPLE
-        (Get-Content $ConfigPath | ConvertFrom-Json) | Get-SubmissionRequestBody -AppxPath "C:\Appx_x86.appxbundle", "C:\Appx_arm.appxbundle" -Release MarchRelease
+        (Get-Content $ConfigPath -Encoding UTF8 | ConvertFrom-Json) | Get-SubmissionRequestBody -AppxPath "C:\Appx_x86.appxbundle", "C:\Appx_arm.appxbundle" -Release MarchRelease
 
         Retrieves the submission request generated using the config file at $ConfigPath and the
         appxbundle files located at "C:\Appx_x86.appxbundle" and "C:\Appx_arm.appxbundle".
@@ -1315,7 +1722,118 @@ function Get-SubmissionRequestBody
         $submissionRequestBody.listings = Convert-ListingsMetadata @listingsResources
     }
 
-    $submissionRequestBody = Remove-DeprecatedProperties $submissionRequestBody
+    $submissionRequestBody = Remove-DeprecatedProperties -SubmissionRequestBody $submissionRequestBody
+
+    return $submissionRequestBody
+}
+
+function Get-InAppProductSubmissionRequestBody
+{
+<#
+    .SYNOPSIS
+        Creates a PSCustomObject representing the JSON that will be sent with an
+        In-App Product submission request.  Some property values are taken from the
+        config file, some are given static values, and some are retrieved from localized metadata.
+
+    .PARAMETER ConfigObj
+        A PSCustomObject representing this tool's configuration file.  Some values of the
+        submission are populated in the config file and retrieved here.
+
+    .PARAMETER PDPRootPath
+        Root path to the directory containing lang-code subfolders of PDPs to be processed.
+
+    .PARAMETER Release
+        Optional.  When specified, it is used to indicate the correct subfolder within
+       'PDPRootPath' to find the PDP files to use.
+
+    .PARAMETER PDPInclude
+        PDP filenames that SHOULD be processed.
+        Wildcards are allowed, eg "InAppProductDescription*.xml".
+        It is fine to specify both "PDPInclude" and "PDPExclude".
+
+    .PARAMETER PDPExclude
+        PDP filenames that SHOULD NOT be processed.
+        Wildcards are allowed, eg "InAppProductDescription*.xml".
+        It is fine to specify both "PDPInclude" and "PDPExclude".
+
+    .PARAMETER LanguageExclude
+        Array of lang-code strings that SHOULD NOT be processed.
+
+    .PARAMETER ImagesRootPath
+        Root path to the directory containing release subfolders of images to be packaged.
+
+    .OUTPUTS
+        PSCustomObject  An object representing the full In-App Product submission request.
+
+    .EXAMPLE
+        Get-InAppProductSubmissionRequestBody (Get-Content $ConfigPath -Encoding UTF8 | ConvertFrom-Json)
+
+        Retrieves the submission request generated using the config file at $ConfigPath.
+
+    .EXAMPLE
+        (Get-Content $ConfigPath -Encoding UTF8 | ConvertFrom-Json) | Get-InAppProductSubmissionRequestBody -Release MarchRelease
+
+        Retrieves the submission request generated using the config file at $ConfigPath.
+        The Release used for finding PDPs under 'PDPRootPath' is MarchRelease.
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject] $ConfigObject,
+
+        [string] $PDPRootPath,
+        
+        [string] $Release,
+
+        [string[]] $PDPInclude,
+
+        [string[]] $PDPExclude,
+
+        [string[]] $LanguageExclude,
+        
+        [string] $ImagesRootPath
+    )
+
+    # Add static properties and metadata about packaged binaries.
+    $submissionRequestBody = $ConfigObject.iapSubmission
+
+    if (-not [String]::IsNullOrWhiteSpace($PDPRootPath))
+    {
+        $submissionRequestBody | Add-Member -MemberType NoteProperty -Name "listings" -Value (New-Object System.Object)
+
+        # Add listings information
+        $listingsPath = $PDPRootPath
+
+        # If 'Release' is present, no need to look within a sub-folder..
+        if (-not [System.String]::IsNullOrWhiteSpace($Release))
+        {
+            $pathWithRelease = Join-Path -Path $PDPRootPath -ChildPath $Release
+            if (Test-Path -PathType Container -Path $pathWithRelease)
+            {
+                $listingsPath = $pathWithRelease
+            }
+            else
+            {
+                $out = @()
+                $out += "'$pathWithRelease' is not a valid directory or cannot be found."
+                $out += "Check the values of '$script:s_PDPRootPath' and '$script:s_Release' and try again."
+
+                Write-Log ($out -join [Environment]::NewLine) -Level Error
+                throw "Halt Execution"
+            }
+        }
+
+        $listingsResources = @{
+            $script:s_PDPRootPath = $listingsPath;
+            $script:s_PDPInclude = $PDPInclude;
+            $script:s_PDPExclude = $PDPExclude;
+            $script:s_LanguageExclude = $LanguageExclude;
+            $script:s_ImagesRootPath = $ImagesRootPath;
+        }
+
+        $submissionRequestBody.listings = Convert-InAppProductListingsMetadata @listingsResources
+    }
 
     return $submissionRequestBody
 }
@@ -1340,6 +1858,9 @@ function Resolve-PackageParameters
         Hashtable mapping the parameters of New-SubmissionPackage (except for ConfigPath)
         to their provided values.
 
+    .PARAMETER SkipValidation
+        An array of parameters that this method should not attempt to validate.
+
     .OUTPUTS
         Hashtable with keys "PDPRootPath", "Release", "PDPInclude", "PDPExclude",
         "ImagesRootPath", "AppxPath", "OutPath", and "OutName", each with validated values.
@@ -1358,7 +1879,9 @@ function Resolve-PackageParameters
         [PSCustomObject] $ConfigObject,
 
         [Parameter(Mandatory)]
-        [Hashtable] $ParamMap
+        [Hashtable] $ParamMap,
+
+        [String[]] $SkipValidation = @()
     )
 
     # Generic fail message. Format with parameter name.
@@ -1401,51 +1924,61 @@ function Resolve-PackageParameters
         }
     }
 
-    # If either 'PDPRootPath' or 'ImagesRootPath' is present, both must be present
-    if ((-not [String]::IsNullOrWhiteSpace($ParamMap[$script:s_PDPRootPath])) -xor
-        (-not [String]::IsNullOrWhiteSpace($ParamMap[$script:s_ImagesRootPath])))
+    if (($SkipValidation -inotcontains $script:s_PDPRootPath) -and ($SkipValidation -inotcontains $script:s_ImagesRootPath))
     {
-        $out = @()
-        $out += "Only one of '$script:s_PDPRootPath' and '$script:s_ImagesRootPath' was specified."
-        $out += "If one of these parameters is specified, then both must be specified."
+        # If either 'PDPRootPath' or 'ImagesRootPath' is present, both must be present
+        if ((-not [String]::IsNullOrWhiteSpace($ParamMap[$script:s_PDPRootPath])) -xor
+            (-not [String]::IsNullOrWhiteSpace($ParamMap[$script:s_ImagesRootPath])))
+        {
+            $out = @()
+            $out += "Only one of '$script:s_PDPRootPath' and '$script:s_ImagesRootPath' was specified."
+            $out += "If one of these parameters is specified, then both must be specified."
 
-        Write-Log ($out -join [Environment]::NewLine) -Level Error
-        throw "Halt Execution"
+            Write-Log ($out -join [Environment]::NewLine) -Level Error
+            throw "Halt Execution"
+        }
     }
     
 
-    # 'OutPath' is mandatory.
-    if ([System.String]::IsNullOrWhiteSpace($ParamMap[$script:s_OutPath]))
+    if ($SkipValidation -inotcontains $script:s_OutPath)
     {
-        $configVal = $ConfigObject.packageParameters.OutPath
-        if ([System.String]::IsNullOrWhiteSpace($configVal))
+        # 'OutPath' is mandatory.
+        if ([System.String]::IsNullOrWhiteSpace($ParamMap[$script:s_OutPath]))
         {
-            Write-Log ($out -f $script:s_OutPath) -Level Error
-            throw "Halt Execution"
+            $configVal = $ConfigObject.packageParameters.OutPath
+            if ([System.String]::IsNullOrWhiteSpace($configVal))
+            {
+                Write-Log ($out -f $script:s_OutPath) -Level Error
+                throw "Halt Execution"
+            }
+            else
+            {
+                $ParamMap[$script:s_OutPath] = $configVal
+                Write-Log ($fromConfig -f $script:s_OutPath, $configVal) -Level Verbose
+            }
         }
-        else
-        {
-            $ParamMap[$script:s_OutPath] = $configVal
-            Write-Log ($fromConfig -f $script:s_OutPath, $configVal) -Level Verbose
-        }
+
+        # Resolve path parameters to full paths. Necessary in case a path contains '.' or '..'
+        $ParamMap[$script:s_OutPath] = Convert-Path -Path $ParamMap[$script:s_OutPath]
     }
 
-    # Resolve path parameters to full paths. Necessary in case a path contains '.' or '..'
-    $ParamMap[$script:s_OutPath] = Convert-Path -Path $ParamMap[$script:s_OutPath]
 
-    # 'OutName' is mandatory.
-    if ([System.String]::IsNullOrWhiteSpace($ParamMap[$script:s_OutName]))
+    if ($SkipValidation -inotcontains $script:s_OutName)
     {
-        $configVal = $ConfigObject.packageParameters.OutName
-        if ([System.String]::IsNullOrWhiteSpace($configVal))
+        # 'OutName' is mandatory.
+        if ([System.String]::IsNullOrWhiteSpace($ParamMap[$script:s_OutName]))
         {
-            Write-Log ($out -f $script:s_OutName) -Level Error
-            throw "Halt Execution"
-        }
-        else
-        {
-            $ParamMap[$script:s_OutName] = $configVal
-            Write-Log ($fromConfig -f $script:s_OutName, $configVal) -Level Verbose
+            $configVal = $ConfigObject.packageParameters.OutName
+            if ([System.String]::IsNullOrWhiteSpace($configVal))
+            {
+                Write-Log ($out -f $script:s_OutName) -Level Error
+                throw "Halt Execution"
+            }
+            else
+            {
+                $ParamMap[$script:s_OutName] = $configVal
+                Write-Log ($fromConfig -f $script:s_OutName, $configVal) -Level Verbose
+            }
         }
     }
 
@@ -1486,79 +2019,84 @@ function Resolve-PackageParameters
         Write-Log "`tUsing default value: $script:s_PDPInclude = `"*.xml`"" -Level Verbose
     }
 
-    # 'AppxPath' is mandatory.
-    if ($ParamMap[$script:s_AppxPath].Count -eq 0)
+    if ($SkipValidation -inotcontains $script:s_AppxPath)
     {
-        $packagePaths = @()
-        $validExtensions = $script:supportedExtensions | ForEach-Object { "*" + $_ }
-        foreach ($path in $ConfigObject.packageParameters.AppxPath)
+        # 'AppxPath' is mandatory.
+        if ($ParamMap[$script:s_AppxPath].Count -eq 0)
         {
-            if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path) -and ($path -notin $packagePaths))
+            $packagePaths = @()
+            $validExtensions = $script:supportedExtensions | ForEach-Object { "*" + $_ }
+            foreach ($path in $ConfigObject.packageParameters.AppxPath)
             {
-                $packagePaths += $path
-            }
-            elseif ([System.String]::IsNullOrWhiteSpace($env:TFS_DropLocation))
-            {
-                $out = @()
-                $out += "`"$path`" is not a file or cannot be found."
-                $out += "See the `"$script:s_AppxPath`" object in the config file."
-
-                Write-Log ($out -join [Environment]::NewLine) -Level Error
-                throw "Halt Execution"
-            }
-            else
-            {
-                $path = Join-Path $env:TFS_DropLocation $path
                 if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path) -and ($path -notin $packagePaths))
                 {
                     $packagePaths += $path
                 }
-                elseif (Test-Path -PathType Container -Path $path)
-                {
-                    $fullPaths = (Get-ChildItem -File -Include $validExtensions -Path (Join-Path $path "*.*")).FullName
-                    foreach ($fullPath in $fullPaths)
-                    {
-                        if ($fullPath -notin $packagePaths)
-                        {
-                            $packagePaths += $fullPath
-                        }
-                    }
-                }
-                else
+                elseif ([System.String]::IsNullOrWhiteSpace($env:TFS_DropLocation))
                 {
                     $out = @()
-                    $out += "Could not find a file with a supported extension ($($script:supportedExtensions -join ", ")) using the relative path: '$path'."
+                    $out += "`"$path`" is not a file or cannot be found."
                     $out += "See the `"$script:s_AppxPath`" object in the config file."
 
                     Write-Log ($out -join [Environment]::NewLine) -Level Error
                     throw "Halt Execution"
                 }
+                else
+                {
+                    $path = Join-Path $env:TFS_DropLocation $path
+                    if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path) -and ($path -notin $packagePaths))
+                    {
+                        $packagePaths += $path
+                    }
+                    elseif (Test-Path -PathType Container -Path $path)
+                    {
+                        $fullPaths = (Get-ChildItem -File -Include $validExtensions -Path (Join-Path $path "*.*")).FullName
+                        foreach ($fullPath in $fullPaths)
+                        {
+                            if ($fullPath -notin $packagePaths)
+                            {
+                                $packagePaths += $fullPath
+                            }
+                        }
+                    }
+                    else
+                    {
+                        $out = @()
+                        $out += "Could not find a file with a supported extension ($($script:supportedExtensions -join ", ")) using the relative path: '$path'."
+                        $out += "See the `"$script:s_AppxPath`" object in the config file."
+
+                        Write-Log ($out -join [Environment]::NewLine) -Level Error
+                        throw "Halt Execution"
+                    }
+                }
             }
+
+            $ParamMap[$script:s_AppxPath] = $packagePaths
+            $quotedVals = $packagePaths | ForEach-Object { "`"$_`"" }
+            Write-Log ($fromConfig -f $script:s_AppxPath, ($quotedVals -join ', ')) -Level Verbose
         }
 
-        $ParamMap[$script:s_AppxPath] = $packagePaths
-        $quotedVals = $packagePaths | ForEach-Object { "`"$_`"" }
-        Write-Log ($fromConfig -f $script:s_AppxPath, ($quotedVals -join ', ')) -Level Verbose
+        # Resolve AppxPath to a list of full paths.
+        $ParamMap[$script:s_AppxPath] = $ParamMap[$script:s_AppxPath] | ForEach-Object { Convert-Path -Path $_ }
     }
 
-    # Resolve AppxPath to a list of full paths.
-    $ParamMap[$script:s_AppxPath] = $ParamMap[$script:s_AppxPath] | ForEach-Object { Convert-Path -Path $_ }
-
-    # Switches always have a concrete value ($true or $false).  Therefore, we'll only consider a
-    # switch to have been passed-in from the command-line (thus, overriding the config's value)
-    # if its value is $true.
-    if (-not $ParamMap[$script:s_DisableAutoPackageNameFormatting])
+    if ($SkipValidation -inotcontains $script:s_DisableAutoPackageNameFormatting)
     {
-        $configVal = $ConfigObject.packageParameters.DisableAutoPackageNameFormatting
-        if ([System.String]::IsNullOrWhiteSpace($configVal))
+        # Switches always have a concrete value ($true or $false).  Therefore, we'll only consider a
+        # switch to have been passed-in from the command-line (thus, overriding the config's value)
+        # if its value is $true.
+        if (-not $ParamMap[$script:s_DisableAutoPackageNameFormatting])
         {
-            $configVal = $false
+            $configVal = $ConfigObject.packageParameters.DisableAutoPackageNameFormatting
+            if ([System.String]::IsNullOrWhiteSpace($configVal))
+            {
+                $configVal = $false
+            }
+
+            $ParamMap[$script:s_DisableAutoPackageNameFormatting] = $configVal
+            Write-Log ($fromConfig -f $script:s_DisableAutoPackageNameFormatting, $configVal) -Level Verbose
         }
-
-        $ParamMap[$script:s_DisableAutoPackageNameFormatting] = $configVal
-        Write-Log ($fromConfig -f $script:s_DisableAutoPackageNameFormatting, $configVal) -Level Verbose
     }
-
     return $ParamMap
 }
 
@@ -1628,7 +2166,7 @@ function Convert-AppConfig
         [string] $ConfigPath
     )
 
-    $lines = (Get-Content -Path $ConfigPath | Remove-Comment) -join ''
+    $lines = (Get-Content -Path $ConfigPath -Encoding UTF8 | Remove-Comment) -join ''
         
     return ($lines | ConvertFrom-Json)
 }
@@ -1747,8 +2285,8 @@ function Join-SubmissionPackage
     }
 
     # out json content will be based off of master, so we can just consider master's json as "out"
-    $outJsonContent = (Get-Content $MasterJsonPath -Encoding UTF8) | ConvertFrom-Json
-    $additionalJsonContent = (Get-Content $AdditionalJsonPath -Encoding UTF8) | ConvertFrom-Json
+    $outJsonContent = (Get-Content -Path $MasterJsonPath -Encoding UTF8) | ConvertFrom-Json
+    $additionalJsonContent = (Get-Content -Path $AdditionalJsonPath -Encoding UTF8) | ConvertFrom-Json
 
     if ($AddPackages)
     {
@@ -1818,8 +2356,6 @@ function New-SubmissionPackage
         The .json and .zip files generated by this tool are given the common name specified by
         the [-OutName] parameter.
 
-        This function supports the common switches Verbose, WhatIf, and Confirm.
-
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
 
     .PARAMETER ConfigPath
@@ -1884,20 +2420,20 @@ function New-SubmissionPackage
         To retain the existing package filenames, specify this switch.
 
     .EXAMPLE
-        New-SubmissionPackage -ConfigPath 'C:\Config\PackagingToolConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\App.appxbundle'
+        New-SubmissionPackage -ConfigPath 'C:\Config\StoreBrokerConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\App.appxbundle'
         
         This example creates the submission request body and .zip file for the architecture-neutral
         '.appxbundle' located at 'C:\bin\App.appxbundle'.  Two files will be placed under 'C:\Out\Path\',
         'Upload.json' and 'Upload.zip'
 
     .EXAMPLE
-        New-SubmissionPackage -ConfigPath 'C:\Config\PackagingToolConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\App.appxbundle' -Verbose
+        New-SubmissionPackage -ConfigPath 'C:\Config\StoreBrokerConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\App.appxbundle' -Verbose
         
         This example is the same except it specifies Verbose logging and the function will output a
         detailed report of its actions.
 
     .EXAMPLE
-        New-SubmissionPackage -ConfigPath 'C:\Config\PackagingToolConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\x86\App_x86.appxupload', 'C:\Other\Path\Arm\App_arm.appxupload'
+        New-SubmissionPackage -ConfigPath 'C:\Config\StoreBrokerConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\x86\App_x86.appxupload', 'C:\Other\Path\Arm\App_arm.appxupload'
         
         This example is the same except it specifies an x86 and Arm build.  Multiple files to
         include can be passed to 'AppxPath' by separating with a comma.
@@ -2049,6 +2585,215 @@ function New-SubmissionPackage
         }
 
         Set-TelemetryException -Exception $_.Exception -ErrorBucket "New-SubmissionPackage" -Properties $telemetryProperties
+        Write-Log $($_.Exception.Message) -Level Error
+
+        throw
+    }
+    finally
+    {
+        if ($script:tempFolderExists)
+        {
+            Write-Log "Deleting temporary directory: $script:tempFolderPath" -Level Verbose
+            Remove-Item -Force -Recurse $script:tempFolderPath -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function New-InAppProductSubmissionPackage
+{
+<#
+    .SYNOPSIS
+        Top-level function for creating an in-app product submission's JSON body
+        and .zip package for upload.
+
+    .DESCRIPTION
+        Creates the JSON body for a submission request.  Localized listing metadata
+        is taken from the path specified in the config file.
+
+        In the process of creating the JSON, the packaging tool also copies any specified
+        images to a .zip file.
+
+        The .json and .zip files generated by this tool are given the common name specified by
+        the [-OutName] parameter.
+
+        The Git repo for this module can be found here: http://aka.ms/StoreBroker
+
+    .PARAMETER ConfigPath
+        Full path to the JSON file the Packaging Tool will use as the configuration file.
+
+    .PARAMETER PDPRootPath
+       There are two supported layouts for your PDP files:
+           1. <PDPRootPath>\<lang-code>\...\PDP.xml
+           2. <PDPRootPath>\<Release>\<lang-code>\...\PDP.xml
+       The only difference between these two is that there is a <Release> directory after the
+       <PDPRootPath> and before the <lang-code> sub-directories.
+      
+       The first layout is generally used when your localization system will be downloading
+       the localized PDP files during your build.  In that situation, it's always retrieving
+       the latest version.  Alternatively, if the latest localized versions of your PDP
+       files are always stored in the same location, this layout is also for you.
+      
+       On the other hand, if you will be archiving the localized PDP's based on each release
+       to the Store, then the second layout is the one that you should use.  In this scenario,
+       you will specify the value of "<Release>" immediately below, or at the commandline.
+
+    .PARAMETER Release
+        Optional.  When specified, it is used to indicate the correct subfolder within
+       'PDPRootPath' to find the PDP files to use.
+
+    .PARAMETER PDPInclude
+        PDP filenames that SHOULD be processed.
+        If not specified, the default is to process any XML files found in sub-directories
+        of [-PDPRootPath].
+        Wildcards are allowed, eg "InAppProductDescription*.xml".
+        It is fine to specify both "PDPInclude" and "PDPExclude".
+
+    .PARAMETER PDPExclude
+        PDP filenames that SHOULD NOT be processed.
+        Wildcards are allowed, eg "InAppProductDescription*.xml".
+        It is fine to specify both "PDPInclude" and "PDPExclude".
+
+    .PARAMETER LanguageExclude
+        Array of lang-code strings that SHOULD NOT be processed.
+
+    .PARAMETER ImagesRootPath
+        Your icons must be placed with this structure:
+            <ImagesRootPath>\<Release>\<lang-code>\...\icon.png
+        
+        The 'Release' that will be used is NOT the value specified to StoreBroker,
+        it is the 'Release' value found in the corresponding PDP file.
+
+    .PARAMETER OutPath
+        Full path to a directory where the Packaging Tool can write the .json submission request
+        body and .zip package to upload.
+
+    .PARAMETER OutName
+        Common name to give to the .json and .zip files outputted by the Packaging Tool.
+
+    .EXAMPLE
+        New-InAppProductSubmissionPackage -ConfigPath 'C:\Config\StoreBrokerIAPConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease
+        
+        This example creates the submission request body and .zip file for the IAP.Two files will
+        be placed under 'C:\Out\Path\', 'Upload.json' and 'Upload.zip'
+
+    .EXAMPLE
+        New-InAppProductSubmissionPackage -ConfigPath 'C:\Config\StoreBrokerIAPConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -Verbose
+        
+        This example is the same except it specifies Verbose logging and the function will output a
+        detailed report of its actions.
+#>
+
+    [CmdletBinding(SupportsShouldProcess)]
+    [Alias('New-IapSubmissionPackage')]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({ if (Test-Path -PathType Leaf $_) { $true } else { throw "$_ cannot be found." } })]
+        [string] $ConfigPath,
+
+        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [string] $PDPRootPath,
+
+        [string] $Release,
+
+        [string[]] $PDPInclude,
+
+        [string[]] $PDPExclude,
+
+        [string[]] $LanguageExclude,
+
+        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [string] $ImagesRootPath,
+
+        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [string] $OutPath,
+
+        [string] $OutName
+    )
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+    try 
+    {
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+        # Preamble before printing invocation parameters
+        Write-Log "New-InAppProductSubmissionPackage invoked with parameters:" -Level Verbose
+        Write-Log "`t$script:s_ConfigPath = `"$ConfigPath`"" -Level Verbose
+
+        # Check the value of each parameter and add to parameter hashtable if not null.
+        # Resolve-PackageParameters will take care of validating the values, we only need
+        # to avoid splatting null values as this will generate a runtime exception.
+        # Log the value of each parameter.
+        $validationSet = $script:s_PDPRootPath, $script:s_Release, $script:s_PDPInclude, $script:s_PDPExclude, $script:s_LanguageExclude, $script:s_ImagesRootPath, $script:s_OutPath, $script:s_OutName
+        $packageParams = @{}
+        foreach ($param in $validationSet)
+        {
+            $val = Get-Variable -Name $param -ValueOnly -ErrorAction SilentlyContinue |
+                   Where-Object { -not [String]::IsNullOrWhiteSpace($_) }
+
+            # ([string] $null) -ne $null, is true.
+            # Explicitly check the type of the value to avoid printing [string] params that are $null.
+            if ((($val -isnot [System.String]) -and ($null -ne $val)) -or 
+                (($val -is [System.String]) -and (-not [String]::IsNullOrWhiteSpace($val))))
+            {
+                $packageParams[$param] = $val
+                
+                # Treat the value as if it is an array.
+                # If it's not, it will still pretty print fine.
+                $quotedVals = $val | ForEach-Object { "`"$_`"" }
+                Write-Log "`t$param = $($quotedVals -join ', ')" -Level Verbose
+            }
+        }
+        
+        # Convert the Config.json
+        $config = Convert-AppConfig -ConfigPath $ConfigPath
+
+        # Check that all parameters are provided or specified in the config
+        $validatedParams = Resolve-PackageParameters -ConfigObject $config -ParamMap $packageParams -SkipValidation @($script:s_DisableAutoPackageNameFormatting, $script:s_AppxPath)
+
+        # Assign final, validated params
+        $validationSet |
+            Where-Object { $null -ne $validatedParams[$_] } |
+            ForEach-Object { Set-Variable -Name $_ -Value $validatedParams[$_] -ErrorAction SilentlyContinue }
+
+        # Create a temp directory to work in
+        $script:tempFolderPath = New-TemporaryDirectory
+
+        # It may not actually exist due to What-If support.
+        $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and 
+                                   (Test-Path -PathType Container $script:tempFolderPath)
+
+        # Get the submission request object
+        $resourceParams = $script:s_PDPRootPath, $script:s_Release, $script:s_PDPInclude, $script:s_PDPExclude, $script:s_LanguageExclude, $script:s_ImagesRootPath
+        $params = Get-Variable -Name $resourceParams -ErrorAction SilentlyContinue |
+                  ForEach-Object { $m = @{} } { $m[$_.Name] = $_.Value } { $m } # foreach begin{} process{} end{}
+
+        $submissionBody = Get-InAppProductSubmissionRequestBody -ConfigObject $config @params
+
+        Write-SubmissionRequestBody -JsonObject $submissionBody -OutFilePath (Join-Path -Path $OutPath -ChildPath ($OutName + '.json'))
+
+        # Zip the contents of the temporary directory.  Then delete the temporary directory.
+        $zipPath = Join-Path -Path $OutPath -ChildPath ($OutName + '.zip')
+
+        if ($PSCmdlet.ShouldProcess($zipPath, "Output to File") -and $script:tempFolderExists)
+        {
+            if (Test-Path -PathType Leaf $zipPath)
+            {
+                Remove-Item -Force -Recurse -Path $zipPath
+            }
+
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($script:tempFolderPath, $zipPath)
+        }
+
+        # Record the telemetry for this event.
+        $stopwatch.Stop()
+        $telemetryMetrics = @{ [StoreBrokerTelemetryMetric]::Duration = $stopwatch.Elapsed.TotalSeconds }
+        
+        Set-TelemetryEvent -EventName New-InAppProductSubmissionPackage -Metrics $telemetryMetrics
+    }
+    catch
+    {
+        Set-TelemetryException -Exception $_.Exception -ErrorBucket "New-InAppProductSubmissionPackage"
         Write-Log $($_.Exception.Message) -Level Error
 
         throw

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.0.1'
+    ModuleVersion = '1.1.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'
@@ -61,8 +61,10 @@
         'New-ApplicationFlightSubmission',
         'New-ApplicationSubmission',
         'New-InAppProductSubmission',
+        'New-InAppProductSubmissionPackage',
         'New-InAppProduct',
         'New-StoreBrokerConfigFile',
+        'New-StoreBrokerInAppProductConfigFile',
         'New-SubmissionPackage',
         'Open-DevPortal',
         'Remove-ApplicationFlight',
@@ -99,7 +101,9 @@
         'Get-Iaps',
         'New-Iap',
         'New-IapSubmission',
+        'New-IapSubmissionPackage',
         'New-PackageToolConfigFile',
+        'New-StoreBrokerIapConfigFile',
         'Remove-Iap',
         'Remove-IapSubmission',
         'Replace-ApplicationFlightSubmission',

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1007,7 +1007,7 @@ function Update-ApplicationSubmission
         $output += "Please update your app's StoreBroker config file by adding an ""appId"" property with"
         $output += "your app's AppId to the ""appSubmission"" section.  If you're unclear on what change"
         $output += "needs to be done, you can re-generate your config file using"
-        $output += "   ""New-PackageToolConfigFile -AppId $AppId"" -Path ""`$home\desktop\newconfig.json"""
+        $output += "   ""New-StoreBrokerConfigFile -AppId $AppId"" -Path ""`$home\desktop\newconfig.json"""
         $output += "and then diff the new config file against your current one to see the requested appId change."
         Write-Log $($output -join [Environment]::NewLine) -Level Warning
     }


### PR DESCRIPTION
* Added new PDP schema and example file for IAP's and updated the
  corresonding PDP.md documentation.
* Adds ConvertFrom-ExistingIapSubmission.ps1, mirroring
  ConvertFrom-ExistingSubmission.ps1, to auto-generate the IAP
  PDP set from an existing publishing or pending submission.
* Added the ability to generate a new IAP StoreBroker configuration
  file based on a default config file, as well as based on a
  current submission for that IAP, similar to what we do for
  applications.
* Added New-InAppProductSubmissionPackage to generate a StoreBroker
  payload from a config file and IAP PDP's (and optional icons).
* Updated PackageTool's Resolve-PackageParameters helper method to
  optionally skip a list of parameters so that the same method could
  be used for both packaging commands since they're so similar, even
  though IAP's don't use appx packages.
* Updated Update-InAppProductSubmission to do a similar iapId check
  of the commandline vs the payload's json value, similar to what we
  do for Update-ApplicationSubmission.
* Updated SETUP.md and USAGE.md documentation to reflect these changes,
  and removed the note in README.md that this work hasn't been done yet.

Additionally:
* Fixed telemetry property typos for Iap's (referencing an Iap property
  instead of IapId), along with other AppId->IapId references for the
  IAP methods.
* Fixed documentation example typo in ConvertFrom-ExistingSubmission.ps1
* Minor related Comment-Based-Help (CBH) changes to PackageTool.

Resolves #3 : Create PDP XSD for IAP's, and add New-IapSubmissionPackage