### PR TITLE
Prevent checks for global vars from going into $global:Error

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -33,9 +33,10 @@ function Initialize-HelpersGlobalVariables
     param()
 
     # We only set their values if they don't already have values defined.
-    # We use -ErrorAction SilentlyContinue during the Get-Variable check since it throws an exception
+    # We use -ErrorAction Ignore during the Get-Variable check since it throws an exception
     # by default if the variable we're getting doesn't exist, and we just want the bool result.
-    if (!(Get-Variable -Name SBLoggingEnabled -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    # SilentlyContinue would cause it to go into the global $Error array, Ignore prevents that as well.
+    if (!(Get-Variable -Name SBLoggingEnabled -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBLoggingEnabled = $true
     }
@@ -43,7 +44,7 @@ function Initialize-HelpersGlobalVariables
     # $Home relies on existence of $env:HOMEDRIVE and $env:HOMEPATH which are only 
     # set when a user logged in interactively, which may not be the case for some build machines.
     # $env:USERPROFILE is the equivalent of $Home, and should always be available.
-    if (!(Get-Variable -Name SBLogPath -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBLogPath -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         if (-not [System.String]::IsNullOrEmpty($env:USERPROFILE))
         {
@@ -55,37 +56,37 @@ function Initialize-HelpersGlobalVariables
         }
     }
 
-    if (!(Get-Variable -Name SBShouldLogPid -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBShouldLogPid -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBShouldLogPid = $false
     }
 
-    if (!(Get-Variable -Name SBNotifyDefaultDomain -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBNotifyDefaultDomain -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBNotifyDefaultDomain = $null
     }
 
-    if (!(Get-Variable -Name SBNotifySmtpServer -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBNotifySmtpServer -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBNotifySmtpServer = $null
     }
 
-    if (!(Get-Variable -Name SBNotifyDefaultFrom -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBNotifyDefaultFrom -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBNotifyDefaultFrom = $env:username
     }
 
-    if (!(Get-Variable -Name SBNotifyCredential -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBNotifyCredential -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBNotifyCredential = [PSCredential]$null
     }
 
-    if (!(Get-Variable -Name SBUseUTC -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBUseUTC -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBUseUTC = $false
     }
 
-    if (!(Get-Variable -Name SBWebRequestTimeoutSec -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBWebRequestTimeoutSec -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBWebRequestTimeoutSec = 0
     }

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.3'
+    ModuleVersion = '1.11.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -83,9 +83,10 @@ function Initialize-StoreIngestionApiGlobalVariables
     param()
 
     # We only set their values if they don't already have values defined.
-    # We use -ErrorAction SilentlyContinue during the Get-Variable check since it throws an exception
+    # We use -ErrorAction Ignore during the Get-Variable check since it throws an exception
     # by default if the variable we're getting doesn't exist, and we just want the bool result.
-    if (!(Get-Variable -Name SBDefaultProxyEndpoint -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    # SilentlyContinue would cause it to go into the global $Error array, Ignore prevents that as well.
+    if (!(Get-Variable -Name SBDefaultProxyEndpoint -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBDefaultProxyEndpoint = $null
     }

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -84,19 +84,20 @@ function Initialize-TelemetryGlobalVariables
     param()
 
     # We only set their values if they don't already have values defined.
-    # We use -ErrorAction SilentlyContinue during the Get-Variable check since it throws an exception
+    # We use -ErrorAction Ignore during the Get-Variable check since it throws an exception
     # by default if the variable we're getting doesn't exist, and we just want the bool result.
-    if (!(Get-Variable -Name SBDisableTelemetry -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    # SilentlyContinue would cause it to go into the global $Error array, Ignore prevents that as well.
+    if (!(Get-Variable -Name SBDisableTelemetry -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBDisableTelemetry = $false
     }
 
-    if (!(Get-Variable -Name SBDisablePiiProtection -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBDisablePiiProtection -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBDisablePiiProtection = $false
     }
 
-    if (!(Get-Variable -Name SBApplicationInsightsKey -Scope Global -ValueOnly -ErrorAction SilentlyContinue))
+    if (!(Get-Variable -Name SBApplicationInsightsKey -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBApplicationInsightsKey = '4cdaa89f-33c5-46b4-ba5a-3befb5d8fe01'
     }


### PR DESCRIPTION
The check for the existence of a global variable will by default
cause an innocuous error to wind up in `$global:Error` if the
variable doesn't exist.

We had been using `-ErrorAction SilentlyContinue` so that the user
didn't see those errors, but they still ended up in `$global:Error`.
Changing to `-ErrorAction Ignore` prevents the user from seeing
the error, _and_ prevents the error from ending up in `$global:Error`.