### PR TITLE
Prevent "Cannot index into a null array." exception

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.4.1'
+    ModuleVersion = '1.4.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1617,8 +1617,12 @@ function Invoke-SBRestMethod
                         $ex.Message = $_.Exception.Message
                         $ex.StatusCode = $_.Exception.Response.StatusCode
                         $ex.StatusDescription = $_.Exception.Response.StatusDescription
-                        $ex.CorrelationId = $_.Exception.Response.Headers[$script:headerMSCorrelationId]
                         $ex.InnerMessage = $_.ErrorDetails.Message
+                        if ($_.Exception.Response.Headers.Count -gt 0)
+                        {
+                            $ex.CorrelationId = $_.Exception.Response.Headers[$script:headerMSCorrelationId]
+                        }
+
                         throw ($ex | ConvertTo-Json -Depth 20)
                     }
                 }
@@ -1691,7 +1695,10 @@ function Invoke-SBRestMethod
             $statusCode = $ex.Response.StatusCode.value__ # Note that value__ is not a typo.
             $statusDescription = $ex.Response.StatusDescription
             $innerMessage = $_.ErrorDetails.Message
-            $correlationId = $ex.Response.Headers[$script:headerMSCorrelationId]
+            if ($ex.Response.Headers.Count -gt 0)
+            {
+                $correlationId = $ex.Response.Headers[$script:headerMSCorrelationId]
+            }
 
         }
         elseif (($_.Exception -is [System.Management.Automation.RemoteException]) -and


### PR DESCRIPTION
A PowerShell timeout of a web request will still result in a WebException being thrown,
although there will be no headers in the Response.  If you try to index into a `$null`
value, you end up getting an InvalidOperationException indicating: "Cannot index into a null array."

So, we'll now make sure that `$ex.Response.Headers` has headers before trying to get the
correlationId.  It's ok if the header itself is missing...we'll just get back a $null which
is fine...the issue is only when you try to index into null (e.g. `$null["foo"]`).