### PR TITLE
Fix how we reference Special folders (Desktop, Documents)

### DIFF
--- a/Documentation/SETUP.md
+++ b/Documentation/SETUP.md
@@ -69,11 +69,12 @@ From an **Administrator** PowerShell console, run the following command:
 
 You need to choose a folder that you're going to store the module in.  We recommend choosing to
 use a **new sub-folder** within one of the folders in your `$env:PSModulePath`.  By default,
-even if the folder doesn't exist yet, `$Home\Documents\WindowsPowerShell\Modules` is one of
-those folders -- this is the one that we'd recommend that you use.  If it doesn't exist yet, just
+even if the folder doesn't exist yet,
+`Join-Path -Path ([System.Environment]::GetFolderPath('MyDocuments')) -ChildPath 'WindowsPowerShell\Modules'`
+is one of those folders -- this is the one that we'd recommend that you use.  If it doesn't exist yet, just
 go ahead and create it:
 
-    New-Item -Type Directory -Force -Path $Home\Documents\WindowsPowerShell\Modules\StoreBroker
+    New-Item -Type Directory -Force -Path (Join-Path -Path ([System.Environment]::GetFolderPath('MyDocuments')) -ChildPath 'WindowsPowerShell\Modules\StoreBroker')
 
 If you follow that advice, then the module will automatically be available in any PowerShell
 console session implicitly.  If you choose to store the module somewhere else, then you will need
@@ -292,12 +293,12 @@ One way to do this would be the following:
      password into a plain-text file, and only the same user logged-in to the exact same computer
      will be able to decrypt it.
           
-         $cred.Password | ConvertFrom-SecureString | Set-Content $HOME\Documents\clientSecret.txt
+         $cred.Password | ConvertFrom-SecureString | Set-Content -Path (Join-Path -Path ([System.Environment]::GetFolderPath('MyDocuments')) -ChildPath 'clientSecret.txt')
 
   4. When you want to create the credentials yourself later on and authenticate (being sure to
      replace `<tenantId>` and `<clientId>` with the proper values):
  
-         $clientSecret = Get-Content $HOME\Documents\clientSecret.txt | ConvertTo-SecureString
+         $clientSecret = Get-Content -Path (Join-Path -Path ([System.Environment]::GetFolderPath('MyDocuments')) -ChildPath 'clientSecret.txt') | ConvertTo-SecureString
          $cred = New-Object System.Management.Automation.PSCredential "<clientId>", $clientSecret
          Set-StoreBrokerAuthentication -TenantId <tenantId> -Credential $cred
 
@@ -431,7 +432,7 @@ Every project should have its own StoreBroker config file.  The config file has 
 
 #### Config Setup Steps
 
-1. Now run `New-StoreBrokerConfigFile -Path $home\desktop\SBConfig.json -AppId <AppId>`,
+1. Now run `New-StoreBrokerConfigFile -Path (Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'SBConfig.json') -AppId <AppId>`,
    substituting in your [AppId](#getting-your-appid), and that will generate a pre-populated config
    file to your desktop, based on the current configuration of your app in the Store. (Feel free
    to name this file whatever you want).
@@ -603,7 +604,7 @@ Every IAP should have its own StoreBroker config file.  The config file has two 
 
 #### IAP Config Setup Steps
 
-1. Now run `New-StoreBrokerInAppProductConfigFile -Path $home\desktop\SBConfig.json -IapId <IapId>`,
+1. Now run `New-StoreBrokerInAppProductConfigFile -Path (Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'SBConfig.json') -IapId <IapId>`,
    substituting in your [IapId](#getting-your-iapid), and that will generate a pre-populated config
    file to your desktop, based on the current configuration of your IAP in the Store. (Feel free
    to name this file whatever you want).

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -41,14 +41,12 @@ function Initialize-HelpersGlobalVariables
         $global:SBLoggingEnabled = $true
     }
 
-    # $Home relies on existence of $env:HOMEDRIVE and $env:HOMEPATH which are only 
-    # set when a user logged in interactively, which may not be the case for some build machines.
-    # $env:USERPROFILE is the equivalent of $Home, and should always be available.
     if (!(Get-Variable -Name SBLogPath -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        if (-not [System.String]::IsNullOrEmpty($env:USERPROFILE))
+        $documentsFolder = [System.Environment]::GetFolderPath('MyDocuments')
+        if (-not [System.String]::IsNullOrEmpty($documentsFolder))
         {
-            $global:SBLogPath = $(Join-Path $env:USERPROFILE "Documents\StoreBroker.log")
+            $global:SBLogPath = Join-Path -Path $documentsFolder -ChildPath 'StoreBroker.log'
         }
         else
         {

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.4'
+    ModuleVersion = '1.11.5'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1077,13 +1077,15 @@ function Update-ApplicationSubmission
     # Extra layer of validation to protect users from trying to submit a payload to the wrong application
     if ([String]::IsNullOrWhiteSpace($submission.appId))
     {
+        $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
+
         $output = @()
         $output += "The config file used to generate this submission did not have an AppId defined in it."
         $output += "The AppId entry in the config helps ensure that payloads are not submitted to the wrong application."
-        $output += "Please update your app's StoreBroker config file by adding an ""appId"" property with"
-        $output += "your app's AppId to the ""appSubmission"" section.  If you're unclear on what change"
+        $output += "Please update your app's StoreBroker config file by adding an `"appId`" property with"
+        $output += "your app's AppId to the `"appSubmission`" section.  If you're unclear on what change"
         $output += "needs to be done, you can re-generate your config file using"
-        $output += "   ""New-StoreBrokerConfigFile -AppId $AppId"" -Path ""`$home\desktop\newconfig.json"""
+        $output += "   New-StoreBrokerConfigFile -AppId $AppId -Path `"$configPath`""
         $output += "and then diff the new config file against your current one to see the requested appId change."
         Write-Log $($output -join [Environment]::NewLine) -Level Warning
     }

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1283,12 +1283,15 @@ function Update-ApplicationFlightSubmission
     # payload to the wrong application
     if ([String]::IsNullOrWhiteSpace($submission.appId))
     {
+        $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
+
         $output = @()
         $output += "The config file used to generate this submission did not have an AppId defined in it."
         $output += "The AppId entry in the config helps ensure that payloads are not submitted to the wrong application."
-        $output += "Please update your app's StoreBroker config file by adding an ""appId"" property with"
-        $output += "your app's AppId to the ""appSubmission"" section.  If you're unclear on what change"
-        $output += "needs to be done, you can re-generate your config file using ""New-PackageToolConfigFile -AppId $AppId"" -Path ""`$home\desktop\newconfig.json"""
+        $output += "Please update your app's StoreBroker config file by adding an `"appId`" property with"
+        $output += "your app's AppId to the `"appSubmission`" section.  If you're unclear on what change"
+        $output += "needs to be done, you can re-generate your config file using"
+        $output += "   New-PackageToolConfigFile -AppId $AppId -Path `"$configPath`""
         $output += "and then diff the new config file against your current one to see the requested appId change."
         Write-Log $($output -join [Environment]::NewLine) -Level Warning
     }

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -1310,13 +1310,15 @@ function Update-InAppProductSubmission
     # Extra layer of validation to protect users from trying to submit a payload to the wrong IAP
     if ([String]::IsNullOrWhiteSpace($submission.iapId))
     {
+        $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
+        
         $output = @()
         $output += "The config file used to generate this submission did not have an IapId defined in it."
         $output += "The IapId entry in the config helps ensure that payloads are not submitted to the wrong In-App Product."
-        $output += "Please update your app's StoreBroker config file by adding an ""iapId"" property with"
-        $output += "your IAP's IapId to the ""iapSubmission"" section.  If you're unclear on what change"
+        $output += "Please update your app's StoreBroker config file by adding an `"iapId`" property with"
+        $output += "your IAP's IapId to the `"iapSubmission`" section.  If you're unclear on what change"
         $output += "needs to be done, you can re-generate your config file using"
-        $output += "   ""New-StoreBrokerInAppProductConfigFile -IapId $IapId"" -Path ""`$home\desktop\newconfig.json"""
+        $output += "   New-StoreBrokerInAppProductConfigFile -IapId $IapId -Path `"$configPath`""
         $output += "and then diff the new config file against your current one to see the requested iapId change."
         Write-Log $($output -join [Environment]::NewLine) -Level Warning
     }


### PR DESCRIPTION
We previously referenced the Desktop and Documents folders like so:
`$home\Documents` and `$home\desktop`, but those folders can be
redirected to a different drive (and folder name) without changing
the user's profile directory (e.g. `$home`).

Given this, we will use the special method
[[System.Environment]::GetFolderPath()](https://msdn.microsoft.com/en-us/library/14tx8hby%28v=vs.110%29.aspx)
which can give us the correct path to those ["special folders"](https://msdn.microsoft.com/en-us/library/system.environment.specialfolder(v=vs.110).aspx)
(named `MyDocuments` and `Desktop`).

This required minor changes to the code and the documentation.