### PR TITLE
Provide helpful error message if users try to manipulate packages without specifying any

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.6'
+    ModuleVersion = '1.11.7'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1453,6 +1453,16 @@ function Patch-ApplicationSubmission
         }
     }
 
+    if (($AddPackages -or $ReplacePackages) -and ($NewSubmission.applicationPackages.Count -eq 0))
+    {
+        $output = @()
+        $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages." 
+        $output += "Please check your input settings to New-SubmissionPackage and ensure you're providing a value for AppxPath."
+        $output = $output -join [Environment]::NewLine
+        Write-Log $output -Level Error
+        throw $output
+    }
+    
     # When updating packages, we'll simply add the new packages to the list of existing packages.
     # At some point when the API provides more signals to us with regard to what platform/OS
     # an existing package is for, we may want to mark "older" packages for the same platform

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1627,6 +1627,16 @@ function Patch-ApplicationFlightSubmission
         }
     }
 
+    if (($AddPackages -or $ReplacePackages) -and ($NewSubmission.applicationPackages.Count -eq 0))
+    {
+        $output = @()
+        $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages." 
+        $output += "Please check your input settings to New-SubmissionPackage and ensure you're providing a value for AppxPath."
+        $output = $output -join [Environment]::NewLine
+        Write-Log $output -Level Error
+        throw $output
+    }
+
     # Caller wants to simply append the new packages to the existing set of packages in the
     # submission.
     if ($AddPackages)


### PR DESCRIPTION
If a user tries to use `-AddPackages` or `-ReplacePackages` with a StoreBroker payload
that doesn't contain any, they end up with a literal `null` entry in the `applicationPackages`
list due to how we manipulate the submission object.  This then results in an error with the API.

We should actually be catching this scenario during patching time, and providing users a helpful
error message letting them know that they should check their input parameters to `New-SubmissionPackage`
so that they know how to recover.