### PR TITLE
Fix static analysis warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ into the source.
 
 StoreBroker is maintained by:
 
-- **[@HowardWolosky-MSFT](http://github.com/HowardWolosky-MSFT)**
+- **[@TheHoward](http://github.com/TheHoward)**
 - **[@DanBelcher-MSFT](http://github.com/DanBelcher-MSFT)**
 
 As StoreBroker is a production dependency for Microsoft, we have a couple workflow restrictions:
@@ -134,6 +134,11 @@ either fix the issues that it calls out, or add a `[Diagnostics.CodeAnalysis.Sup
 with a justification explaining why it's ok to suppress that rule within that part of the script.
 Refer to the [PSScriptAnalyzer documentation](https://github.com/PowerShell/PSScriptAnalyzer/) for
 more information on how to use that attribute, or look at other existing examples within this module.
+
+> Please ensure that your installation of PSScriptAnalyzer is up-to-date by running:
+> `Update-Module -Name PSScriptAnalyzer`
+> You should close and re-open your console window if the module was updated as a result of running
+> that command.
 
 ----------
 

--- a/Documentation/GOVERNANCE.md
+++ b/Documentation/GOVERNANCE.md
@@ -38,8 +38,8 @@ StoreBroker.
 
 ### Current Committee Members
 
- * Howard Wolosky ([HowardWolosky-MSFT](https://github.com/HowardWolosky-MSFT))
- * Daniel Belcher ([DanBelcher-MSFT](https://github.com/DanBelcher-MSFT)).
+ * Howard Wolosky ([@TheHoward](https://github.com/TheHoward))
+ * Daniel Belcher ([@DanBelcher-MSFT](https://github.com/DanBelcher-MSFT)).
 
 ### Committee Member Responsibilities
 

--- a/Documentation/PDP.md
+++ b/Documentation/PDP.md
@@ -132,13 +132,13 @@ At this time, StoreBroker has two PDP schemas in use:
 
 ### Application Submissions
  * **Uri**: `http://schemas.microsoft.com/appx/2012/ProductDescription`
- * **XSD**: [PDP\ProductDescription.xsd](..\PDP\ProductDescription.xsd)
- * **Sample XML**: [PDP\ProductDescription.xml](..\PDP\ProductDescription.xml)
+ * **XSD**: [PDP\ProductDescription.xsd](../PDP/ProductDescription.xsd)
+ * **Sample XML**: [PDP\ProductDescription.xml](../PDP/ProductDescription.xml)
 
 ### In-App Product (IAP) ("add-on") Submissions
  * **Uri**: `http://schemas.microsoft.com/appx/2012/InAppProductDescription`
- * **XSD**: [PDP\InAppProductDescription.xsd](..\PDP\InAppProductDescription.xsd)
- * **Sample XML**: [PDP\InAppProductDescription.xml](..\PDP\InAppProductDescription.xml)
+ * **XSD**: [PDP\InAppProductDescription.xsd](../PDP/InAppProductDescription.xsd)
+ * **Sample XML**: [PDP\InAppProductDescription.xml](../PDP/InAppProductDescription.xml)
 
 ----------
 

--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -290,7 +290,6 @@ function Add-Icon
     $elementName = "Icon"
     [System.Xml.XmlElement] $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
 
-    $maxChars = 200
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ 'Filename' = $iconFilename };

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1568,6 +1568,7 @@ function Remove-DeprecatedProperties
 #>
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="This is intended to be where all deprecated properties are removed.  It's an accurate name.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "", Justification="Does not cause any change to system state. No value gained from ShouldProcess in this specific instance.")]
     param(
         [Parameter(Mandatory)]
         [PSCustomObject] $SubmissionRequestBody
@@ -2125,7 +2126,7 @@ filter Remove-Comment
 
         "example", "test "
 #>
-
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "", Justification="Does not cause any change to system state. No value gained from ShouldProcess in this specific instance.")]
     param(
         [string] $CommentDelimiter = "//",
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.1.2'
+    ModuleVersion = '1.1.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -390,7 +390,7 @@ function Get-AccessToken
                     Invoke-RestMethod $url -Method Post -Body $body
                 }
 
-                $job = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $body)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $body)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {
@@ -677,7 +677,7 @@ function Set-SubmissionPackage
                     $cloudBlockBlob.UploadFromFile($PackagePath, [System.IO.FileMode]::Open)
                 }
 
-                $job = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($UploadUrl, $PackagePath, $azureStorageDll)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($UploadUrl, $PackagePath, $azureStorageDll)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {
@@ -839,7 +839,7 @@ function Get-SubmissionPackage
                     $cloudBlockBlob.DownloadToFile($PackagePath, [System.IO.FileMode]::OpenOrCreate)
                 }
 
-                $job = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($UploadUrl, $PackagePath, $azureStorageDll)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($UploadUrl, $PackagePath, $azureStorageDll)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {
@@ -1521,7 +1521,7 @@ function Invoke-SBRestMethod
                     Invoke-RestMethod @params
                 }
 
-                $job = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -669,7 +669,7 @@ function Remove-ApplicationSubmission
         "NoStatus" = $NoStatus
     }
 
-    $result = Invoke-SBRestMethod @params
+    $null = Invoke-SBRestMethod @params
 }
 
 function New-ApplicationSubmission
@@ -1666,7 +1666,7 @@ function Complete-ApplicationSubmission
             "NoStatus" = $NoStatus
         }
 
-        $result = Invoke-SBRestMethod @params 
+        $null = Invoke-SBRestMethod @params 
 
         $output = @()
         $output += "The submission has been successfully committed."

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -544,7 +544,7 @@ function Remove-ApplicationFlight
         "NoStatus" = $NoStatus
     }
 
-    $result = Invoke-SBRestMethod @params
+    $null = Invoke-SBRestMethod @params
 }
 
 function Get-ApplicationFlightSubmission
@@ -896,7 +896,7 @@ function Remove-ApplicationFlightSubmission
         "NoStatus" = $NoStatus
     }
 
-    $result = Invoke-SBRestMethod @params
+    $null = Invoke-SBRestMethod @params
 }
 
 function New-ApplicationFlightSubmission
@@ -1738,7 +1738,7 @@ function Complete-ApplicationFlightSubmission
             "NoStatus" = $NoStatus
         }
 
-        $result = Invoke-SBRestMethod @params
+        $null = Invoke-SBRestMethod @params
 
         $output = @()
         $output += "The submission has been successfully committed."

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -620,7 +620,7 @@ function Remove-InAppProduct
         "NoStatus" = $NoStatus
     }
 
-    $result = Invoke-SBRestMethod @params
+    $null = Invoke-SBRestMethod @params
 }
 
 function Get-InAppProductSubmission
@@ -1012,7 +1012,7 @@ function Remove-InAppProductSubmission
         "NoStatus" = $NoStatus
     }
 
-    $result = Invoke-SBRestMethod @params
+    $null = Invoke-SBRestMethod @params
 }
 
 function New-InAppProductSubmission
@@ -1867,7 +1867,7 @@ function Complete-InAppProductSubmission
             "NoStatus" = $NoStatus
         }
 
-        $result = Invoke-SBRestMethod @params
+        $null = Invoke-SBRestMethod @params
 
         $output = @()
         $output += "The submission has been successfully committed."


### PR DESCRIPTION
There are some new warnings coming up when checking StoreBroker
with newer versions of [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer).

* `PSUseDeclaredVarsMoreThanAssignments` - We had some instances where
  a variable was being assigned to but never used.  For the API instances,
  we now capture to $null in the instances where we don't want the helper
  method's results being returned to the user.

* `PSUseShouldProcessForStateChangingFunctions` - Two PackageTool methods
  use the verb "Remove" but have no need for providing ShouldProcess support.
  Those instances are now suppressed.

All remaining warnings are false positives of `PSUseDeclaredVarsMoreThanAssignments`.
I have opened two different issues against PSScriptAnalyzer to track these false
positives:
   * [PSUseDeclaredVarsMoreThanAssignment not correctly handling global vars assigned to within functions](PowerShell/PSScriptAnalyzer#698)
   * [PSUseDeclaredVarsMoreThanAssignment not correctly handling array adds](PowerShell/PSScriptAnalyzer#699)

Updated CONTRIBUTING.md to remind users to keep the analyzer module up-to-date.

Additionally, the links in PDP.md were invalid.  Those have now been fixed.