### PR TITLE
Publish a StoreBroker NuGet package.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,6 +301,10 @@ Where:
 * `<minor>` - If this is a feature update, increment by one and be sure to reset `<patch>` to 0.
 * `<patch>` - If this is a bug fix, leave `<minor>` alone and increment this by one.
 
+When new code changes are checked in to the repo, a new NuGet package must be published by Microsoft.
+This process is documented in Microsoft's internal StoreBroker repo.
+Refer to the CONTRIBUTING.md in that repo for more information on creating a signed NuGet package.
+
 ----------
 
 ### Legal and Licensing

--- a/StoreBroker.nuspec
+++ b/StoreBroker.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.Windows.StoreBroker</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>microsoft,nugetstorebrokerteam</owners>
+    <licenseUrl>https://aka.ms/StoreBroker_License</licenseUrl>
+    <projectUrl>https://aka.ms/StoreBroker</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>A PowerShell module that leverages the Windows Store Submission API to allow easy automation of application submissions to the Windows Store.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>microsoft windows store broker storebroker submission api powershell posh module</tags>
+    <language>en-US</language>
+  </metadata>
+  <files>
+      <file src="StoreBroker\" target="StoreBroker\"/>
+      <file src="Extensions\" target="Extensions\"/>
+      <file src="PDP\*.xsd" target="PDP\"/>
+  </files>
+</package>

--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -30,7 +30,7 @@ function Get-NugetExe
         $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
         $script:nugetExePath = Join-Path $(New-TemporaryDirectory) "nuget.exe"
     
-        Write-Log "Downlading $sourceNugetExe to $script:nugetExePath" -Level Verbose
+        Write-Log "Downloading $sourceNugetExe to $script:nugetExePath" -Level Verbose
         Invoke-WebRequest $sourceNugetExe -OutFile $script:nugetExePath
     }
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.7.0'
+    ModuleVersion = '1.7.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'
@@ -143,10 +143,10 @@
             Tags = @('Store', 'App', 'Submission')
 
             # A URL to the license for this module.
-            LicenseUri = 'http://aka.ms/StoreBroker_License'
+            LicenseUri = 'https://aka.ms/StoreBroker_License'
 
             # A URL to the main website for this project.
-            ProjectUri = 'http://aka.ms/StoreBroker'
+            ProjectUri = 'https://aka.ms/StoreBroker'
 
             # A URL to an icon representing this module.
             # IconUri = ''


### PR DESCRIPTION
This change adds support for publishing a StoreBroker NuGet package. The CONTRIBUTING.md is updated to reference the internal repo as the location
for documentation describing the packaging/publishing process.

StoreBroker.nuspec is added to the root directory and describes the content for the .nupkg. The author of the package is Microsoft and the package will be co-owned by the 'microsoft' and 'nugetstorebrokerteam' NuGet accounts.

The .nupkg will contain the entirety of the StoreBroker subfolder (the files constituting the module), both of the Extensions\ConvertFrom-* scripts, and the XSD files from the PDP folder (for validating PDP XML schema).

Resolves #1 : Create and publish NuGet package