### PR TITLE
Increase Proxy maxRequestLength

### DIFF
--- a/RESTProxy/Web.config
+++ b/RESTProxy/Web.config
@@ -24,7 +24,7 @@
   -->
   <system.web>
     <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" maxRequestLength="32768" />
 
     <authentication mode="Windows" />
     <authorization>


### PR DESCRIPTION
The default `maxRequestLength` for an ASP.NET service is 4096 (4 megabytes).
Some users of the proxy that had applications that were localized to many
languages (100+) were finding that the proxy was returning back an internal
server error (500) when trying to POST or PUT that JSON content.

The root cause for that failure was `Request.Content.ReadAsByteArrayAsync()`
in `RootController` was throwing a "maximum request length exceeded" exception
because the content size exceeded this `maxRequestLength` value.

In this specific instance, doubling the value to 8192 was sufficient to resolve
the problem.  However, in order to add a bit more buffer and prevent a similar
scenario from happening in the future, I've quadrupled the value (4096 -> 32768).