### PR TITLE
SupportContactInfo is now a required field for app submissions

### DIFF
--- a/PDP/ProductDescription.xsd
+++ b/PDP/ProductDescription.xsd
@@ -112,7 +112,7 @@
 
   <xs:simpleType name="SupportContactInfoString">
     <xs:restriction base="xs:string">
-      <xs:pattern value="\s*(\S(\r|\n|.){0,2047}\s*)?"/>
+      <xs:pattern value="\s*(\S(\r|\n|.){1,2047}\s*)?"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -348,11 +348,11 @@
           </xs:complexType>
         </xs:element>
         
-        <xs:element name="SupportContactInfo" minOccurs="0">
+        <xs:element name="SupportContactInfo" minOccurs="1">
           <xs:complexType>
             <xs:annotation>
               <xs:documentation>
-                Optional, may not exceed 2048 characters
+                Required, may not exceed 2048 characters
               </xs:documentation>
             </xs:annotation>
             <xs:simpleContent>

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.8.3'
+    ModuleVersion = '1.8.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The store recently made the Support Contact info a required field for the App Store listing page.

Updating the XSD to make the value required and non-empty.  Updating the version number for the
module as that will be necessary when releasing an updated NuGet package with this change.