### PR TITLE
Support relative paths that don't begin with '.'

### DIFF
--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -601,5 +601,10 @@ function Main
 }
 
 
+
+
+# Script body
+$OutPath = Resolve-UnverifiedPath -Path $OutPath
+
 # function Main invocation
 Main

--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -965,13 +965,14 @@ function Ensure-PdpFilePath
         [string] $FileName
     )
 
-    $dropFolder = Join-Path $PdpRootPath $Lang
+    $dropFolder = Join-Path -Path $PdpRootPath -ChildPath $Lang
+
     if (-not (Test-Path -PathType Container -Path $dropFolder))
     {
         New-Item -Force -ItemType Directory -Path $dropFolder | Out-Null
     }
 
-    return (Join-Path $dropFolder $FileName)
+    return (Join-Path -Path $dropFolder -ChildPath $FileName)
 }
 
 function Show-ImageFileNames
@@ -1111,6 +1112,11 @@ function Main
     Show-ImageFileNames -LangImageNames $langImageNames -Release $Release
 }
 
+
+
+
+# Script body
+$OutPath = Resolve-UnverifiedPath -Path $OutPath
 
 # function Main invocation
 Main

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -839,3 +839,44 @@ function Resolve-UnverifiedPath
         return $resolvedPath.ProviderPath
     }
 }
+
+function Ensure-Directory
+{
+<#
+    .SYNOPSIS
+        A utility function for ensuring a given directory exists.
+
+    .DESCRIPTION
+        A utility function for ensuring a given directory exists.
+
+        If the directory does not already exist, it will be created.
+
+    .PARAMETER Path
+        A full or relative path to the directory that should exist when the function exits.
+
+    .NOTES
+        Uses the Resolve-UnverifiedPath function to resolve relative paths.
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    try
+    {
+        $Path = Resolve-UnverifiedPath -Path $Path
+
+        if (-not (Test-Path -PathType Container -Path $Path))
+        {
+            Write-Log "Creating directory: [$Path]" -Level Verbose
+            New-Item -ItemType Directory -Path $Path | Out-Null
+        }
+    }
+    catch
+    {
+        Write-Log "Could not ensure directory: [$Path]" -Level Error
+
+        throw 
+    }
+}

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.10.1'
+    ModuleVersion = '1.11.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Support relative paths that don't begin with '.' to denote the current working directory.

For example, an -OutPath of "SomeFolder" should represent a sub-folder of the current working directory. While PowerShell can handle path fragments of this type, interacting with .NET methods, such as XmlDocument.Save() can cause the file to be saved to an unintended directory.

The fix is to use Resolve-UnverifiedPath in-order to resolve path fragments like this to a full path.

Additonally, adds a new function Ensure-Directory, to ensure a directory is created/exists.

#64 
