### PR TITLE
skip console messages if the host is non-interactive

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.1.1'
+    ModuleVersion = '1.1.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Issue #12 

First try the -NonInteractive parameter check (which should catch most cases).  If no parameters are supplied, check for the 'Default Host' name.  

The latter check is needed when running the scripts within the [EdgePS](https://github.com/tjanczuk/edge#how-to-script-powershell-in-a-nodejs-application) hosting environment. Unfortunately, no parameters are supplied in the binary version that we are consuming.

Resolves #12: Console messages should be suppressed in Write-Log for non-interactive consoles 