### PR TITLE
Add $global:SBWebRequestTimeoutSec option

### DIFF
--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -7,6 +7,7 @@
     *   [Help Documentation](#help-documentation)
     *   [Formatting Results](#formatting-results)
     *   [Logging](#logging)
+    *   [Additional Configuration](#additional-configuration)
     *   [Common Switches](#common-switches)
     *   [Accessing the Portal](#accessing-the-portal)
 *   [Creating Your Application Payload](#creating-your-application-payload)
@@ -78,6 +79,16 @@ when the module is loaded.
 > `$profile`. From a **PowerShell console** run `notepad $profile`. If Notepad informs you that
 > the file doesn't exist, let Notepad create the profile for you. Then, just add your updated
 > assignments to it.
+
+### Additional Configuration
+
+There are some additional optional configurations that can be made with StoreBroker if the
+situation requires it.  Most users will likely never need to touch these.  The pre-existing
+values of these variables will be honored if they already exist, otherwise they will be created
+(with defaults) when the module is loaded.
+
+ **`$global:SBWebRequestTimeoutSec`** - [int] Number of seconds to use for the timeout of the
+   internal `Invoke-WebRequest` call. Defaults to `0` (indefinite)
 
 ### Common Switches
 

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -76,6 +76,11 @@ function Initialize-HelpersGlobalVariables
     {
         $global:SBUseUTC = $false
     }
+
+    if (!(Get-Variable -Name SBWebRequestTimeoutSec -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    {
+        $global:SBWebRequestTimeoutSec = 0
+    }
 }
 
 # We need to be sure to call this explicitly so that the global variables get initialized.

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.4.7'
+    ModuleVersion = '1.5.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1557,7 +1557,7 @@ function Invoke-SBRestMethod
     try
     {
         Write-Log $Description -Level Verbose
-        Write-Log "Accessing [$Method] $url" -Level Verbose
+        Write-Log "Accessing [$Method] $url [Timeout = $global:SBWebRequestTimeoutSec]" -Level Verbose
 
         if ($NoStatus)
         {
@@ -1569,6 +1569,7 @@ function Invoke-SBRestMethod
                 $params.Add("Headers", $headers)
                 $params.Add("UseDefaultCredentials", $true)
                 $params.Add("UseBasicParsing", $true)
+                $params.Add("TimeoutSec", $global:SBWebRequestTimeoutSec)
                 
                 if ($Method -in ('post', 'put') -and (-not [String]::IsNullOrEmpty($Body)))
                 {
@@ -1590,7 +1591,7 @@ function Invoke-SBRestMethod
             if ($PSCmdlet.ShouldProcess($jobName, "Start-Job"))
             {
                 [scriptblock]$scriptBlock = {
-                    param($Url, $method, $Headers, $Body, $HeaderName)
+                    param($Url, $method, $Headers, $Body, $HeaderName, $TimeoutSec)
 
                     # Because this is running in a different PowerShell process, we need to
                     # redefine this script variable (for use within the exception)
@@ -1602,6 +1603,7 @@ function Invoke-SBRestMethod
                     $params.Add("Headers", $Headers)
                     $params.Add("UseDefaultCredentials", $true)
                     $params.Add("UseBasicParsing", $true)
+                    $params.Add("TimeoutSec", $TimeoutSec)
                 
                     if ($Method -in ('post', 'put') -and (-not [String]::IsNullOrEmpty($Body)))
                     {
@@ -1635,7 +1637,7 @@ function Invoke-SBRestMethod
                     }
                 }
 
-                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $script:headerMSCorrelationId)
+                $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $script:headerMSCorrelationId, $global:SBWebRequestTimeoutSec)
 
                 if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                 {


### PR DESCRIPTION
Some users are experiencing timeouts caused internally by
`Invoke-WebRequest`.  The default value for `Invoke-WebRequest`'s
`TimeoutSec` parameter is `0` (indefinite timeout), so this should
never happen.

To help gauge if there's a bug with PowerShell or not, we're adding
in this optional configuration that allows users to globally define
the timeout (in seconds) that should be provided directly to
`Invoke-WebRequest`.