### PR TITLE
Fix unformatted error message when OutPath is not specified

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -2398,9 +2398,9 @@ function Resolve-PackageParameters
             $configVal = $ConfigObject.packageParameters.OutPath
             if ([System.String]::IsNullOrWhiteSpace($configVal))
             {
-                $newLineOutput = ($out -join [Environment]::NewLine)
-                Write-Log $newLineOutput -Level Error
-                throw $newLineOutput
+                $output = ($out -f $script:s_OutPath) 
+                Write-Log $output -Level Error
+                throw $output
             }
             else
             {

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.5'
+    ModuleVersion = '1.11.6'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
`Resolve-PackageParameters` has a default error message that requires
parameter formatting to be applied to it to indicate the name of the
parameter that is missing.

While it's used correctly for `OutName`, it's used incorrectly for
`OutPath`.  `$out` is already joined with newlines and only needs to
be formatted.  `$OutName` does this correctly.

Fixing `$OutPath` to leverage `$out` the same way as `$OutName`.
