### PR TITLE
Store changed max length of keywords to 30 characters

### DIFF
--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -350,7 +350,7 @@ function Add-Keywords
     }
 
     # Add comment to parent
-    $maxChars = 45
+    $maxChars = 30
     $maxChildren = 7
     $paramSet = @{
         "Element" = $elementNode;
@@ -360,7 +360,7 @@ function Add-Keywords
     Add-ToElement @paramSet
 
     # Add comment to children
-    $maxChars = 45
+    $maxChars = 30
     $paramSet = @{
         "Parent" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f "keyword") + "{0}" };

--- a/PDP/ProductDescription.xml
+++ b/PDP/ProductDescription.xml
@@ -11,12 +11,12 @@
   </AppStoreName>
 
   <Keywords>
-    <!-- Valid length: 45 character limit, up to 7 -->
-    <Keyword _locID="App_keyword1"><!-- _locComment_text="{MaxLength=45} App keyword 1" -->Video edit</Keyword>
-    <Keyword _locID="App_keyword2"><!-- _locComment_text="{MaxLength=45} App keyword 2" -->Captions</Keyword>
-    <Keyword _locID="App_keyword3"><!-- _locComment_text="{MaxLength=45} App keyword 3" -->Trim</Keyword>
-    <Keyword _locID="App_keyword4"><!-- _locComment_text="{MaxLength=45} App keyword 4" -->Soundtrack</Keyword>
-    <Keyword _locID="App_keyword5"><!-- _locComment_text="{MaxLength=45} App keyword 5" -->Video sharing</Keyword>
+    <!-- Valid length: 30 character limit, up to 7 -->
+    <Keyword _locID="App_keyword1"><!-- _locComment_text="{MaxLength=30} App keyword 1" -->Video edit</Keyword>
+    <Keyword _locID="App_keyword2"><!-- _locComment_text="{MaxLength=30} App keyword 2" -->Captions</Keyword>
+    <Keyword _locID="App_keyword3"><!-- _locComment_text="{MaxLength=30} App keyword 3" -->Trim</Keyword>
+    <Keyword _locID="App_keyword4"><!-- _locComment_text="{MaxLength=30} App keyword 4" -->Soundtrack</Keyword>
+    <Keyword _locID="App_keyword5"><!-- _locComment_text="{MaxLength=30} App keyword 5" -->Video sharing</Keyword>
   </Keywords>
    <!-- Valid length: 10000 character limit -->
    <Description _locID="App_Description"><!-- _locComment_text="{MaxLength=10000} App Description" --> 

--- a/PDP/ProductDescription.xsd
+++ b/PDP/ProductDescription.xsd
@@ -18,7 +18,7 @@
 
   <xs:simpleType name="KeywordString">
     <xs:restriction base="xs:normalizedString">
-      <xs:pattern value="\s*(\S(\r|\n|.){0,44}\s*)?"/>
+      <xs:pattern value="\s*(\S(\r|\n|.){0,29}\s*)?"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Updating the PDP XSD, sample PDP XML, and `Convert-FromExistingSubmission` to use the new max-length of keywords (30) instead of the old max length (45), per the [Store documentation](https://docs.microsoft.com/en-us/windows/uwp/publish/create-app-store-listings#search-terms)