### PR TITLE
Clarify behavior of Dev Portal with new submissions

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.2.1'
+    ModuleVersion = '1.2.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -32,6 +32,19 @@ $script:keywordPendingCommit = 'PendingCommit'
 $script:keywordRelease = 'Release'
 $script:keywordPublished = 'Published'
 
+# Warning that is referenced in multiple places throughout the module.
+# {0} will be replaced in context with the relevant command.
+$script:manualPublishWarning = @"
+PLEASE NOTE: Due to the nature of how the Store API works, you won't see any of your changes in the
+Dev Portal until your submission has entered into certification.  It doesn't have to *complete*
+certification for you to see your changes, but it does have to enter certification first.
+If it's important for you to verify your changes in the Dev Portal prior to publishing,
+consider publishing with the `"$script:keywordManual`" targetPublishMode by setting that value in your
+config file and then additionally specifying the -UpdatePublishModeAndVisibility switch
+when calling {0}, or by specifying the
+-TargetPublishMode $script:keywordManual parameter when calling {0}.
+"@
+
 function Initialize-StoreIngestionApiGlobalVariables
 {
 <#
@@ -1235,10 +1248,10 @@ function Open-DevPortal
 {
 <#
     .SYNOPSIS
-        Launches the dev portal in the default web browser to display the requested information.
+        Launches the Dev Portal in the default web browser to display the requested information.
 
     .DESCRIPTION
-        Launches the dev portal in the default web browser to display the requested information.
+        Launches the Dev Portal in the default web browser to display the requested information.
 
         Sometimes users simply want to be able to see what's going on within the web portal as
         opposed to the commandline.  This is designed to make that work as quickly as possible.
@@ -1257,19 +1270,19 @@ function Open-DevPortal
     .EXAMPLE
         Open-DevPortal 0ABCDEF12345
 
-        Opens a new tab in the default web browser to the page in the dev portal that displays
+        Opens a new tab in the default web browser to the page in the Dev Portal that displays
         the general status of the application.
 
     .EXAMPLE
         Open-DevPortal 0ABCDEF12345 1234567890123456789
 
-        Opens a new tab in the default web browser to the page in the dev portal that displays
+        Opens a new tab in the default web browser to the page in the Dev Portal that displays
         the indicated submission.  Will work for both app and flight submissions.
 
     .EXAMPLE
         Open-DevPortal 0ABCDEF12345 1234567890123456789 -ShowFlight
 
-        Opens a new tab in the default web browser to the page in the dev portal that displays
+        Opens a new tab in the default web browser to the page in the Dev Portal that displays
         the flight edit page (enabling you to change the name, flight groups and ranking).
 #>
     [CmdletBinding(DefaultParametersetName="App")]
@@ -1303,7 +1316,7 @@ function Open-DevPortal
 
     Set-TelemetryEvent -EventName Open-DevPortal -Properties $telemetryProperties 
 
-    Write-Log "Opening dev portal in default web browser." 
+    Write-Log "Opening Dev Portal in default web browser." 
     
     $appUrl        = "https://developer.microsoft.com/en-us/dashboard/apps/$AppId"
     $submissionUrl = "https://developer.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$SubmissionId/"

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1106,10 +1106,12 @@ function Update-ApplicationSubmission
 
         $output = @()
         $output += "Successfully cloned the existing submission and modified its content."
-        $output += "You can view it on the Dev portal here:"
+        $output += "You can view it on the Dev Portal here:"
         $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
         $output += "or by running this command:"
         $output += "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission"
+        $output += ""
+        $output += $script:manualPublishWarning -f 'Update-ApplicationSubmission'
         Write-Log $($output -join [Environment]::NewLine)
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
@@ -1336,7 +1338,7 @@ function Patch-ApplicationSubmission
     # the existing listings array with the new one.  We can't do that unfortunately though,
     # as we need to mark the existing screenshots as "PendingDelete" so that they'll be deleted
     # during the upload.  Otherwise, even though we don't include them in the updated JSON, they
-    # will still remain there in the dev portal.
+    # will still remain there in the Dev Portal.
     if ($UpdateListings)
     {
         # Save off the original listings so that we can make changes to them without affecting
@@ -1672,21 +1674,14 @@ function Complete-ApplicationSubmission
         $output += "The submission has been successfully committed."
         $output += "This is just the beginning though."
         $output += "It still has multiple phases of validation to get through, and there's no telling how long that might take."
-        $output += "You can view the progress of the submission validation on the Dev portal here:"
+        $output += "You can view the progress of the submission validation on the Dev Portal here:"
         $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
         $output += "or by running this command:"
         $output += "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission"
         $output += "You can automatically monitor this submission with this command:"
         $output += "    Start-ApplicationSubmissionMonitor -AppId $AppId -SubmissionId $submissionId -EmailNotifyTo $env:username"
         $output += ""
-        $output += "PLEASE NOTE: Due to the nature of how the Store API works, you won't see any of your changes in the"
-        $output += "dev portal until your submission has entered into certification.  It doesn't have to *complete*"
-        $output += "certification for you to see your changes, but it does have to enter certification first."
-        $output += "If it's important for you to verify your changes in the dev portal prior to publishing,"
-        $output += "consider publishing with the `"$script:keywordManual`" targetPublishMode by setting that value in your"
-        $output += "config file and then additionally specifying the -UpdatePublishModeAndVisibility switch"
-        $output += "when calling Update-ApplicationSubmission, or by specifying the"
-        $output += "-TargetPublishMode $script:keywordManual parameter when calling Update-ApplicationSubmission."
+        $output += $script:manualPublishWarning -f 'Update-ApplicationSubmission'
         Write-Log $($output -join [Environment]::NewLine) 
     }
     catch [System.InvalidOperationException]

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -329,10 +329,10 @@ function Get-FlightGroups
 {
 <#
     .SYNOPSIS
-        Launches the dev portal in the default web browser to display all of the available flight groups.
+        Launches the Dev Portal in the default web browser to display all of the available flight groups.
 
     .DESCRIPTION
-        Launches the dev portal in the default web browser to display all of the available flight groups.
+        Launches the Dev Portal in the default web browser to display all of the available flight groups.
         This is necessary because there currently exists no API to programatically browse these groups.
 
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
@@ -340,7 +340,7 @@ function Get-FlightGroups
     .EXAMPLE
         Open-ApplicationFlightGroups
 
-        Opens a new tab in the default web browser to the page in the dev portal that displays
+        Opens a new tab in the default web browser to the page in the Dev Portal that displays
         all of the available flight groups.
 #>
     [CmdletBinding()]
@@ -350,7 +350,7 @@ function Get-FlightGroups
 
     Set-TelemetryEvent -EventName Get-FlightGroups
 
-    Write-Log "Opening the dev portal UI in your default browser to view flight groups because there is currently no API access for this data."
+    Write-Log "Opening the Dev Portal UI in your default browser to view flight groups because there is currently no API access for this data."
     Write-Log "The FlightGroupID is the number at the end of the URL when you click on any flight group name."
 
     if (-not [String]::IsNullOrWhiteSpace($global:SBInternalGroupIds))
@@ -1306,10 +1306,12 @@ function Update-ApplicationFlightSubmission
 
         $output = @()
         $output += "Successfully cloned the existing submission and modified its content."
-        $output += "You can view it on the Dev portal here:"
+        $output += "You can view it on the Dev Portal here:"
         $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
         $output += "or by running this command:"
         $output += "    Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission"
+        $output += ""
+        $output += $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission'
         Write-Log $($output -join [Environment]::NewLine)
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
@@ -1744,21 +1746,14 @@ function Complete-ApplicationFlightSubmission
         $output += "The submission has been successfully committed."
         $output += "This is just the beginning though."
         $output += "It still has multiple phases of validation to get through, and there's no telling how long that might take."
-        $output += "You can view the progress of the submission validation on the Dev portal here:"
+        $output += "You can view the progress of the submission validation on the Dev Portal here:"
         $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
         $output += "or by running this command:"
         $output += "    Get-ApplicationFlightSubmission -AppId $AppId -Flight $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission"
         $output += "You can automatically monitor this submission with this command:"
         $output += "    Start-ApplicationFlightSubmissionMonitor -AppId $AppId -Flight $FlightId -SubmissionId $submissionId -EmailNotifyTo $env:username"
         $output += ""
-        $output += "PLEASE NOTE: Due to the nature of how the Store API works, you won't see any of your changes in the"
-        $output += "dev portal until your submission has entered into certification.  It doesn't have to *complete*"
-        $output += "certification for you to see your changes, but it does have to enter certification first."
-        $output += "If it's important for you to verify your changes in the dev portal prior to publishing,"
-        $output += "consider publishing with the `"$script:keywordManual`" targetPublishMode by setting that value in your"
-        $output += "config file and then additionally specifying the -UpdatePublishMode switch"
-        $output += "when calling Update-ApplicationFlightSubmission, or by specifying the"
-        $output += "-TargetPublishMode $script:keywordManual parameter when calling Update-ApplicationFlightSubmission."
+        $output += $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission'
 
         Write-Log $($output -join [Environment]::NewLine)
     }

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -1405,10 +1405,12 @@ function Update-InAppProductSubmission
 
         $output = @()
         $output += "Successfully cloned the existing submission and modified its content."
-        $output += "You can view it on the Dev portal here:"
+        $output += "You can view it on the Dev Portal here:"
         $output += "    https://dev.windows.com/en-us/dashboard/iaps/$IapId/submissions/$submissionId/"
         $output += "or by running this command:"
         $output += "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission"
+        $output += ""
+        $output += $script:manualPublishWarning -f 'Update-InAppProductSubmission'
         Write-Log $($output -join [Environment]::NewLine)
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
@@ -1596,7 +1598,7 @@ function Patch-InAppProductSubmission
     # as we need to mark the existing icons as "PendingDelete" so that they'll be deleted
     # during the upload, but only if the new listing doesn't have a new icon.
     # Otherwise, even though we don't include them in the updated JSON, they will still remain
-    # there in the dev portal which is not the desired behavior.
+    # there in the Dev Portal which is not the desired behavior.
     if ($UpdateListings)
     {
         # Save off the original listings so that we can make changes to them without affecting
@@ -1873,21 +1875,14 @@ function Complete-InAppProductSubmission
         $output += "The submission has been successfully committed."
         $output += "This is just the beginning though."
         $output += "It still has multiple phases of validation to get through, and there's no telling how long that might take."
-        $output += "You can view the progress of the submission validation on the Dev portal here:"
+        $output += "You can view the progress of the submission validation on the Dev Portal here:"
         $output += "    https://dev.windows.com/en-us/dashboard/iaps/$IapId/submissions/$submissionId/"
         $output += "or by running this command:"
         $output += "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission"
         $output += "You can automatically monitor this submission with this command:"
         $output += "    Start-InAppProductSubmissionMonitor -IapId $IapId -SubmissionId $submissionId -EmailNotifyTo $env:username"
         $output += ""
-        $output += "PLEASE NOTE: Due to the nature of how the Store API works, you won't see any of your changes in the"
-        $output += "dev portal until your submission has entered into certification.  It doesn't have to *complete*"
-        $output += "certification for you to see your changes, but it does have to enter certification first."
-        $output += "If it's important for you to verify your changes in the dev portal prior to publishing,"
-        $output += "consider publishing with the `"$script:keywordManual`" targetPublishMode by setting that value in your"
-        $output += "config file and then additionally specifying the -UpdatePublishModeAndVisibility switch"
-        $output += "when calling Update-InAppProductSubmission, or by specifying the"
-        $output += "-TargetPublishMode $script:keywordManual parameter when calling Update-InAppProductSubmission."
+        $output += $script:manualPublishWarning -f 'Update-InAppProductSubmission'
         Write-Log $($output -join [Environment]::NewLine)
     }
     catch [System.InvalidOperationException]


### PR DESCRIPTION
We have a warning on Commit that changes to a submission can't be seen
in the Dev Portal until the submission enters the Certification phase,
however we weren't providing that warning right after a submission was
patched, which was leading to some user confusion of why they couldn't
see their changes.

The warning has been moved to a single location and is now referenced
throughout the module.

Additionally, normalized the capitalization of the phrase "Dev Portal"
throughout the module.