### PR TITLE
Assume neutral architecture when none is specified

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1608,6 +1608,11 @@ function Read-AppxMetadata
 
         $metadata.version        = $manifest.Package.Identity.Version
         $metadata.architecture   = $manifest.Package.Identity.ProcessorArchitecture
+        if ([String]::IsNullOrWhiteSpace($metadata.architecture))
+        {
+            $metadata.architecture = "neutral"
+        }
+
         $metadata.targetPlatform = Get-TargetPlatform -AppxManifestPath $appxManifest
         $metadata.name           = $manifest.Package.Identity.Name -creplace '^Microsoft\.', ''
         

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.12.3'
+    ModuleVersion = '1.12.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Per the [MSDN documentation](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-identity),
`neutral` is the default value for `ProcessorArchitecture`.

Updating our Appx metadata reading logic to assume `neutral` when none is specified.

This will avoid a later exception in `Get-FormattedFilename` that does Metadata table validation.

Resolves Issue #89