### PR TITLE
Updating pricing tier documentation reference

### DIFF
--- a/StoreBroker/AppConfigTemplate.json
+++ b/StoreBroker/AppConfigTemplate.json
@@ -199,7 +199,7 @@
             //
             // Set the price of the app.
             // The value provided should be a "Tier" and NOT an actual price
-            // For a mapping of "Tiers" to prices, see TODO: add reference
+            // For a mapping of "Tiers" to prices, refer to https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-add-on-submissions#price-tiers
             // Can also be "Free" or "NotAvailable"
 
             "priceId": "NotAvailable",

--- a/StoreBroker/IapConfigTemplate.json
+++ b/StoreBroker/IapConfigTemplate.json
@@ -215,7 +215,7 @@
             //
             // Set the price of the add-on.
             // The value provided should be a "Tier" and NOT an actual price
-            // For a mapping of "Tiers" to prices, see TODO: add reference
+            // For a mapping of "Tiers" to prices, refer to https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-add-on-submissions#price-tiers
             // Can also be "Free" or "NotAvailable"
 
             "priceId": "NotAvailable",

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.4.4'
+    ModuleVersion = '1.4.5'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The config files that are generated document what the pricing
json is supposed to look like, but there's a TODO in place for
determining how a price maps to a "tier" enum value.

Adding in the reference to the API documentation that explains
how to get that Tier information.