### PR TITLE
Increment version for NuGet packaging

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.8.1'
+    ModuleVersion = '1.8.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
While there were no code changes to the core module for StoreBroker
with PR #51, there was a change to the XSD that is included in the
NuGet package.  Since the NuGet package version has to increase with
an update, and since we've tied it to the version number of the
module, this version number needs to be incremented.