### PR TITLE
Add support for faster uploads using Azure Storage Data Movement Library

### DIFF
--- a/Documentation/SETUP.md
+++ b/Documentation/SETUP.md
@@ -161,7 +161,8 @@ StoreBroker has a dependency on dll's from the following NuGet packages:
 
 **For uploading/downloading packages**
 
-    WindowsAzure.Storage v6.0.0: Microsoft.WindowsAzure.Storage.dll
+    WindowsAzure.Storage v8.1.1: Microsoft.WindowsAzure.Storage.dll
+    Microsoft.Azure.Storage.DataMovement v0.5.1: Microsoft.WindowsAzure.Storage.DataMovement.dll
 
 **For [Telemetry](USAGE.md#telemetry)**
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.7.1'
+    ModuleVersion = '1.8.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
This update provides about a 10-15x increase in upload performance by
switching from using the standard Windows Azure Storage API's for
uploading/downloading, to the Azure Storage Data Movement API set,
which is optimized for faster uploads.

That change by itself cut the transfer speeds in half.  This then applies
two other suggested best practices for increasing transfer bandwidth:

  * Increasing the `DefaultConnectionLimit`
      > By default, the .Net HTTP connection limit is 2. This implies that
      > only two concurrent connections can be maintained. It prevents more
      > parallel connections accessing Azure blob storage from your application.

  * Turning off `Expect100Continue`
      > When the property "Expect100Continue" is set to true, client requests
      > that use the PUT and POST methods will add an Expect: 100-continue
      > header to the request and it will expect to receive a 100-Continue
      > response from the server to indicate that the client should send the
      > data to be posted. This mechanism allows clients to avoid sending large
      > amounts of data over the network when the server, based on the request
      > headers, intends to reject the request.
      >
      > However, once the entire payload is received on the server end, other
      > errors may still occur. And if Windows Azure clients have tested the
      > client well enough to ensure that it is not sending any bad requests,
      > clients could turn off 100-continue so that the entire request is sent
      > in one roundtrip. This is especially true when clients send small size
      > storage objects.


Some validation tests were performed with sample sizes of 10:

**Upload of a one-gigabye file**
_Current method_
  * Avg: 205 seconds
  * Median: 196 seconds

_Using DataMovement alone_
  * Avg: 98.5 seconds
  * Median: 100 seconds

_Using DataMovement with best practices_
  * Avg: 18 seconds
  * Median: 18 seconds

**Upload of a six-gigabye file**
_Current method_
  * Avg: 1367 seconds
  * Median: 1413 seconds
_*Note: This took so much longer that I only tried two samples._

_Using DataMovement with best practices_
  * Avg: 90.6 seconds
  * Median: 91.5 seconds

Because these results were so surprising, I then downloaded the file after uploading it,
and used `fc.exe /b <orig file> <downloaded file>` to validate the file was indeed uploaded
successfully and completely.

Resolves Issue #47: Add support for faster uploads using Azure Storage Data Movement Library