### PR TITLE
Avoid throwing an exception for duplicate images.

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -980,8 +980,8 @@ function Get-LocalizedMediaFile
     if ($image.Count -gt 1)
     {
         $output = "More then one version of [$Filename] has been found for this language. Please ensure only one copy of this image exists within the language's sub-folders: [$($image.FullName -join ', ')]"
-        Write-Log $output -Level Error
-        throw $output
+        Write-Log $output -Level Warning
+        #throw $output
     }
 
     $fileFullPackagePath = Join-Path -Path $script:tempFolderPath -ChildPath $fileRelativePackagePath

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.12.1'
+    ModuleVersion = '1.12.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
When fallback image support was implemented, we switched to throwing an exception for duplicate images. This is actually a breaking change for users that previously had an incorrect image folder structure.  We published the change using incorrect NuGet version semantics which makes it difficult for users to rollback to the non-breaking change.  To fix, we should change to only report a warning in this case.  This will allow users with incorrect image folder structure to still successfully package as they were before. In the future, we will switch back to the exception during packaging, but we will publish the change as a new major version because it is a breaking change.