### PR TITLE
Additional package metadata

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.5.1'
+    ModuleVersion = '1.6.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1939,3 +1939,52 @@ function Invoke-SBRestMethodMultipleResult
         throw
     }
 }
+
+function Remove-UnofficialSubmissionProperties
+{
+<#
+    .SYNOPSIS
+        Removes additional properties from the submission object that aren't part of the submission API.
+        
+    .DESCRIPTION
+        Removes additional properties from the submission object that aren't part of the submission API.
+        
+        The properties don't actually need to exist on the submission object before calling this function.
+        
+    .PARAMETER Submission
+        A PSCustomObject representing the submission.
+        
+    .EXAMPLE
+        Remove-UnofficialSubmissionProperties -Submission (Get-ApplicationSubmission -AppId $appId -SubmissionId $submissionId)
+        
+    .NOTES
+        Valid properties for applicationPackages are taken from https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#application-package-object
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Submission
+    )
+    
+    # These properties aren't really valid in submission content.
+    # We can safely call this method without validating that the property actually exists.
+    $Submission.PSObject.Properties.Remove("appId")
+    $Submission.PSObject.Properties.Remove("iapId")
+    
+    foreach ($package in $Submission.applicationPackages)
+    {
+        @(
+            "version",
+            "architecture",
+            "targetPlatform",
+            "languages",
+            "capabilities",
+            "targetDeviceFamilies",
+            "targetDeviceFamiliesEx",
+            "minOSVersion",
+            "innerPackages"
+        ) | ForEach-Object {
+            $package.PSObject.Properties.Remove($_)
+        }
+    }
+}

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1099,9 +1099,7 @@ function Update-ApplicationSubmission
         }
     }
 
-    # Now, we'll remove the appId property since it's not really valid in submission content.
-    # We can safely call this method without validating that the property actually exists.
-    $submission.PSObject.Properties.Remove('appId')
+    Remove-UnofficialSubmissionProperties -Submission $submission
 
     # Identify potentially incorrect usage of this method by checking to see if no modification
     # switch was provided by the user

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1304,9 +1304,7 @@ function Update-ApplicationFlightSubmission
         }
     }
 
-    # Now, we'll remove the appId property since it's not really valid in submission content.
-    # We can safely call this method without validating that the property actually exists.
-    $submission.PSObject.Properties.Remove('appId')
+    Remove-UnofficialSubmissionProperties -Submission $submission
 
     # Identify potentially incorrect usage of this method by checking to see if no modification
     # switch was provided by the user

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -1332,9 +1332,7 @@ function Update-InAppProductSubmission
         }
     }
 
-    # Now, we'll remove the iapId property since it's not really valid in submission content.
-    # We can safely call this method without validating that the property actually exists.
-    $submission.PSObject.Properties.Remove('iapId')
+    Remove-UnofficialSubmissionProperties -Submission $submission
 
     # Identify potentially incorrect usage of this method by checking to see if no modification
     # switch was provided by the user


### PR DESCRIPTION
This change adds additional package metadata to the output .JSON from the New-SubmissionPackage command.

New metadata is added to each object in 'applicationPackages'.  The new fields are:
-version
-architecture
-targetPlatform
-languages
-capabilities
-targetDeviceFamilies
-targetDeviceFamiliesEx
-minOSVersion
-innerPackages

These properties are removed during a submission because they are re-calculated by the Store.

Resolves #16 