### PR TITLE
Update Invoke-WebRequest to use -UseBasicParsing

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.4.5'
+    ModuleVersion = '1.4.6'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1568,6 +1568,7 @@ function Invoke-SBRestMethod
                 $params.Add("Method", $Method)
                 $params.Add("Headers", $headers)
                 $params.Add("UseDefaultCredentials", $true)
+                $params.Add("UseBasicParsing", $true)
                 
                 if ($Method -in ('post', 'put') -and (-not [String]::IsNullOrEmpty($Body)))
                 {
@@ -1600,6 +1601,7 @@ function Invoke-SBRestMethod
                     $params.Add("Method", $Method)
                     $params.Add("Headers", $Headers)
                     $params.Add("UseDefaultCredentials", $true)
+                    $params.Add("UseBasicParsing", $true)
                 
                     if ($Method -in ('post', 'put') -and (-not [String]::IsNullOrEmpty($Body)))
                     {


### PR DESCRIPTION
StoreBroker is being used on some systems where the
Internet Explorer engine is not available, or Internet
Explorer's first-launch configuration is not complete.

In those scenarios, it's necessary to specify -UseBasicParsing
with Invoke-WebRequest to indicate that it should use the response
object for HTML content without Document Object Model (DOM) parsing.