### PR TITLE
Add Open-Store

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.6.1'
+    ModuleVersion = '1.7.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'
@@ -71,6 +71,7 @@
         'New-StoreBrokerInAppProductConfigFile',
         'New-SubmissionPackage',
         'Open-DevPortal',
+        'Open-Store',
         'Remove-ApplicationFlight',
         'Remove-ApplicationFlightSubmission',
         'Remove-ApplicationSubmission',

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1347,6 +1347,62 @@ function Open-DevPortal
     }
 }
 
+function Open-Store()
+{
+<#
+.SYNOPSIS
+    Opens the specified app in the Windows Store.
+
+.DESCRIPTION
+    Opens the specified app in the Windows Store.
+
+    The Git repo for this module can be found here: https://aka.ms/StoreBroker
+
+.PARAMETER AppId
+    The ID of the app that should be opened in the Store.
+
+.PARAMETER Web
+    If specified, opens the Web Store instead of the native Windows Store App.
+
+.EXAMPLE
+    Open-Store -AppId 0ABCDEF12345
+
+    Opens the Windows Store app and navigates to the specified application.
+
+.EXAMPLE
+    Open-Store -AppId 0ABCDEF12345 -Web
+
+    Opens the user's browser to the specified app's Windows Store page.
+#>
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $AppId,
+
+        [switch] $Web
+    )
+
+    # Telemetry-related
+    $telemetryProperties = @{
+        [StoreBrokerTelemetryProperty]::AppId = $AppId
+        [StoreBrokerTelemetryProperty]::Web = $Web
+    }
+
+    Set-TelemetryEvent -EventName Open-Store -Properties $telemetryProperties
+
+    $webUri = "https://www.microsoft.com/store/apps/$AppId"
+    $storeAppUri = "ms-windows-store://pdp/?productid=$AppId"
+
+    $uri = $storeAppUri
+    if ($Web)
+    {
+        $uri = $webUri
+    }
+
+    Write-Log "Launching $uri" -Level Verbose
+    Start-Process -FilePath $uri
+}
+
 function Get-ProperEnumCasing
 {
 <#

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -39,6 +39,7 @@ Add-Type -TypeDefinition @"
       UpdatePublishModeAndVisibility,
       UriFragment,
       UserName,
+      Web,
    }
 "@
 


### PR DESCRIPTION
We already had an `Open-DevPortal` function which opened the specified
app in the Developer Portal.  This adds a similar function for opening
the specified app in either the Windows Store web site or in the native
Windows App Store.