### PR TITLE
Capture activityId to log with 500 / Internal Server Error failures

### DIFF
--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -498,6 +498,8 @@ function Add-ScreenshotCaptions
 
             if ($null -eq $captionImageMap[$description])
             {
+                # Note: PSScriptAnalyzer falsely flags this next line as PSUseDeclaredVarsMoreThanAssignment due to:
+                # https://github.com/PowerShell/PSScriptAnalyzer/issues/699
                 $captionImageMap[$description] = @{}
             }
                         

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -628,6 +628,9 @@ function Test-Xml
     {
         $msg = @()
         $msg += "Provided XML file:`n`t$($XmlFile)`nis not valid under its referenced schema:`n`t$($XsdFile)"
+
+        # Note: PSScriptAnalyzer falsely flags this next line as PSUseDeclaredVarsMoreThanAssignment due to:
+        # https://github.com/PowerShell/PSScriptAnalyzer/issues/699
         $script:validationErrors | ForEach-Object { $msg += $_ }
         $msg = $msg -join [Environment]::NewLine
 
@@ -1313,6 +1316,9 @@ function New-ApplicationMetadataTable
         Hashtable    A hashtable with $null values and keys for the properties mentioned
                      in the description.
 #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "", Justification="This doesn't change any system state...just creates a new object.")]
+    param()
+
     $table = @{}
     foreach ($property in $script:applicationMetadataProperties)
     {
@@ -1784,7 +1790,7 @@ function Get-FormattedFilename
         $architectureTag = ($Metadata.innerPackages.Keys | Sort-Object) -join '.'
 
         # Grab an arbitrary one and use that version.
-        $arch = $Metadata.innerPackages.Keys | Sort-Object | Select -First 1
+        $arch = $Metadata.innerPackages.Keys | Sort-Object | Select-Object -First 1
         $version = $Metadata.innerPackages.$arch.version
     }
 
@@ -2988,6 +2994,9 @@ function New-SubmissionPackage
 
         # Get the submission request object
         $resourceParams = $script:s_PDPRootPath, $script:s_Release, $script:s_PDPInclude, $script:s_PDPExclude, $script:s_LanguageExclude, $script:s_ImagesRootPath, $script:s_AppxPath, $script:s_DisableAutoPackageNameFormatting
+
+        # Note: PSScriptAnalyzer falsely flags this next line as PSUseDeclaredVarsMoreThanAssignment due to:
+        # https://github.com/PowerShell/PSScriptAnalyzer/issues/699
         $params = Get-Variable -Name $resourceParams -ErrorAction SilentlyContinue |
                   ForEach-Object { $m = @{} } { $m[$_.Name] = $_.Value } { $m } # foreach begin{} process{} end{}
 
@@ -3213,6 +3222,9 @@ function New-InAppProductSubmissionPackage
 
         # Get the submission request object
         $resourceParams = $script:s_PDPRootPath, $script:s_Release, $script:s_PDPInclude, $script:s_PDPExclude, $script:s_LanguageExclude, $script:s_ImagesRootPath
+
+        # Note: PSScriptAnalyzer falsely flags this next line as PSUseDeclaredVarsMoreThanAssignment due to:
+        # https://github.com/PowerShell/PSScriptAnalyzer/issues/699
         $params = Get-Variable -Name $resourceParams -ErrorAction SilentlyContinue |
                   ForEach-Object { $m = @{} } { $m[$_.Name] = $_.Value } { $m } # foreach begin{} process{} end{}
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.1'
+    ModuleVersion = '1.11.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -78,6 +78,9 @@ function Initialize-TelemetryGlobalVariables
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification="We use global variables sparingly and intentionally for module configuration, and employ a consistent naming convention.")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="We are initializing multiple variables.")]
+
+    # Note, this doesn't currently work due to https://github.com/PowerShell/PSScriptAnalyzer/issues/698
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignment", "", Justification = "These are global variables and so are used elsewhere.")]
     param()
 
     # We only set their values if they don't already have values defined.


### PR DESCRIPTION
According to the API team, in the cases where they return back a
500 / Internal Server Error, they will return back JSON content
in the body that contains an `activityId` property, which will be
a GUID.  This property will apparantly help the Submission API team
diagnose these server errors.  Therefore, we now try to log it.

A `WebException` contains an `HttpWebResponse` object which requires
stream access in order to read any embedded content.  So, I've added
a new helper method, `Get-HttpWebResponseContent` which we'll call
when accessing the `WebException` in order to get to the raw content.

If we are able to get content, deserialize it, _and_ there's an
`activityId`, we'll just log that `activityId`.  Otherwise, we'll
log the entire raw content (if it exists).

I'm also reverting a small part of change 6c8bed398, which attempted
to throw a custom error message containing the `MS-CorrelationId` in
a scenario where we would never actually have it.  In this case, I'm
simply reverting that code to just throw the original exception.

This also fixes any dangling PSScriptAnalyzer issues that _can_ be fixed,
and explicitly notes in the code the ones that can't be fixed
due to (referenced) PSScriptAnalyzer bugs.

Resolves #72: Add activityId to log when API call fails with 500 / Internal Server Error