### PR TITLE
Fix an exception in the Update-*Submission cmdlets

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.12.2'
+    ModuleVersion = '1.12.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1141,7 +1141,7 @@ function Update-ApplicationSubmission
             {
                 $output = @()
                 $output += "We can only modify a submission that is in the '$script:keywordPendingCommit' state."
-                $output += "The submission that you requested to modify ($SubmissionId) is in '$(submissionToUpdate.status)' state."
+                $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
                 
                 $newLineOutput = ($output -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1344,7 +1344,7 @@ function Update-ApplicationFlightSubmission
             {
                 $output = @()
                 $output += "We can only modify a submission that is in the '$script:keywordPendingCommit' state."
-                $output += "The submission that you requested to modify ($SubmissionId) is in '$(submissionToUpdate.status)' state."
+                $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
                 
                 $newLineOutput = ($output -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -1371,7 +1371,7 @@ function Update-InAppProductSubmission
             {
                 $output = @()
                 $output += "We can only modify a submission that is in the '$script:keywordPendingCommit' state."
-                $output += "The submission that you requested to modify ($SubmissionId) is in '$(submissionToUpdate.status)' state."
+                $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
                 
                 $newLineOutput = ($output -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error


### PR DESCRIPTION
Fix an exception in the Update-ApplicationSubmission, Update-ApplicationFlightSubmission, and Update-InAppProductSubmission that occurs when the user specifies a -SubmissionId but the submission is not in a 'PendingCommit' state.

While creating the exception message to throw, we forgot a '$' character and so PowerShell cannot interpret the sub-expression in the message.