### PR TITLE
Properly escape special characters when generating config files

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -279,7 +279,7 @@ function Get-SHA512Hash
     .SYNOPSIS
         Gets the SHA512 hash of the requested string.
 
-    .SYNOPSIS
+    .DESCRIPTION
         Gets the SHA512 hash of the requested string.
 
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
@@ -305,6 +305,57 @@ function Get-SHA512Hash
     $sha512= New-Object -TypeName System.Security.Cryptography.SHA512CryptoServiceProvider
     $utf8 = New-Object -TypeName System.Text.UTF8Encoding
     return [System.BitConverter]::ToString($sha512.ComputeHash($utf8.GetBytes($PlainText))) -replace '-', ''
+}
+
+function Get-EscapedJsonValue
+{
+<#
+    .SYNOPSIS
+        Escapes special characters within a string for use within a JSON value.
+
+    .DESCRIPTION
+        Escapes special characters within a string for use within a JSON value.
+
+        The Git repo for this module can be found here: http://aka.ms/StoreBroker
+
+    .PARAMETER Value
+        The string that needs to be escaped
+
+    .EXAMPLE
+        Get-EscapedJsonValue -Value 'This is my "quote". Look here: c:\windows\'
+
+        Returns back the string 'This is my \"quote\". Look here: c:\\windows\\'
+
+    .OUTPUTS
+        System.String - A string with special characters escaped for use within JSON.
+
+    .NOTES
+        Normalizes newlines and carriage returns to always be \r\n.
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $Value
+    )
+
+    # The syntax of -replace is a bit confusing, so it's worth a note here.
+    # The first parameter is a regular expression match pattern.  The second parameter is a replacement string.
+    # So, when we try to do "-replace '\\', '\\", that's matching a single backslash (which has to be
+    # escaped within the match regular expression as a double-backslash), and replacing it with a
+    # string containing literally two backslashes.
+    # (And as a reminder, PowerShell's escape character is actually the backtick (`) and not backslash (\).)
+
+    # \, ", <tab>
+    $escaped = $Value -replace '\\', '\\' -replace '"', '\"' -replace '\t', '\t'
+
+    # Now normalize actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
+    $escaped = $escaped -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
+
+    return $escaped
 }
 
 function ConvertTo-Array

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -102,8 +102,7 @@ function Get-StoreBrokerConfigFileContentForIapId
         $updated = $updated -replace '"lifetime": ".*",', "`"lifetime`": `"$($sub.lifetime)`","
         $updated = $updated -replace '"contentType": ".*",', "`"contentType`": `"$($sub.contentType)`","
 
-        # Need to replace actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
-        $tag = $sub.tag -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
+        $tag = Get-EscapedJsonValue -Value $sub.tag
         $updated = $updated -replace '"tag": ""', "`"tag`": `"$tag`""
 
         $keywords = $sub.keywords | ConvertTo-Json -Depth $script:jsonConversionDepth
@@ -111,8 +110,7 @@ function Get-StoreBrokerConfigFileContentForIapId
         $updated = $updated -replace '(\s+)"keywords": \[.*(\r|\n)+\s*\]', "`$1`"keywords`": $keywords"
 
         # NOTES FOR CERTIFICATION
-        # Need to replace actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
-        $notesForCertification = $sub.notesForCertification -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
+        $notesForCertification = Get-EscapedJsonValue -Value $sub.notesForCertification
         $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": `"$notesForCertification`""
 
         return $updated
@@ -305,8 +303,7 @@ function Get-StoreBrokerConfigFileContentForAppId
         $updated = $updated -replace '"isGameDvrEnabled": .*,', "`"isGameDvrEnabled`": $($sub.isGameDvrEnabled.ToString().ToLower()),"
 
         # NOTES FOR CERTIFICATION
-        # Need to replace actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
-        $notesForCertification = $sub.notesForCertification -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
+        $notesForCertification = Get-EscapedJsonValue -Value $sub.notesForCertification
         $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": `"$notesForCertification`""
 
         return $updated

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.2.0'
+    ModuleVersion = '1.2.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
We were escaping linefeeds when generating config files, but we
were not escaping back slashes, quote characters or tabs.