### PR TITLE
Improve performance when creating output zip payload

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.8.4'
+    ModuleVersion = '1.9.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Improve performance when creating output zip payload.

We found there was a significant delay when creating the final zip output if the output path existed on a remote machine.  We will change to compress the payload on the local machine before moving the output to the final destination.

In addition, added extra logging around commands that interact with the filesystem, so that future debugging will have an easier time determining the duration of the command.

Bumped the module version to 1.9.0