### PR TITLE
Fix default NuGet download path for interactive console users

### DIFF
--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -99,7 +99,7 @@ function Get-NugetPackage
         {
             if (-not [System.String]::IsNullOrEmpty($Version))
             {
-                & $nugetPath install $PackageName -o $TargetPath -version $Version  -source nuget.org -NonInteractive | Out-Null
+                & $nugetPath install $PackageName -o $TargetPath -version $Version -source nuget.org -NonInteractive | Out-Null
             }
             else
             {
@@ -118,11 +118,11 @@ function Get-NugetPackage
 
                 if (-not [System.String]::IsNullOrEmpty($Version))
                 {
-                    & $NugetPath install $PackageName -o $TargetPath -version $Version
+                    & $NugetPath install $PackageName -o $TargetPath -version $Version -source nuget.org 
                 }
                 else
                 {
-                    & $NugetPath install $PackageName -o $TargetPath 
+                    & $NugetPath install $PackageName -o $TargetPath -source nuget.org 
                 }
             }
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.5.0'
+    ModuleVersion = '1.5.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
We need to explicitly specify the NuGet source feed for nuget packages,
otherwise we risk donload failure on user machines where they've changed
the default feed configuration.

This fix was done a while ago for users of `-NoStatus`, but it was
accidentally not done for default users.  This corrects that oversight.