### PR TITLE
Process ID (PID) of StoreBroker PowerShell session now captured in log

### DIFF
--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -72,6 +72,18 @@ when the module is loaded.
     When `$true`, times are logged using UTC (and those timestamps will end with a Z per the
     [W3C standard](http://www.w3.org/TR/NOTE-datetime))
 
+ **`$global:SBShouldLogPid`** [bool] Defaults to `$false`. If `$true`, the
+ Process ID (`$global:PID`) of the current PowerShell process will be added
+ to every log entry.  This can be helpful if you have situations where
+ multiple instances of StoreBroker run concurrently and you want to
+ more easily isolate the log entries for one process.  An alternative
+ solution would be to use `$global:SBLogPath` to specify a different
+ log file for each StoreBroker process. An easy way to view the filtered
+ entries for a session is (replacing `PID` with the PID that you are interested in):
+
+    Get-Content -Path $global:SBLogPath -Encoding UTF8 | Where { $_ -like '*[[]PID[]]*' }
+
+
 > **PowerShell Tip**
 >
 > If you wish to always use a different value for these, set the new values in your PowerShell

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -52,6 +52,11 @@ function Initialize-HelpersGlobalVariables
         }
     }
 
+    if (!(Get-Variable -Name SBShouldLogPid -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    {
+        $global:SBShouldLogPid = $false
+    }
+
     if (!(Get-Variable -Name SBNotifyDefaultDomain -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
     {
         $global:SBNotifyDefaultDomain = $null
@@ -483,18 +488,33 @@ function Write-Log
             $dateString = $date.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ssZ")
         }
 
-        $logFileMessage = '{0}{1} : {2} : {3} : {4}' -f
-            (" " * $Indent),
-            $dateString,
-            $env:username,
-            $Level.ToUpper(),
-            $Message
-            
         $consoleMessage = '{0}{1} : {2} : {3}' -f
             (" " * $Indent),
             $dateString,
             $env:username,
             $Message
+
+        if ($global:SBShouldLogPid)
+        {
+            $MaxPidDigits = 10 # This is an estimate (see https://stackoverflow.com/questions/17868218/what-is-the-maximum-process-id-on-windows)
+            $pidColumnLength = $MaxPidDigits + "[]".Length
+            $logFileMessage = "{0}{1} : {2, -$pidColumnLength} : {3} : {4} : {5}" -f
+                (" " * $Indent),
+                $dateString,
+                "[$global:PID]",
+                $env:username,
+                $Level.ToUpper(),
+                $Message
+        }
+        else
+        {
+            $logFileMessage = '{0}{1} : {2} : {3} : {4}' -f
+                (" " * $Indent),
+                $dateString,
+                $env:username,
+                $Level.ToUpper(),
+                $Message
+        }
 
         switch ($Level)
         {

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.9.0'
+    ModuleVersion = '1.10.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Some users have scenarios where they are running concurrent instances of StoreBroker,
and for reasons specific to their situation, have chosen to have the logs always go
to the same log file (instead of using `$global:SBLogPath` to set a different
log file for each session.

In these scenarios, it can be challenging to read the logs and understand what exactly
was happening since there are entries from multiple commands intermixed.  This
change introduces adding the `$pid` of the StoreBroker PowerShell session to every
log entry so that on post-mortem analysis, it would be easy to filter to just the
logs for the specific `$pid`.

For more info on `$pid`, [see here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1&viewFallbackFrom=powershell-Microsoft.PowerShell.Core#pid)