### PR TITLE
Log MS-CorrelationId with each API request

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.3.0'
+    ModuleVersion = '1.4.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The Windows Store Submission API returns a special
header named `MS-CorrelationId` with every API response.
This value can be used to correlate the request on their
end, which is necessary when needing to debug / investigate
problems with specific requests.

We now log this header value (to the Verbose channel) upon
each request currently being executed internally by
`Invoke-SBRestMethod`.

Previously, `Invoke-SBRestMethod` was a wrapper around
`Invoke-RestMethod`.  However, `Invoke-RestMethod` drops
headers that come from the response.  Therefore, it is now
moving to use `Invoke-WebRequest` (which `Invoke-RestMethod`
itself is a wrapper on).

On success, it's quite easy to get accsess to the response headers.
Getting access to the headers in the failure scenario is a bit
more complicated.

Any failure in the request (400, 409, etc...) is considered a `WebException`.
That exception has a `Response` object with access to the headers.
When `-NoStatus` is being used, that exception is sent directly, making header
access easy.

However, in the asynchronous execution scenario (which is the default),
exceptions come back serialized within a `RemoteException`,
and `WebException` does not serialize its header collection.  This means
that we can't directly use the `WebException` if we want access to the
header value.  Instead, we do a catch within the execution of the asynchronous
job itself, and we'll throw a custom exception that is our own JSON object
which contains the specific data that we need to use in the true exception
handling.

With that, we can then unify our true exception handling, extract out the
information from the exception object into common local variables, and then
use the same codepath for handling both the pure and wrapped exceptions.

The net result is that we now uniformly report errors the exact same way,
and we log `MS-CorrelationId` in all success and failure scenarios.