### PR TITLE
Support packaging .appxupload files containing a single .appxbundle.

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.6.0'
+    ModuleVersion = '1.6.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
StoreBroker used to support this scenario but dropped support after documentation indicated an .appxupload should only ever contain a single .appx file, see https://docs.microsoft.com/en-us/windows/uwp/packaging/create-app-package-with-makeappx-tool.

Regardless of the documentation, there are StoreBroker users who have been uploading with this type of file and the Store seems to support it.  This change adds back support for this type of file.