### PR TITLE
Re-enable support for non-release structured ImagesRootPath

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -929,7 +929,6 @@ function Get-LocalizedMediaFile
         [Parameter(Mandatory)]
         [string] $Language,
 
-        [Parameter(Mandatory)]
         [string] $Release,
 
         [string] $MediaFallbackLanguage

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.12.0'
+    ModuleVersion = '1.12.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The recent addition of fallback media support assumed that
users would always specify a `Release` attribute within the PDP
file (and therefore made the Release parameter to `Get-LocalizedMediaFile`
a required attribute).  It turns out that we have users that aren't
specifying a value for the `Release` attribute in the PDP file,
and so were therefore hitting a parameter validation error while
running packaging.

This fix removes the `Mandatory` attribute from the `Release` parameter
to `Get-LocalizedMediaFile` in order to re-enable this usage scenario.