### PR TITLE
Fix Additional Metadata for App Submission packages

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.0'
+    ModuleVersion = '1.11.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
In v1.6.0, we added [additional metadata](https://github.com/Microsoft/StoreBroker/commit/391954b962756b1f222d2e4e45aa6d203b805db4)
to the generated JSON file for application submission packages.

Unfortunately, we operated under the incorrect assumption that there could
only ever be a single Min OS version specified for a package.  In fact, a
single package can target multiple device families, and each device family
can target a different minimum OS version.  The only requirement around
Min OS Versions for packages is that if there is an appxbundle, all appx
files within that bundle must target the same minimum os version for a given
device family.

Given this change in our understanding of how things work, we're modifying
the additional metadata that we were generating.  `targetDeviceFamiliesEx`
will now contain the same version that `targetDeviceFamilies` contains
(both the device family name and the minimum os version), but they will
be split into named properties.  Additionally, the `minOsVersion` property
has been removed since the data it has is less relevant when it's not paired
with the specific deviceFamily that it's related to.

Finally, we are now adding a new `sbschema` property (which is simply an
integer) which we'll be increasing from now on whenever we make changes
to non-standard properties in our output JSON in the event that StoreBroker
(or other applications leveraging the StoreBroker payload) are depending on
those values and need to know how to behave if they're not there.

USAGE.md has been updated to now track (and explain) the
[schema version changes](https://github.com/Microsoft/StoreBroker/blob/master/Documentation/USAGE.md#schema-versions)
(for botn App submissions and for IAP submissions).