### PR TITLE
Enable Language Fallback support for media (screenshots and icons)

### DIFF
--- a/Documentation/PDP.md
+++ b/Documentation/PDP.md
@@ -10,6 +10,7 @@
     *   [Screenshots and Captions](#screenshots-and-captions)
         *   [Folder Structure](#folder-structure)
     *   [Icons](#icons)
+    *   [Fallback Language Support](#fallback-language-support)
 *   [Schemas And Samples](#schemas-and-samples)
 *   [Loc Attributes and Comments](#loc-attributes-and-comments)
     *   [Marking A String To Not Be Localized](#marking-a-string-to-not-be-localized)
@@ -123,6 +124,37 @@ is needed based on that region's culture), and so the icon is part of the PDP.
 
 The only thing that can be specified for the Icon is the filename of that icon.  It is expected
 that the filename will be found within the defined [folder structure](#folder-structure).
+
+### Fallback Language Support
+
+PDP files are language-specific, and as we saw in the [Folder Structure](#folder-structure) section,
+any screenhots or icons that are referenced by a PDP are only searched for within that same language's
+media sub-folder within `ImagesRootPath`.
+
+There are situations however where you might want to share an image/media file across more than one language.
+For instance: maybe you want all Spanish language PDP's to use the images from `es-es`.
+Both `New-SubmissionPackage` and `New-InAppProductSubmissionPackage` support a `MediaFallbackLanguage` parameter
+which lets you specify the language where StoreBroker should look if any of the referenced media files cannot
+be found in the language-specific images/media folder.
+
+For screenshot and icons, you can specify a `FallbackLanguage` attribute whose value would be a lang-code
+(ex. `en-US`, `es-es`, etc...).  For icons, the attribute is directly on the `<Icon />` element.  For
+screenshots, the attribute is available on both the `<ScreenshotCaptions />` _and_ `<Caption />` elements.
+It can be set on either, or both, of those elements.  If specified on both, the value in the `<Caption />`
+node value will win, since it is the more-specific value.
+
+As usual, StoreBroker will first search for any media files referenced by that element in that PDP's
+langcode-specific images/media sub-folder.  If not found, it will then look in the fallback language's
+images/media sub-folder.  Only then will StoreBroker fail if the file still cannot be found.
+
+The key to remember is that this behaves in a "fallback" fashion, similar to language localization, and not
+as an override.  StoreBroker will always attempt to use the language-specific version of the file unless
+it can't be found.
+
+> Specifying the `FallbackLanguage` attribute will override the `MediaFallbackLanguage` parameter/config value
+> for `New-SubmissionPackage` and `New-InAppProductSubmissionPackage` for that specific media element.
+> There can only be _one_ fallback language for any given media file.  So, at most, StoreBroker will search
+> for a given media file twice (original language and fallback language) before failing the packaging action.
 
 ----------
 

--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -302,11 +302,11 @@ this submission.
    > Changing the percentage to 100 is not the same as Finalizing the package rollout.  For more information
    > on this topic, refer to the [Store documentation](https://docs.microsoft.com/en-us/windows/uwp/publish/gradual-package-rollout).
 
-* **`ExistingPackageRolloutAction`** _[NoAction, Halt, Finalize]_ You can't create a new submission if
-  the current pending submission is currently using package rollout.  In that scenario, prior to calling
-  this command, you can manually call `Complete-ApplicationSubmissionPackageRollout` or
-  `Stop-ApplicationSubmissionPackageRollout`, or you can just specify this parameter and the action it
-  should take, and it will do that for you automatically prior to cloning the submission.
+ * **`ExistingPackageRolloutAction`** _[NoAction, Halt, Finalize]_ You can't create a new submission if
+   the current pending submission is currently using package rollout.  In that scenario, prior to calling
+   this command, you can manually call `Complete-ApplicationSubmissionPackageRollout` or
+   `Stop-ApplicationSubmissionPackageRollout`, or you can just specify this parameter and the action it
+   should take, and it will do that for you automatically prior to cloning the submission.
 
 > Due to the nature of how the Store API works, you won't see any of your changes in the
 > dev portal until your submission has entered into certification.  It doesn't have to _complete_
@@ -1141,5 +1141,18 @@ us for analysis.  We expose it here for complete transparency.
      different number of screenshots in the store for your app, depending on the platform accessing
      the Store.  If you need to have a different set of screenshots based on language/locale,
      see the earlier FAQ on that very question.
+
+* **Can I use the same screenshots/icons/media file for different languages?**
+
+   * Yes.  Both `New-SubmissionPackage` and `New-InAppProductSubmissionPackage` support a
+     `MediaFallbackLanguage` commandline parameter (and similarly named config file option).
+     If specified, and a language-specific version of the media can't be found during packaging,
+     then StoreBroker will look in that fallback language's images/media sub-folder for the
+     same-named media file.
+
+     You can also be even more specific and specify a `FallbackLanguage` attribute on a media element
+     (`ScreenshotCaptions`, `Caption` or `Icon`) in a language's PDP file if you want more fine-tuned
+     control over which files fallback and which ones don't (and specify different languages in each
+     instance).  You can find out more about that in [PDP.md](./PDP.md#fallback-language-support).
 
 ----------

--- a/PDP/InAppProductDescription.xsd
+++ b/PDP/InAppProductDescription.xsd
@@ -36,6 +36,13 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
+    <xs:attribute name="FallbackLanguage">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:maxLength value="255" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:attributeGroup>
 
   <xs:simpleType name="ReleaseString">

--- a/PDP/ProductDescription.xsd
+++ b/PDP/ProductDescription.xsd
@@ -40,6 +40,12 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="LangCodeString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,29}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:attributeGroup name="ScreenshotImageGroup">
     <xs:attribute name="DesktopImage">
       <xs:simpleType>
@@ -76,6 +82,7 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
+    <xs:attribute name="FallbackLanguage" type="tns:LangCodeString" />
   </xs:attributeGroup>
   
   <xs:simpleType name="CaptionStringContent">
@@ -137,7 +144,6 @@
   <xs:simpleType name="AppStoreNameString">
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
-
 
   <xs:element name="ProductDescription">
     <xs:annotation>
@@ -245,6 +251,7 @@
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
+            <xs:attribute name="FallbackLanguage" type="tns:LangCodeString" />
           </xs:complexType>
         </xs:element>
 

--- a/StoreBroker/AppConfigTemplate.json
+++ b/StoreBroker/AppConfigTemplate.json
@@ -102,6 +102,15 @@
 
     "ImagesRootPath": "",
 
+    // Some apps may not localize all of their metadata media (images, trailers, etc..) across all languages.
+    // By default, StoreBroker will look in the PDP langcode's subfolder within ImagesRootPath for that
+    // language's media content.  If the requested filename is not found, StoreBroker packaging will fail.
+    // If you specify a fallback language here (e.g. 'en-us'), then if the requested file isn't found in
+    // the PDP language's media subfolder, StoreBroker will then look into the fallback language's media
+    // subfolder for the exactly same-named image before failing.
+
+    "MediaFallbackLanguage": "",
+
     // Specify any number of full paths to .appx, .appxbundle, or .appxupload files here.
     // Ex:
     // "AppxPath": [

--- a/StoreBroker/IapConfigTemplate.json
+++ b/StoreBroker/IapConfigTemplate.json
@@ -102,6 +102,15 @@
 
         "ImagesRootPath": "",
 
+        // Some apps may not localize all of their metadata media (images, trailers, etc..) across all languages.
+        // By default, StoreBroker will look in the PDP langcode's subfolder within ImagesRootPath for that
+        // language's media content.  If the requested filename is not found, StoreBroker packaging will fail.
+        // If you specify a fallback language here (e.g. 'en-us'), then if the requested file isn't found in
+        // the PDP language's media subfolder, StoreBroker will then look into the fallback language's media
+        // subfolder for the exactly same-named image before failing.
+
+        "MediaFallbackLanguage": "",
+
         // Full path to a directory where the Packaging Tool can write the .json submission request
         //     body and .zip package to upload.
         //

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.11.7'
+    ModuleVersion = '1.12.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The Store Submission API was recently updated to allow for submissions to reference the same media file across multiple elements.  In other words, the same .png file can now be referenced as a screenshot for multiple languages.

Some applications choose not to localize their screenshots, only focusing on localizing the written metadata for their PDP's.  In these scenarios, they would have a smaller StoreBroker package (and a simpler authoring environment) if they could simply tell StoreBroker to use a different language's screenshots when language-specific ones are not available.

With this change, the following end-user features are now enabled:
  * The StoreBroker config file has been updated to support a `MediaFallbackLanguage` config option
    that allows users to specify a lang-code (e,g, `en-us`, `es-es`, etc...)
  * Users can specify a `-MediaFallbackLanguage` parameter to `New-SubmissionPackage` and
    `New-InAppProductSubmissionPackage`, specifying a lang-code (e,g, `en-us`, `es-es`, etc...) which will
    override any config file option that has been specified.
  * Users can specify a `FallbackLanguage` attribute on the `<caption />` and `<icon />` elements in
     PDP files to optionally choose a different fallback language on a per-element basis.

In any of these cases, if the language-specific media file cannot be found, and a fallback language has
been specified, StoreBroker will then look in the fallback language's Images/media sub-folder for the
same-named media file.  Only then, if still not found, will packaging fail.

It should be noted that there can only ever be _one_ designated fallback language for any given file.
The logic does not cascade.  Therefore, if a user specifies a fallback language in both the config file
_and_ at the command prompt, the command prompt always wins.  If a value has been specified via
the config file and/or command prompt, _as well as_ in a PDP file, the fallback language from the PDP
file will be the one that is used _for that element_, and then StoreBroker will revert back to using the
one from the config file / command prompt until it encounters another one defined specifically in
the PDP file.

Addresses #28: Unable to submit common screenshot for all languages