### PR TITLE
Clarify how to get AppId ; allow empty strings to be logged

### DIFF
--- a/Documentation/SETUP.md
+++ b/Documentation/SETUP.md
@@ -355,10 +355,23 @@ call:
 
 The next steps require you to know the AppId for the App you are trying to use StoreBroker with.
 
-Run the following and get the `ID` that is shown there (it looks like this: `0ABCDEF12345`).
+If you have easy access to the Dev Portal, you can get it directly from there by:
+  1. Log in to the [Dev Portal](https://developer.microsoft.com/en-us/dashboard/apps/overview)
+  2. Select the app
+  3. Click on **App Management**
+  4. Click on **App Identity**
+  5. Look towards the bottom and grab the `Store ID` that is displayed.  This is your `AppId`.
+
+Alternatively, you can find this value directly with StoreBroker by running the following and
+getting the `id` that is shown there (it looks like this: `0ABCDEF12345`).
 That's your `AppId` (replace `<appName>` with all or part your app's name to limit the results):
 
     Get-Applications -GetAll | Where-Object primaryName -like "*<appName>*" | Format-Application
+
+If you run into issues with this command, it's possible that you're having trouble with your search
+with `Where-Object`.  Instead, just try running this:
+
+    Get-Applications -GetAll | Format-Applications
 
 > The Windows Store Submission API does not allow for the *creation* of new apps.
 > To use StoreBroker, you must have already created **and published** an app submission via the

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -467,7 +467,8 @@ function Write-Log
         [Parameter(
             Mandatory,
             ValueFromPipeline)]
-        [ValidateNotNullOrEmpty()]
+        [AllowEmptyString()]
+        [AllowNull()]
         [string] $Message,
 
         [ValidateSet('Error', 'Warning', 'Info', 'Verbose', 'Debug')]

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.10.0'
+    ModuleVersion = '1.10.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
@martinsuchan reported that SETUP.md was a bit confusing
regarding how to get the `AppId`.  I've updated the section
to indicate how to get it from the DevPortal directly, as well
as how to get it with a simplified piping command (without the
`Where-Object`).

Additionally, this removes the restriction on `Write-Log` that
message must be non-null/empty.  Requiring a non-null/empty
string resulted in error messages that focused on bad input
to `Write-Log`, which should really be a black-box command
to users of StoreBroker.  Instead, we'll let empty strings
be logged, which should cause users to look into the command
that they were executing instead.  This is more in-line with
how PowerShell default commands handle situations where there
is no result.

Resolves #63 - Confusing "Getting Your AppId" section in SETUP