### PR TITLE
Fix for trying to get the RawStream for errors.

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -922,8 +922,12 @@ function Get-HttpWebResponseContent
 
         if ($WebResponse.ContentLength -gt 0)
         {
-            $stream = $Response.GetResponseStream()
-            $encoding = [System.Text.Encoding]::GetEncoding($WebResponse.ContentEncoding)
+            $stream = $WebResponse.GetResponseStream()
+            $encoding = [System.Text.Encoding]::UTF8
+            if (-not [String]::IsNullOrWhiteSpace($WebResponse.ContentEncoding))
+            {
+                $encoding = [System.Text.Encoding]::GetEncoding($WebResponse.ContentEncoding)
+            }
 
             $streamReader = New-Object -TypeName System.IO.StreamReader -ArgumentList ($stream, $encoding)
             $content = $streamReader.ReadToEnd()

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.2'
+    ModuleVersion = '1.11.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1837,7 +1837,15 @@ function Invoke-SBRestMethod
                         $ex.StatusCode = $_.Exception.Response.StatusCode
                         $ex.StatusDescription = $_.Exception.Response.StatusDescription
                         $ex.InnerMessage = $_.ErrorDetails.Message
-                        $ex.RawContent = Get-HttpWebResponseContent -WebResponse $_.Exception.Response
+                        try
+                        {
+                            $ex.RawContent = Get-HttpWebResponseContent -WebResponse $_.Exception.Response
+                        }
+                        catch
+                        {
+                            Write-Log "Unable to retrieve the raw HTTP Web Response: $($_.Exception.Message)" -Level Warning
+                        }
+                        
                         if ($_.Exception.Response.Headers.Count -gt 0)
                         {
                             $ex.CorrelationId = $_.Exception.Response.Headers[$script:headerMSCorrelationId]
@@ -1918,7 +1926,15 @@ function Invoke-SBRestMethod
             $statusCode = $ex.Response.StatusCode.value__ # Note that value__ is not a typo.
             $statusDescription = $ex.Response.StatusDescription
             $innerMessage = $_.ErrorDetails.Message
-            $rawContent = Get-HttpWebResponseContent -WebResponse $ex.Response
+            try
+            {
+                $rawContent = Get-HttpWebResponseContent -WebResponse $ex.Response                
+            }
+            catch
+            {
+                Write-Log "Unable to retrieve the raw HTTP Web Response: $($_.Exception.Message)" -Level Warning
+            }
+            
             if ($ex.Response.Headers.Count -gt 0)
             {
                 $correlationId = $ex.Response.Headers[$script:headerMSCorrelationId]


### PR DESCRIPTION
36384212b introduced a change to try to get additional error
content from the response stream when we received an error from
the server.

Unfortunately, there was a typo in the parameter name we were
attempting to access the content stream from, resulting in
a new exception being thrown: "You cannot call a method on a
null-valued expression".

This fixes the typo, and also makes the attempt to get that value
best-effort by doing a try/catch around the call, simply so that
we never lose reporting the true error from the API.