### PR TITLE
v1.1.1 - Add a logger option to print timestamps in UTC for log traces

### DIFF
--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -56,7 +56,7 @@ into the corresponding `Format-*` command.
 ### Logging
 
 All commands will log to the console, as well as to a log file, by default.
-The logging is affected by two global variables.  The pre-existing values of these
+The logging is affected by three global variables.  The pre-existing values of these
 variables will be honored if they already exist, otherwise they will be created (with defaults)
 when the module is loaded.
 
@@ -65,6 +65,10 @@ when the module is loaded.
     
  **`$global:SBLoggingEnabled`** [bool] Defaults to `$true`. To disable file-based logging,
     set to `$false`
+
+ **`$global:SBUseUTC`** [bool] Defaults to `$false`. If `$false`, times are logged in local time.
+    When `$true`, times are logged using UTC (and those timestamps will end with a Z per the
+    [W3C standard](http://www.w3.org/TR/NOTE-datetime))
 
 > **PowerShell Tip**
 >

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -71,6 +71,11 @@ function Initialize-HelpersGlobalVariables
     {
         $global:SBNotifyCredential = [PSCredential]$null
     }
+
+    if (!(Get-Variable -Name SBUseUTC -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    {
+        $global:SBUseUTC = $false
+    }
 }
 
 # We need to be sure to call this explicitly so that the global variables get initialized.
@@ -415,16 +420,23 @@ function Write-Log
 
     Process
     {
+        $date = Get-Date
+        $dateString = $date.ToString("yyyy-MM-dd HH:mm:ss")
+        if ($global:SBUseUTC)
+        {
+            $dateString = $date.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ssZ")
+        }
+
         $logFileMessage = '{0}{1} : {2} : {3} : {4}' -f
             (" " * $Indent),
-            (Get-Date -Format "yyyy-MM-dd HH:mm:ss"),
+            $dateString,
             $env:username,
             $Level.ToUpper(),
             $Message
             
         $consoleMessage = '{0}{1} : {2} : {3}' -f
             (" " * $Indent),
-            (Get-Date -Format "yyyy-MM-dd HH:mm:ss"),
+            $dateString,
             $env:username,
             $Message
 
@@ -433,7 +445,7 @@ function Write-Log
             'Error'   { Write-Error $ConsoleMessage }
             'Warning' { Write-Warning $ConsoleMessage }
             'Verbose' { Write-Verbose $ConsoleMessage }
-            'Debug'   { Write-Degbug $ConsoleMessage }
+            'Debug'   { Write-Debug $ConsoleMessage }
             'Info'    {
                 # We'd prefer to use Write-Information to enable users to redirect that pipe if
                 # they want, unfortunately it's only available on v5 and above.  We'll fallback to

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.1.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
`Write-Log` is used for writing all messages to the console and the log file.
It embeds a timestamp with each message, but this timestamp uses LocalTime.
A request has come in to optionally allow users to have this timestamp
recorded in UTC instead of LocalTime.

This adds a new global variable `$global:SBUseUTC` that defaults to `$false`.
If set to `$true`, then `Write-Log` will use UTC for the timestamps.

The documentation has been updated to reflect this new
configuration option.

* Additionally fixed a typo in `Write-Log` where it was trying to
call `Write-Debug`.

Resolves #10: Add a logger option to print timestamps in UTC for log traces