### PR TITLE
Enable relative package paths for uploading/downloading

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -756,3 +756,60 @@ function Write-InteractiveHost
         Write-Host @PSBoundParameters
     }
 }
+
+function Resolve-UnverifiedPath
+{
+<#
+    .SYNOPSIS
+        A wrapper around Resolve-Path that works for paths that exist as well
+        as for paths that don't (Resolve-Path normally throws an exception if
+        the path doesn't exist.)
+
+    .DESCRIPTION
+        A wrapper around Resolve-Path that works for paths that exist as well
+        as for paths that don't (Resolve-Path normally throws an exception if
+        the path doesn't exist.)
+
+        The Git repo for this module can be found here: https://aka.ms/StoreBroker
+
+    .EXAMPLE
+        Resolve-UnverifiedPath -Path 'c:\windows\notepad.exe'
+
+        Returns the string 'c:\windows\notepad.exe'.
+
+    .EXAMPLE
+        Resolve-UnverifiedPath -Path '..\notepad.exe'
+
+        Returns the string 'c:\windows\notepad.exe', assuming that it's executed from
+        within 'c:\windows\system32' or some other sub-directory.
+
+    .EXAMPLE
+        Resolve-UnverifiedPath -Path '..\foo.exe'
+
+        Returns the string 'c:\windows\foo.exe', assuming that it's executed from
+        within 'c:\windows\system32' or some other sub-directory, even though this
+        file doesn't exist.
+
+    .OUTPUTS
+        [string] - The fully resolved path 
+
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(
+            Position=0,
+            ValueFromPipeline)]
+        [string] $Path
+    )
+
+    $resolvedPath = Resolve-Path -Path $Path -ErrorVariable resolvePathError -ErrorAction SilentlyContinue
+
+    if ($null -eq $resolvedPath)
+    {
+        return $resolvePathError[0].TargetObject
+    }
+    else
+    {
+        return $resolvedPath.Path
+    }
+}

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.4.3'
+    ModuleVersion = '1.4.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -697,6 +697,9 @@ function Set-SubmissionPackage
         [switch] $NoStatus
     )
 
+    # Let's resolve this path to a full path so that it works with non-PowerShell commands (like the Azure module)
+    $PackagePath = Resolve-UnverifiedPath -Path $PackagePath
+
     # Telemetry-related
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::PackagePath = (Get-PiiSafeString -PlainText $PackagePath) }
@@ -859,6 +862,9 @@ function Get-SubmissionPackage
         [switch] $NoStatus
     )
 
+    # Let's resolve this path to a full path so that it works with non-PowerShell commands (like the Azure module)
+    $PackagePath = Resolve-UnverifiedPath -Path $PackagePath
+
     # Telemetry-related
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::PackagePath = (Get-PiiSafeString -PlainText $PackagePath) }
@@ -886,7 +892,7 @@ function Get-SubmissionPackage
         }
         else
         {
-            $jobName = "Get-ApplicationSubmissionPackage-" + (Get-Date).ToFileTime().ToString()
+            $jobName = "Get-SubmissionPackage-" + (Get-Date).ToFileTime().ToString()
 
             if ($PSCmdlet.ShouldProcess($jobName, "Start-Job"))
             {
@@ -923,7 +929,7 @@ function Get-SubmissionPackage
         # Record the telemetry for this event.
         $stopwatch.Stop()
         $telemetryMetrics = @{ [StoreBrokerTelemetryMetric]::Duration = $stopwatch.Elapsed.TotalSeconds }
-        Set-TelemetryEvent -EventName Get-ApplicationSubmissionPackage -Properties $telemetryProperties -Metrics $telemetryMetrics 
+        Set-TelemetryEvent -EventName Get-SubmissionPackage -Properties $telemetryProperties -Metrics $telemetryMetrics 
     }
     catch [System.Management.Automation.RuntimeException]
     {
@@ -941,7 +947,7 @@ function Get-SubmissionPackage
             }
         }
 
-        Set-TelemetryException -Exception $_.Exception -ErrorBucket Get-ApplicationSubmissionPackage -Properties $telemetryProperties 
+        Set-TelemetryException -Exception $_.Exception -ErrorBucket Get-SubmissionPackage -Properties $telemetryProperties 
         Write-Log $($output -join [Environment]::NewLine) -Level Error 
         throw "Halt Execution"
     }
@@ -956,7 +962,7 @@ function Get-SubmissionPackage
         $output += "StatusDescription: $($_.Exception.Response.StatusDescription)"
         $output += "$($_.ErrorDetails)"
         
-        Set-TelemetryException -Exception $_.Exception -ErrorBucket Get-ApplicationSubmissionPackage -Properties $telemetryProperties 
+        Set-TelemetryException -Exception $_.Exception -ErrorBucket Get-SubmissionPackage -Properties $telemetryProperties 
         Write-Log $($output -join [Environment]::NewLine) -Level Error 
         throw "Halt Execution"
     }


### PR DESCRIPTION
PowerShell-native commands can work just fine with relative file
paths, however when interacting with other code, it's necessary
to use `Convert-Path` to first resolve the path to its full path.

`Set-SubmissionPackage` / `Get-SubmissionPackage` use the Azure
assemblies for uploading/downloading packages, and thus need to
have `$PackagePath` resolved to its full path in the even that
users are providing relative paths to the command.

Additionally, fixing the telemetry bucket name used
for `Get-SubmissionPackage`.