### PR TITLE
Fix behavior of Resolve-UnverifiedPath

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -810,6 +810,6 @@ function Resolve-UnverifiedPath
     }
     else
     {
-        return $resolvedPath.Path
+        return $resolvedPath.ProviderPath
     }
 }

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.4.6'
+    ModuleVersion = '1.4.7'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
For verified paths, we should return `ProviderPath` as opposed to
`Path` in order to have consistent results in all PowerShell
environments.