### PR TITLE
Improve use of Write-Log and exceptions

### DIFF
--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -94,7 +94,7 @@ function Add-ToElement
         PS C:\>Add-ToElement -Element $root -Comment "Comment1", "Comment2" -Attribute @{ "Attrib1"="Val1"; "Attrib2"="Val2" }
 
         Adds two comments and two attributes to the root element of the XML document.
-        
+
 #>
     param(
         [Parameter(Mandatory)]
@@ -268,7 +268,7 @@ function Add-Icon
         be included with a non-empty value.  This is fine if the Listing has an icon defined,
         but if it doesn't, then we want to include the element, but commented out so that users
         know later what they need to add if they wish to include an icon at some future time.
-        We will create/add the icon node the way we do in all other cases so that we have its XML, 
+        We will create/add the icon node the way we do in all other cases so that we have its XML,
         but if we then determine that there is no icon for that listing, we'll convert the element
         to its XML string representation that we can add as a comment, and then remove the actual
         node.
@@ -368,7 +368,7 @@ function ConvertFrom-Listing
         xml:lang="{0}"
         Release="{1}"/>', $Lang, $Release))
 
-    Add-Title -Xml $Xml -Listing $Listing    
+    Add-Title -Xml $Xml -Listing $Listing
     Add-Description -Xml $Xml -Listing $Listing
     $icon = Add-Icon -Xml $Xml -Listing $Listing
 
@@ -527,7 +527,7 @@ function Show-ImageFileNames
         {
             $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
         }
-    
+
         Write-Log $($output -join [Environment]::NewLine)
     }
     else
@@ -580,7 +580,7 @@ function Main
             }
             catch
             {
-                Write-Log "Error creating [$lang] PDP: $($Error[0].Exception.Message )" -Level Error
+                Write-Log "Error creating [$lang] PDP:" -Exception $_ -Level Error
                 throw
             }
         }

--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -130,7 +130,7 @@ function Add-ToElement
         else
         {
             $out = "For element $($Element.LocalName), did not create attribute '$key' with value '$($Attribute[$key])' because the attribute already exists."
-            Write-Log $out -Level Warning
+            Write-Log -Message $out -Level Warning
         }
     }
 }
@@ -526,7 +526,7 @@ function Show-ImageFileNames
             $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
         }
 
-        Write-Log $output
+        Write-Log -Message $output
     }
     else
     {
@@ -555,7 +555,7 @@ function Main
         if ([String]::IsNullOrEmpty($SubmissionId))
         {
             $SubmissionId = $iap.pendingInAppProductSubmission.id
-            Write-Log "No published submission exists for this In-App Product.  Using the current pending submission." -Level Warning
+            Write-Log -Message "No published submission exists for this In-App Product.  Using the current pending submission." -Level Warning
         }
     }
 
@@ -567,7 +567,7 @@ function Main
     $langs |
         ForEach-Object {
             $lang = $_.Name
-            Write-Log "Creating PDP for $lang" -Level Verbose
+            Write-Log -Message "Creating PDP for $lang" -Level Verbose
             Write-Progress -Activity "Generating PDP" -Status $lang -PercentComplete $(($pdpsGenerated / $langs.Count) * 100)
             try
             {
@@ -577,14 +577,14 @@ function Main
             }
             catch
             {
-                Write-Log "Error creating [$lang] PDP:" -Exception $_ -Level Error
+                Write-Log -Message "Error creating [$lang] PDP:" -Exception $_ -Level Error
                 throw
             }
         }
 
     if ($pdpsGenerated -gt 0)
     {
-        Write-Log "PDP's have been created here: $OutPath"
+        Write-Log -Message "PDP's have been created here: $OutPath"
         Show-ImageFileNames -LangImageNames $langImageNames -Release $Release
     }
     else

--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -482,11 +482,10 @@ function Show-ImageFileNames
         return
     }
 
-    $output = @()
-    $output += "You now need to find all of your images and place them here: <ImagesRootPath>\$Release\<langcode>\..."
-    $output += "  where <ImagesRootPath> is the path defined in your config file,"
-    $output += "  and <langcode> is the same langcode for the directory of the PDP file referencing those images."
-    Write-Log $($output -join [Environment]::NewLine)
+    Write-Log -Message @(
+        "You now need to find all of your images and place them here: <ImagesRootPath>\$Release\<langcode>\...",
+        "  where <ImagesRootPath> is the path defined in your config file,",
+        "  and <langcode> is the same langcode for the directory of the PDP file referencing those images.")
 
     # Quick analysis to help teams out if they need to do anything special with their PDP's
 
@@ -514,12 +513,11 @@ function Show-ImageFileNames
     # Now show the user the image filenames
     if ($imagesDiffer)
     {
-        $output = @()
-        $output += "It appears that you don't have consistent images across all languages."
-        $output += "While StoreBroker supports this scenario, some localization systems may"
-        $output += "not support this without additional work.  Please refer to the FAQ in"
-        $output += "the documentation for more info on how to best handle this scenario."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "It appears that you don't have consistent images across all languages.",
+            "While StoreBroker supports this scenario, some localization systems may",
+            "not support this without additional work.  Please refer to the FAQ in",
+            "the documentation for more info on how to best handle this scenario.")
 
         $output = @()
         $output += "The currently referenced image filenames, per langcode, are as follows:"
@@ -528,14 +526,13 @@ function Show-ImageFileNames
             $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
         }
 
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
     else
     {
-        $output = @()
-        $output += "Every language that has a PDP references the following images:"
-        $output += "`t$($seenImages -join `"`n`t`")"
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Every language that has a PDP references the following images:",
+            "`t$($seenImages -join `"`n`t`")")
     }
 }
 
@@ -592,11 +589,10 @@ function Main
     }
     else
     {
-        $output = @()
-        $output += "No PDPs were generated."
-        $output += "Please verify that this existing In-App Product has one or more language listings that this extension can convert,"
-        $output += "otherwise you can start fresh using the sample PDP\InAppProductDescription.xml as a starting point."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "No PDPs were generated.",
+            "Please verify that this existing In-App Product has one or more language listings that this extension can convert,",
+            "otherwise you can start fresh using the sample PDP\InAppProductDescription.xml as a starting point.")
     }
 }
 

--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -100,7 +100,7 @@ function Add-ToElement
         PS C:\>Add-ToElement -Element $root -Comment "Comment1", "Comment2" -Attribute @{ "Attrib1"="Val1"; "Attrib2"="Val2" }
 
         Adds two comments and two attributes to the root element of the XML document.
-        
+
 #>
     param(
         [Parameter(Mandatory)]
@@ -229,7 +229,7 @@ function Add-ToChildren
             }
 
             Add-ToElement @params
-            $CountFrom++ 
+            $CountFrom++
         }
 }
 
@@ -502,7 +502,7 @@ function Add-ScreenshotCaptions
                 # https://github.com/PowerShell/PSScriptAnalyzer/issues/699
                 $captionImageMap[$description] = @{}
             }
-                        
+
             ($captionImageMap[$description])[$imageType] = $fileName
         }
 
@@ -903,7 +903,7 @@ function ConvertFrom-Listing
         xml:lang="{0}"
         Release="{1}"/>', $Lang, $Release))
 
-    Add-AppStoreName -Xml $Xml -Listing $Listing    
+    Add-AppStoreName -Xml $Xml -Listing $Listing
     Add-Keywords -Xml $Xml -Listing $Listing
     Add-Description -Xml $Xml -Listing $Listing
     Add-ReleaseNotes -Xml $Xml -Listing $Listing
@@ -1057,7 +1057,7 @@ function Show-ImageFileNames
         {
             $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
         }
-    
+
         Write-Log $($output -join [Environment]::NewLine)
     }
     else
@@ -1105,7 +1105,7 @@ function Main
             }
             catch
             {
-                Write-Log "Error creating [$lang] PDP: $($Error[0].Exception.Message )" -Level Error
+                Write-Log "Error creating [$lang] PDP:" -Exception $_ -Level Error
                 throw
             }
         }

--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -136,7 +136,7 @@ function Add-ToElement
         else
         {
             $out = "For element $($Element.LocalName), did not create attribute '$key' with value '$($Attribute[$key])' because the attribute already exists."
-            Write-Log $out -Level Warning
+            Write-Log -Message $out -Level Warning
         }
     }
 }
@@ -1056,7 +1056,7 @@ function Show-ImageFileNames
             $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
         }
 
-        Write-Log $output
+        Write-Log -Message $output
     }
     else
     {
@@ -1092,7 +1092,7 @@ function Main
     $langs |
         ForEach-Object {
             $lang = $_.Name
-            Write-Log "Creating PDP for $lang" -Level Verbose
+            Write-Log -Message "Creating PDP for $lang" -Level Verbose
             Write-Progress -Activity "Generating PDP" -Status $lang -PercentComplete $(($pdpsGenerated / $langs.Count) * 100)
             try
             {
@@ -1102,12 +1102,12 @@ function Main
             }
             catch
             {
-                Write-Log "Error creating [$lang] PDP:" -Exception $_ -Level Error
+                Write-Log -Message "Error creating [$lang] PDP:" -Exception $_ -Level Error
                 throw
             }
         }
 
-    Write-Log "PDP's have been created here: $OutPath"
+    Write-Log -Message "PDP's have been created here: $OutPath"
     Show-ImageFileNames -LangImageNames $langImageNames -Release $Release
 }
 

--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -1012,11 +1012,10 @@ function Show-ImageFileNames
         return
     }
 
-    $output = @()
-    $output += "You now need to find all of your images and place them here: <ImagesRootPath>\$Release\<langcode>\..."
-    $output += "  where <ImagesRootPath> is the path defined in your config file,"
-    $output += "  and <langcode> is the same langcode for the directory of the PDP file referencing those images."
-    Write-Log $($output -join [Environment]::NewLine)
+    Write-Log -Message @(
+        "You now need to find all of your images and place them here: <ImagesRootPath>\$Release\<langcode>\...",
+        "  where <ImagesRootPath> is the path defined in your config file,",
+        "  and <langcode> is the same langcode for the directory of the PDP file referencing those images.")
 
     # Quick analysis to help teams out if they need to do anything special with their PDP's
 
@@ -1044,12 +1043,11 @@ function Show-ImageFileNames
     # Now show the user the image filenames
     if ($imagesDiffer)
     {
-        $output = @()
-        $output += "It appears that you don't have consistent images across all languages."
-        $output += "While StoreBroker supports this scenario, some localization systems may"
-        $output += "not support this without additional work.  Please refer to the FAQ in"
-        $output += "the documentation for more info on how to best handle this scenario."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "It appears that you don't have consistent images across all languages.",
+            "While StoreBroker supports this scenario, some localization systems may",
+            "not support this without additional work.  Please refer to the FAQ in",
+            "the documentation for more info on how to best handle this scenario.")
 
         $output = @()
         $output += "The currently referenced image filenames, per langcode, are as follows:"
@@ -1058,14 +1056,13 @@ function Show-ImageFileNames
             $output += " * [$langCode]: " + ($LangImageNames.$langCode -join ", ")
         }
 
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
     else
     {
-        $output = @()
-        $output += "Every language that has a PDP references the following images:"
-        $output += "`t$($seenImages -join `"`n`t`")"
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Every language that has a PDP references the following images:",
+            "`t$($seenImages -join `"`n`t`")")
     }
 }
 

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -15,7 +15,7 @@ function Initialize-HelpersGlobalVariables
 
     .NOTES
         Internal-only helper method.
-    
+
         The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
         which can only be applied to functions.  Otherwise, we would have just had the relevant
         initialization code directly above the function that references the variable.
@@ -183,7 +183,7 @@ function Format-SimpleTableString
     .PARAMETER IndentationLevel
         The number of spaces that this should be indented.
         Defaults to 0.
-        
+
     .EXAMPLE
         Format-SimpleTableString @{"Name" = "Foo"; "Value" = "Bar"}
         Formats to a table with no indentation, and no leading or trailing empty lines.
@@ -269,7 +269,7 @@ function DeepCopy-Object
 #>
 {
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification="Intentional.  This isn't exported, and needed to be explicit relative to Copy-Object.")] 
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification="Intentional.  This isn't exported, and needed to be explicit relative to Copy-Object.")]
     param(
         [Parameter(Mandatory)]
         [PSCustomObject] $Object
@@ -403,17 +403,17 @@ function ConvertTo-Array
 
     Begin
     {
-        $output = @(); 
+        $output = @();
     }
 
     Process
     {
-        $output += $_; 
+        $output += $_;
     }
 
     End
     {
-        return ,$output; 
+        return ,$output;
     }
 }
 
@@ -433,14 +433,14 @@ function Write-Log
 
     .PARAMETER Level
         The type of message to be logged.
-        
+
     .PARAMETER Indent
         The number of spaces to indent the line in the log file.
 
     .PARAMETER Path
         The log file path.
         Defaults to $env:USERPROFILE\Documents\StoreBroker.log
-        
+
     .EXAMPLE
         Write-Log -Message "Everything worked." -Path C:\Debug.log
 
@@ -462,16 +462,28 @@ function Write-Log
         $global:SBLoggingEnabled determines if log entries will be made to the log file.
            If $false, log entries will ONLY go to the relevant output pipeline.
 #>
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding(
+        SupportsShouldProcess,
+        DefaultParameterSetName="LogString")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification="We use global variables sparingly and intentionally for module configuration, and employ a consistent naming convention.")]
     param(
         [Parameter(
+            ParameterSetName="LogString",
             Mandatory,
+            Position=0,
             ValueFromPipeline)]
         [AllowEmptyString()]
         [AllowNull()]
         [string] $Message,
+
+        [Parameter(
+            ParameterSetName="LogException",
+            Mandatory,
+            Position=0,
+            ValueFromPipeline)]
+        [AllowNull()]
+        [System.Management.Automation.ErrorRecord] $Exception,
 
         [ValidateSet('Error', 'Warning', 'Info', 'Verbose', 'Debug')]
         [string] $Level = 'Info',
@@ -484,6 +496,13 @@ function Write-Log
 
     Process
     {
+        if ($PSCmdlet.ParameterSetName -eq "LogException")
+        {
+            # Convert the exception to a string for logging.
+            # If $Exception happens to be $null, $Message will be empty string.
+            $Message = Out-String -InputObject $Exception
+        }
+
         $date = Get-Date
         $dateString = $date.ToString("yyyy-MM-dd HH:mm:ss")
         if ($global:SBUseUTC)
@@ -550,7 +569,8 @@ function Write-Log
         catch
         {
             $output = @()
-            $output += "Failed to add log entry to [$Path]. The error was: '$_'."
+            $output += "Failed to add log entry to [$Path]. The error was:"
+            $output += Out-String -InputObject $_
 
             if (Test-Path -Path $Path -PathType Leaf)
             {
@@ -573,7 +593,7 @@ function Write-Log
     }
 }
 
-function New-TemporaryDirectory 
+function New-TemporaryDirectory
 {
 <#
     .SYNOPSIS
@@ -627,7 +647,7 @@ function Send-SBMailMessage
         $global:SBNotifySmtpServer    - The SMTP Server to be used
                                         [defaults to $null]
         $global:SBNotifyCredential    - The credentials needed to send mail through that SMTP Server
-                                        [defaults to $null]        
+                                        [defaults to $null]
 
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
 
@@ -667,7 +687,7 @@ function Send-SBMailMessage
             $fixedTo += "$_@$global:SBNotifyDefaultDomain"
         }
     }
-    
+
     # Do the same for the "From" email address
     $fixedFrom = $global:SBNotifyDefaultFrom
     if ($fixedFrom -notlike "*@*")
@@ -819,7 +839,7 @@ function Resolve-UnverifiedPath
         file doesn't exist.
 
     .OUTPUTS
-        [string] - The fully resolved path 
+        [string] - The fully resolved path
 
 #>
     [CmdletBinding()]
@@ -880,7 +900,7 @@ function Ensure-Directory
     {
         Write-Log "Could not ensure directory: [$Path]" -Level Error
 
-        throw 
+        throw
     }
 }
 

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -623,9 +623,7 @@ function Write-Log
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification="We use global variables sparingly and intentionally for module configuration, and employ a consistent naming convention.")]
     param(
-        [Parameter(
-            Mandatory,
-            ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [AllowEmptyCollection()]
         [AllowEmptyString()]
         [AllowNull()]
@@ -658,10 +656,15 @@ function Write-Log
 
     End
     {
-        # If we have an exception, add it after the accumulated messages.
         if ($null -ne $Exception)
         {
+            # If we have an exception, add it after the accumulated messages.
             $messages += Out-String -InputObject $Exception
+        }
+        elseif ($messages.Count -eq 0)
+        {
+            # If no exception and no messages, we should early return.
+            return
         }
 
         # Finalize the string to log.
@@ -856,12 +859,12 @@ function Send-SBMailMessage
             {
                 if ($remainingAttempts -gt 0)
                 {
-                    Write-Log "Exception trying to send mail: $($_.Exception.Message). Will try again in $retryBackoffSeconds seconds." -Level Warning
+                    Write-Log "Exception trying to send mail. Will try again in $retryBackoffSeconds seconds." -Exception $_ -Level Warning
                     Start-Sleep -Seconds $retryBackoffSeconds
                 }
                 else
                 {
-                    Write-Log "Exception trying to send mail: $($_.Exception.Message). Retry attempts exhausted.  Unable to send email." -Level Error
+                    Write-Log "Exception trying to send mail. Retry attempts exhausted. Unable to send email." -Exception $_ -Level Error
                 }
             }
         }

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -429,7 +429,9 @@ function Write-Log
         The Git repo for this module can be found here: http://aka.ms/StoreBroker
 
     .PARAMETER Message
-        The message(s) to be logged. This parameter supports pipelining but there are no
+        The message(s) to be logged. Each element of the array will be written to a separate line.
+
+        This parameter supports pipelining but there are no
         performance benefits to doing so. For more information, see the .NOTES for this
         cmdlet.
 
@@ -475,7 +477,7 @@ function Write-Log
 
         Logs the message:
 
-        Write-LogHelper : 2018-01-23 12:57:37 : dabelc : There was a problem.
+        Write-Log : 2018-01-23 12:57:37 : dabelc : There was a problem.
         Here is the exception information:
         You cannot call a method on a null-valued expression.
         At line:1 char:7

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -146,14 +146,14 @@ function Wait-JobWithAnimation
         Write-InteractiveHost "`rDONE - Operation took $([int]($iteration / $framesPerSecond)) second(s) $Description" -NoNewline -f Green
 
         # We forcibly set Verbose to false here since we don't need it printed to the screen, since we just did above -- we just need to log it.
-        Write-Log "DONE - Operation took $([int]($iteration / $framesPerSecond)) second(s) $Description" -Level Verbose -Verbose:$false
+        Write-Log -Message "DONE - Operation took $([int]($iteration / $framesPerSecond)) second(s) $Description" -Level Verbose -Verbose:$false
     }
     else
     {
         Write-InteractiveHost "`rDONE (FAILED) - Operation took $([int]($iteration / $framesPerSecond)) second(s) $Description" -NoNewline -f Red
 
         # We forcibly set Verbose to false here since we don't need it printed to the screen, since we just did above -- we just need to log it.
-        Write-Log "DONE (FAILED) - Operation took $([int]($iteration / $framesPerSecond)) second(s) $Description" -Level Verbose -Verbose:$false
+        Write-Log -Message "DONE (FAILED) - Operation took $([int]($iteration / $framesPerSecond)) second(s) $Description" -Level Verbose -Verbose:$false
     }
 
     Write-InteractiveHost ""
@@ -680,7 +680,7 @@ function New-TemporaryDirectory
 
     $tempFolderPath = Join-Path -Path $env:TEMP -ChildPath $guid
 
-    Write-Log "Creating temporary directory: $tempFolderPath" -Level Verbose
+    Write-Log -Message "Creating temporary directory: $tempFolderPath" -Level Verbose
     New-Item -ItemType directory -Path $tempFolderPath
 }
 
@@ -780,7 +780,7 @@ function Send-SBMailMessage
         while ($remainingAttempts -gt 0)
         {
             $remainingAttempts--
-            Write-Log "Sending email to $($fixedTo -join ', ')" -Level Verbose
+            Write-Log -Message "Sending email to $($fixedTo -join ', ')" -Level Verbose
 
             try
             {
@@ -791,12 +791,12 @@ function Send-SBMailMessage
             {
                 if ($remainingAttempts -gt 0)
                 {
-                    Write-Log "Exception trying to send mail. Will try again in $retryBackoffSeconds seconds." -Exception $_ -Level Warning
+                    Write-Log -Message "Exception trying to send mail. Will try again in $retryBackoffSeconds seconds." -Exception $_ -Level Warning
                     Start-Sleep -Seconds $retryBackoffSeconds
                 }
                 else
                 {
-                    Write-Log "Exception trying to send mail. Retry attempts exhausted. Unable to send email." -Exception $_ -Level Error
+                    Write-Log -Message "Exception trying to send mail. Retry attempts exhausted. Unable to send email." -Exception $_ -Level Error
                 }
             }
         }
@@ -949,13 +949,13 @@ function Ensure-Directory
 
         if (-not (Test-Path -PathType Container -Path $Path))
         {
-            Write-Log "Creating directory: [$Path]" -Level Verbose
+            Write-Log -Message "Creating directory: [$Path]" -Level Verbose
             New-Item -ItemType Directory -Path $Path | Out-Null
         }
     }
     catch
     {
-        Write-Log "Could not ensure directory: [$Path]" -Level Error
+        Write-Log -Message "Could not ensure directory: [$Path]" -Level Error
 
         throw
     }

--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -30,7 +30,7 @@ function Get-NugetExe
         $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
         $script:nugetExePath = Join-Path $(New-TemporaryDirectory) "nuget.exe"
 
-        Write-Log "Downloading $sourceNugetExe to $script:nugetExePath" -Level Verbose
+        Write-Log -Message "Downloading $sourceNugetExe to $script:nugetExePath" -Level Verbose
         Invoke-WebRequest $sourceNugetExe -OutFile $script:nugetExePath
     }
 
@@ -89,7 +89,7 @@ function Get-NugetPackage
         [switch] $NoStatus
     )
 
-    Write-Log "Downloading nuget package [$PackageName] to [$TargetPath]" -Level Verbose
+    Write-Log -Message "Downloading nuget package [$PackageName] to [$TargetPath]" -Level Verbose
 
     $nugetPath = Get-NugetExe
 
@@ -290,7 +290,7 @@ function Get-NugetPackageDllPath
         [switch] $NoStatus
     )
 
-    Write-Log "Looking for $AssemblyName" -Level Verbose
+    Write-Log -Message "Looking for $AssemblyName" -Level Verbose
 
     # First we'll check to see if the user has cached the assembly into the module's script directory
     $moduleAssembly = Join-Path $PSScriptRoot $AssemblyName
@@ -298,12 +298,12 @@ function Get-NugetPackageDllPath
     {
         if (Test-AssemblyIsDesiredVersion -AssemblyPath $moduleAssembly -DesiredVersion $NugetPackageVersion)
         {
-            Write-Log "Found $AssemblyName in module directory ($PSScriptRoot)." -Level Verbose
+            Write-Log -Message "Found $AssemblyName in module directory ($PSScriptRoot)." -Level Verbose
             return $moduleAssembly
         }
         else
         {
-            Write-Log "Found $AssemblyName in module directory ($PSScriptRoot), but its version number didn't match required [$NugetPackageVersion]." -Level Verbose
+            Write-Log -Message "Found $AssemblyName in module directory ($PSScriptRoot), but its version number didn't match required [$NugetPackageVersion]." -Level Verbose
         }
     }
 
@@ -315,12 +315,12 @@ function Get-NugetPackageDllPath
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $alternateAssemblyPath -DesiredVersion $NugetPackageVersion)
             {
-                Write-Log "Found $AssemblyName in alternate directory ($SBAlternateAssemblyDir)." -Level Verbose
+                Write-Log -Message "Found $AssemblyName in alternate directory ($SBAlternateAssemblyDir)." -Level Verbose
                 return $alternateAssemblyPath
             }
             else
             {
-                Write-Log "Found $AssemblyName in alternate directory ($SBAlternateAssemblyDir), but its version number didn't match required [$NugetPackageVersion]." -Level Verbose
+                Write-Log -Message "Found $AssemblyName in alternate directory ($SBAlternateAssemblyDir), but its version number didn't match required [$NugetPackageVersion]." -Level Verbose
             }
         }
     }
@@ -337,18 +337,18 @@ function Get-NugetPackageDllPath
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $cachedAssemblyPath -DesiredVersion $NugetPackageVersion)
             {
-                Write-Log "Found $AssemblyName in temp directory ($script:tempAssemblyCacheDir)." -Level Verbose
+                Write-Log -Message "Found $AssemblyName in temp directory ($script:tempAssemblyCacheDir)." -Level Verbose
                 return $cachedAssemblyPath
             }
             else
             {
-                Write-Log "Found $AssemblyName in temp directory ($script:tempAssemblyCacheDir), but its version number didn't match required [$NugetPackageVersion]." -Level Verbose
+                Write-Log -Message "Found $AssemblyName in temp directory ($script:tempAssemblyCacheDir), but its version number didn't match required [$NugetPackageVersion]." -Level Verbose
             }
         }
     }
 
     # Still not found, so we'll go ahead and download the package via nuget.
-    Write-Log "$AssemblyName is needed and wasn't found.  Acquiring it via nuget..." -Level Verbose
+    Write-Log -Message "$AssemblyName is needed and wasn't found.  Acquiring it via nuget..." -Level Verbose
     Get-NugetPackage -PackageName $NugetPackageName -Version $NugetPackageVersion -TargetPath $script:tempAssemblyCacheDir -NoStatus:$NoStatus
 
     $cachedAssemblyPath = Join-Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
@@ -366,6 +366,6 @@ function Get-NugetPackageDllPath
     }
 
     $output = "Unable to acquire a reference to $AssemblyName."
-    Write-Log $output -Level Error
+    Write-Log -Message $output -Level Error
     throw $output
 }

--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -29,7 +29,7 @@ function Get-NugetExe
     {
         $sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
         $script:nugetExePath = Join-Path $(New-TemporaryDirectory) "nuget.exe"
-    
+
         Write-Log "Downloading $sourceNugetExe to $script:nugetExePath" -Level Verbose
         Invoke-WebRequest $sourceNugetExe -OutFile $script:nugetExePath
     }
@@ -118,11 +118,11 @@ function Get-NugetPackage
 
                 if (-not [System.String]::IsNullOrEmpty($Version))
                 {
-                    & $NugetPath install $PackageName -o $TargetPath -version $Version -source nuget.org 
+                    & $NugetPath install $PackageName -o $TargetPath -version $Version -source nuget.org
                 }
                 else
                 {
-                    & $NugetPath install $PackageName -o $TargetPath -source nuget.org 
+                    & $NugetPath install $PackageName -o $TargetPath -source nuget.org
                 }
             }
 
@@ -138,7 +138,7 @@ function Get-NugetPackage
                 Receive-Job $jobName -AutoRemoveJob -Wait -ErrorAction SilentlyContinue -ErrorVariable remoteErrors | Out-Null
             }
         }
-           
+
         if ($remoteErrors.Count -gt 0)
         {
             throw $remoteErrors[0].Exception
@@ -224,14 +224,14 @@ function Get-NugetPackageDllPath
         on the machine, and returns the path to it.
 
         This will first look for the assembly in the module's script directory.
-        
+
         Next it will look for the assembly in the location defined by
         $SBAlternateAssemblyDir.  This value would have to be defined by the user
         prior to execution of this cmdlet.
-        
+
         If not found there, it will look in a temp folder established during this
         PowerShell session.
-        
+
         If still not found, it will download the nuget package
         for it to a temp folder accessible during this PowerShell session.
 
@@ -354,14 +354,13 @@ function Get-NugetPackageDllPath
     $cachedAssemblyPath = Join-Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
     if (Test-Path -Path $cachedAssemblyPath -PathType Leaf)
     {
-        $output = @()
-        $output += "To avoid this download delay in the future, copy the following file:"
-        $output += "  [$cachedAssemblyPath]"
-        $output += "either to:"
-        $output += "  [$PSScriptRoot]"
-        $output += "or to:"
-        $output += "  a directory of your choosing, and save that directory path to `$SBAlternateAssemblyDir"
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "To avoid this download delay in the future, copy the following file:",
+            "  [$cachedAssemblyPath]",
+            "either to:",
+            "  [$PSScriptRoot]",
+            "or to:",
+            "  a directory of your choosing, and save that directory path to `$SBAlternateAssemblyDir")
 
         return $cachedAssemblyPath
     }

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -104,7 +104,7 @@ function Get-StoreBrokerConfigFileContentForIapId
         if ([String]::IsNullOrEmpty($submissionId))
         {
             $submissionId = $iap.pendingInAppProductSubmission.id
-            Write-Log "No published submission exists for this In-App Product.  Using the current pending submission." -Level Warning
+            Write-Log -Message "No published submission exists for this In-App Product.  Using the current pending submission." -Level Warning
         }
 
         $sub = Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId
@@ -141,7 +141,7 @@ function Get-StoreBrokerConfigFileContentForIapId
     }
     catch
     {
-        Write-Log "Encountered problems getting current In-App Product submission values:" -Exception $_ -Level Error
+        Write-Log -Message "Encountered problems getting current In-App Product submission values:" -Exception $_ -Level Error
         throw
     }
 }
@@ -199,9 +199,9 @@ function New-StoreBrokerInAppProductConfigFile
     $dir = Split-Path -Parent -Path $Path
     if (-not (Test-Path -PathType Container -Path $dir))
     {
-        Write-Log "Creating directory: $dir" -Level Verbose
+        Write-Log -Message "Creating directory: $dir" -Level Verbose
         New-Item -Force -ItemType Directory -Path $dir | Out-Null
-        Write-Log "Created directory." -Level Verbose
+        Write-Log -Message "Created directory." -Level Verbose
     }
 
     $sourcePath = Join-Path -Path $PSScriptRoot -ChildPath $script:defaultIapConfigFileName
@@ -214,9 +214,9 @@ function New-StoreBrokerInAppProductConfigFile
         $template = Get-StoreBrokerConfigFileContentForIapId -ConfigContent $template -IapId $IapId
     }
 
-    Write-Log "Copying (Item: $sourcePath) to (Target: $Path)." -Level Verbose
+    Write-Log -Message "Copying (Item: $sourcePath) to (Target: $Path)." -Level Verbose
     Set-Content -Path $Path -Value $template -Encoding UTF8 -Force
-    Write-Log "Copy complete." -Level Verbose
+    Write-Log -Message "Copy complete." -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::IapId = $IapId }
     Set-TelemetryEvent -EventName New-StoreBrokerIapConfigFile -Properties $telemetryProperties
@@ -336,7 +336,7 @@ function Get-StoreBrokerConfigFileContentForAppId
     }
     catch
     {
-        Write-Log "Encountered problems getting current application submission values:" -Exception $_ -Level Error
+        Write-Log -Message "Encountered problems getting current application submission values:" -Exception $_ -Level Error
         throw
     }
 }
@@ -394,9 +394,9 @@ function New-StoreBrokerConfigFile
     $dir = Split-Path -Parent -Path $Path
     if (-not (Test-Path -PathType Container -Path $dir))
     {
-        Write-Log "Creating directory: $dir" -Level Verbose
+        Write-Log -Message "Creating directory: $dir" -Level Verbose
         New-Item -Force -ItemType Directory -Path $dir | Out-Null
-        Write-Log "Created directory." -Level Verbose
+        Write-Log -Message "Created directory." -Level Verbose
     }
 
     $sourcePath = Join-Path -Path $PSScriptRoot -ChildPath $script:defaultConfigFileName
@@ -409,9 +409,9 @@ function New-StoreBrokerConfigFile
         $template = Get-StoreBrokerConfigFileContentForAppId -ConfigContent $template -AppId $AppId
     }
 
-    Write-Log "Copying (Item: $sourcePath) to (Target: $Path)." -Level Verbose
+    Write-Log -Message "Copying (Item: $sourcePath) to (Target: $Path)." -Level Verbose
     Set-Content -Path $Path -Value $template -Encoding UTF8 -Force
-    Write-Log "Copy complete." -Level Verbose
+    Write-Log -Message "Copy complete." -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
     Set-TelemetryEvent -EventName New-StoreBrokerConfigFile -Properties $telemetryProperties
@@ -470,9 +470,9 @@ function Out-DirectoryToZip
             {
                 if (Test-Path -PathType Leaf -Include "*.zip" -Path $zipPath)
                 {
-                    Write-Log "Removing zip path: [$zipPath]." -Level Verbose
+                    Write-Log -Message "Removing zip path: [$zipPath]." -Level Verbose
                     Remove-Item -Force -Recurse -Path $zipPath
-                    Write-Log "Removal complete." -Level Verbose
+                    Write-Log -Message "Removal complete." -Level Verbose
                 }
             }
 
@@ -484,22 +484,22 @@ function Out-DirectoryToZip
             $compressionLevel = [System.IO.Compression.CompressionLevel]::NoCompression
             $includeBaseDir = $false
 
-            Write-Log "Compressing [$Path] to [$tempLocalZipPath]." -Level Verbose
+            Write-Log -Message "Compressing [$Path] to [$tempLocalZipPath]." -Level Verbose
             [System.IO.Compression.ZipFile]::CreateFromDirectory($Path, $tempLocalZipPath, $compressionLevel, $includeBaseDir)
-            Write-Log "Compression complete." -Level Verbose
+            Write-Log -Message "Compression complete." -Level Verbose
 
-            Write-Log "Moving [$tempLocalZipPath] to [$Destination]." -Level Verbose
+            Write-Log -Message "Moving [$tempLocalZipPath] to [$Destination]." -Level Verbose
             Move-Item -Force -Path $tempLocalZipPath -Destination $Destination
-            Write-Log "Move complete." -Level Verbose
+            Write-Log -Message "Move complete." -Level Verbose
         }
     }
     finally
     {
         if ($null -ne $tempLocalZipDir)
         {
-            Write-Log "Removing temporary directory: [$tempLocalZipDir]." -Level Verbose
+            Write-Log -Message "Removing temporary directory: [$tempLocalZipDir]." -Level Verbose
             Remove-Item -Force -Recurse -Path $tempLocalZipDir -ErrorAction Ignore
-            Write-Log "Removal complete." -Level Verbose
+            Write-Log -Message "Removal complete." -Level Verbose
         }
     }
 }
@@ -529,13 +529,13 @@ function Write-SubmissionRequestBody
     {
         Ensure-Directory -Path (Split-Path -Parent -Path $OutFilePath)
 
-        Write-Log "Writing submission request JSON file: [$OutFilePath]." -Level Verbose
+        Write-Log -Message "Writing submission request JSON file: [$OutFilePath]." -Level Verbose
 
         $JsonObject |
             ConvertTo-Json -Depth $script:jsonConversionDepth -Compress |
             Out-File -Encoding utf8 -FilePath $OutFilePath
 
-        Write-Log "Writing complete." -Level Verbose
+        Write-Log -Message "Writing complete." -Level Verbose
     }
 }
 
@@ -635,7 +635,7 @@ function Test-Xml
         $script:validationErrors | ForEach-Object { $msg += $_ }
         $msg = $msg -join [Environment]::NewLine
 
-        Write-Log $msg -Level Error
+        Write-Log -Message $msg -Level Error
         throw $msg
     }
 }
@@ -724,7 +724,7 @@ function Convert-ListingToObject
                     if ($language -in $LanguageExclude)
                     {
                         $out = "Skipping file '$xmlFilePath' because its lang-code '$language' is in the language exclusion list."
-                        Write-Log $out -Level Verbose
+                        Write-Log -Message $out -Level Verbose
 
                         return
                     }
@@ -859,7 +859,7 @@ function Convert-ListingToObject
                 catch [System.InvalidCastException]
                 {
                     $output = "Provided .xml file is not a valid .xml document: $xmlFilePath"
-                    Write-Log $output -Level Error
+                    Write-Log -Message $output -Level Error
                     throw $output
                 }
             }
@@ -947,7 +947,7 @@ function Get-LocalizedMediaFile
         $mediaFallbackLanguageSourcePath = [System.IO.Path]::Combine($ImagesRootPath, $Release, $MediaFallbackLanguage)
         if (-not (Test-Path -Path $mediaFallbackLanguageSourcePath -PathType Container))
         {
-            Write-Log "A fallback language was specified [$MediaFallbackLanguage], but a folder for that language does not exist [$mediaFallbackLanguageSourcePath], so media fallback support has been disabled." -Level Warning
+            Write-Log -Message "A fallback language was specified [$MediaFallbackLanguage], but a folder for that language does not exist [$mediaFallbackLanguageSourcePath], so media fallback support has been disabled." -Level Warning
             $mediaFallbackLanguageSourcePath = $null
         }
     }
@@ -960,7 +960,7 @@ function Get-LocalizedMediaFile
 
     if (($null -eq $image) -and ($null -ne $mediaFallbackLanguageSourcePath))
     {
-        Write-Log "[$Language] version of $Filename not found.  Using fallback language [$MediaFallbackLanguage] version." -Level Verbose
+        Write-Log -Message "[$Language] version of $Filename not found.  Using fallback language [$MediaFallbackLanguage] version." -Level Verbose
         $image = Get-ChildItem -Recurse -File -Path $mediaFallbackLanguageSourcePath -Include $Filename
         $fileRelativePackagePath = [System.IO.Path]::Combine($script:packageImageFolderName, $MediaFallbackLanguage, $Filename)
     }
@@ -973,14 +973,14 @@ function Get-LocalizedMediaFile
             $output += " Image also not found in fallback language location [$mediaFallbackLanguageSourcePath]";
         }
 
-        Write-Log $output -Level Error
+        Write-Log -Message $output -Level Error
         throw $output
     }
 
     if ($image.Count -gt 1)
     {
         $output = "More then one version of [$Filename] has been found for this language. Please ensure only one copy of this image exists within the language's sub-folders: [$($image.FullName -join ', ')]"
-        Write-Log $output -Level Warning
+        Write-Log -Message $output -Level Warning
         #throw $output
     }
 
@@ -1081,13 +1081,13 @@ function Convert-ListingsMetadata
 
     $listings = @{}
 
-    Write-Log "Converting application listings metadata." -Level Verbose
+    Write-Log -Message "Converting application listings metadata." -Level Verbose
 
     (Get-ChildItem -File $PDPRootPath -Recurse -Include $PDPInclude -Exclude $PDPExclude).FullName |
         Convert-ListingToObject -PDPRootPath $PDPRootPath -LanguageExclude $LanguageExclude -ImagesRootPath $ImagesRootPath -MediaFallbackLanguage $MediaFallbackLanguage |
         ForEach-Object { $listings[$_."lang"] = $_."listing" }
 
-    Write-Log "Conversion complete." -Level Verbose
+    Write-Log -Message "Conversion complete." -Level Verbose
 
     return $listings
 }
@@ -1173,7 +1173,7 @@ function Convert-InAppProductListingToObject
                     if ($language -in $LanguageExclude)
                     {
                         $out = "Skipping file '$xmlFilePath' because its lang-code '$language' is in the language exclusion list."
-                        Write-Log $out -Level Verbose
+                        Write-Log -Message $out -Level Verbose
 
                         return
                     }
@@ -1248,7 +1248,7 @@ function Convert-InAppProductListingToObject
                 catch [System.InvalidCastException]
                 {
                     $output = "Provided .xml file is not a valid .xml document: $xmlFilePath"
-                    Write-Log $output -Level Error
+                    Write-Log -Message $output -Level Error
                     throw $output
                 }
             }
@@ -1338,13 +1338,13 @@ function Convert-InAppProductListingsMetadata
 
     $listings = @{}
 
-    Write-Log "Converting IAP listings metadata." -Level Verbose
+    Write-Log -Message "Converting IAP listings metadata." -Level Verbose
 
     (Get-ChildItem -File $PDPRootPath -Recurse -Include $PDPInclude -Exclude $PDPExclude).FullName |
         Convert-InAppProductListingToObject -PDPRootPath $PDPRootPath -LanguageExclude $LanguageExclude -ImagesRootPath $ImagesRootPath -MediaFallbackLanguage $MediaFallbackLanguage |
         ForEach-Object { $listings[$_."lang"] = $_."listing" }
 
-    Write-Log "Conversion complete." -Level Verbose
+    Write-Log -Message "Conversion complete." -Level Verbose
 
     return $listings
 }
@@ -1395,16 +1395,16 @@ function Open-AppxContainer
         }
         while (Test-Path -PathType Leaf -Path $containerZipPath)
 
-        Write-Log "Copying (Item: $AppxContainerPath) to (Target: $containerZipPath)." -Level Verbose
+        Write-Log -Message "Copying (Item: $AppxContainerPath) to (Target: $containerZipPath)." -Level Verbose
         Copy-Item -Force -Path $AppxContainerPath -Destination $containerZipPath
-        Write-Log "Copy complete." -Level Verbose
+        Write-Log -Message "Copy complete." -Level Verbose
 
         # Expand CONTAINER.appxcontainer.zip to CONTAINER folder
         $expandedContainerPath = New-TemporaryDirectory
 
-        Write-Log "Unzipping archive (Item: $containerZipPath) to (Target: $expandedContainerPath)." -Level Verbose
+        Write-Log -Message "Unzipping archive (Item: $containerZipPath) to (Target: $expandedContainerPath)." -Level Verbose
         [System.IO.Compression.ZipFile]::ExtractToDirectory($containerZipPath, $expandedContainerPath)
-        Write-Log "Unzip complete." -Level Verbose
+        Write-Log -Message "Unzip complete." -Level Verbose
 
         return $expandedContainerPath
     }
@@ -1412,9 +1412,9 @@ function Open-AppxContainer
     {
         if ((-not [System.String]::IsNullOrEmpty($expandedContainerPath)) -and (Test-Path $expandedContainerPath))
         {
-            Write-Log "Deleting item: $expandedContainerPath" -Level Verbose
+            Write-Log -Message "Deleting item: $expandedContainerPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $expandedContainerPath -ErrorAction SilentlyContinue
-            Write-Log "Deletion complete." -Level Verbose
+            Write-Log -Message "Deletion complete." -Level Verbose
         }
 
         throw
@@ -1423,9 +1423,9 @@ function Open-AppxContainer
     {
         if ((-not [System.String]::IsNullOrEmpty($containerZipPath)) -and (Test-Path $containerZipPath))
         {
-            Write-Log "Deleting item: $containerZipPath" -Level Verbose
+            Write-Log -Message "Deleting item: $containerZipPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $containerZipPath -ErrorAction SilentlyContinue
-            Write-Log "Deletion complete." -Level Verbose
+            Write-Log -Message "Deletion complete." -Level Verbose
         }
     }
 }
@@ -1523,7 +1523,7 @@ function Get-TargetPlatform
     $minOSVersion = $root.Prerequisites.OSMinVersion
     if ([String]::IsNullOrEmpty($minOSVersion))
     {
-        Write-Log "Could not find OSMinVersion in [$AppxManifestPath]" -Level Warning
+        Write-Log -Message "Could not find OSMinVersion in [$AppxManifestPath]" -Level Warning
         return $null
     }
 
@@ -1600,7 +1600,7 @@ function Read-AppxMetadata
             throw "`"$AppxPath`" is not a proper .appx. Could not find an AppxManifest.xml."
         }
 
-        Write-Log "Opening `"$appxManifest`"." -Level Verbose
+        Write-Log -Message "Opening `"$appxManifest`"." -Level Verbose
         $manifest = [xml] (Get-Content -Path $appxManifest -Encoding UTF8)
 
 
@@ -1654,9 +1654,9 @@ function Read-AppxMetadata
     {
         if (-not [String]::IsNullOrWhiteSpace($expandedAppxPath))
         {
-            Write-Log "Deleting item: $expandedAppxPath" -Level Verbose
+            Write-Log -Message "Deleting item: $expandedAppxPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $expandedAppxPath -ErrorAction SilentlyContinue | Out-Null
-            Write-Log "Deletion complete." -Level Verbose
+            Write-Log -Message "Deletion complete." -Level Verbose
         }
     }
 
@@ -1716,7 +1716,7 @@ function Read-AppxUploadMetadata
     {
         $throwFormat = "`"$AppxuploadPath`" is not a proper .appxupload. There must be exactly one {0} inside the file."
 
-        Write-Log "Opening `"$AppxuploadPath`"." -Level Verbose
+        Write-Log -Message "Opening `"$AppxuploadPath`"." -Level Verbose
         $expandedContainerPath = Open-AppxContainer -AppxContainerPath $AppxPath
 
         $appxFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include "*.appx").FullName
@@ -1727,7 +1727,7 @@ function Read-AppxUploadMetadata
                 Report-UnsupportedFile -Path $AppxuploadPath
 
                 $error = $throwFormat -f ".appx"
-                Write-Log $error -Level Error
+                Write-Log -Message $error -Level Error
                 throw $error
             }
             else
@@ -1743,7 +1743,7 @@ function Read-AppxUploadMetadata
             Report-UnsupportedFile -Path $AppxuploadPath
 
             $error = $throwFormat -f ".appx or .appxbundle"
-            Write-Log $error -Level Error
+            Write-Log -Message $error -Level Error
             throw $error
         }
         else
@@ -1755,9 +1755,9 @@ function Read-AppxUploadMetadata
     {
         if (-not [String]::IsNullOrWhiteSpace($expandedContainerPath))
         {
-            Write-Log "Deleting item: $expandedContainerPath" -Level Verbose
+            Write-Log -Message "Deleting item: $expandedContainerPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $expandedContainerPath -ErrorAction SilentlyContinue | Out-Null
-            Write-Log "Deletion complete." -Level Verbose
+            Write-Log -Message "Deletion complete." -Level Verbose
         }
     }
 }
@@ -1821,7 +1821,7 @@ function Read-AppxBundleMetadata
             throw "`"$AppxbundlePath`" is not a proper .appxbundle. Could not find an AppxBundleManifest.xml."
         }
 
-        Write-Log "Opening `"$bundleManifestPath`"." -Level Verbose
+        Write-Log -Message "Opening `"$bundleManifestPath`"." -Level Verbose
         $manifest = [xml] (Get-Content -Path $bundleManifestPath -Encoding UTF8)
 
 
@@ -1886,9 +1886,9 @@ function Read-AppxBundleMetadata
     {
         if (-not [String]::IsNullOrWhiteSpace($expandedContainerPath))
         {
-            Write-Log "Deleting item: $expandedContainerPath" -Level Verbose
+            Write-Log -Message "Deleting item: $expandedContainerPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $expandedContainerPath -ErrorAction SilentlyContinue | Out-Null
-            Write-Log "Deletion complete." -Level Verbose
+            Write-Log -Message "Deletion complete." -Level Verbose
         }
     }
 
@@ -2107,7 +2107,7 @@ function Add-AppPackagesMetadata
         if ($PSCmdlet.ShouldProcess($path))
         {
 
-            Write-Log "Processing [$path]" -Level Verbose
+            Write-Log -Message "Processing [$path]" -Level Verbose
 
             $appxName = Split-Path -Leaf -Path $path
 
@@ -2137,9 +2137,9 @@ function Add-AppPackagesMetadata
             {
                 $destinationPath = Join-Path $script:tempFolderPath $appxName
 
-                Write-Log "Copying (Item: $path) to (Target: $destinationPath)" -Level Verbose
+                Write-Log -Message "Copying (Item: $path) to (Target: $destinationPath)" -Level Verbose
                 Copy-Item -Path $path -Destination $destinationPath
-                Write-Log "Copy complete." -Level Verbose
+                Write-Log -Message "Copy complete." -Level Verbose
             }
 
             $SubmissionObject.applicationPackages += $appPackageObject
@@ -2322,7 +2322,7 @@ function Get-SubmissionRequestBody
                 $out += "Check the values of '$script:s_PDPRootPath' and '$script:s_Release' and try again."
 
                 $newLineOutput = ($out -join [Environment]::NewLine)
-                Write-Log $newLineOutput -Level Error
+                Write-Log -Message $newLineOutput -Level Error
                 throw $newLineOutput
             }
         }
@@ -2451,7 +2451,7 @@ function Get-InAppProductSubmissionRequestBody
                 $out += "Check the values of '$script:s_PDPRootPath' and '$script:s_Release' and try again."
 
                 $newLineOutput = ($out -join [Environment]::NewLine)
-                Write-Log $newLineOutput -Level Error
+                Write-Log -Message $newLineOutput -Level Error
                 throw $newLineOutput
             }
         }
@@ -2539,7 +2539,7 @@ function Resolve-PackageParameters
             if (-not [String]::IsNullOrWhiteSpace($configVal))
             {
                 $ParamMap[$param] = $configVal
-                Write-Log ($fromConfig -f $param, $configVal) -Level Verbose
+                Write-Log -Message ($fromConfig -f $param, $configVal) -Level Verbose
             }
         }
 
@@ -2554,7 +2554,7 @@ function Resolve-PackageParameters
             {
                 $out = "$($param): `"$($ParamMap[$param])`" is not a directory or cannot be found."
 
-                Write-Log $out -Level Error
+                Write-Log -Message $out -Level Error
                 throw $out
             }
         }
@@ -2571,7 +2571,7 @@ function Resolve-PackageParameters
             $out += "If one of these parameters is specified, then both must be specified."
 
             $newLineOutput = ($out -join [Environment]::NewLine)
-            Write-Log $newLineOutput -Level Error
+            Write-Log -Message $newLineOutput -Level Error
             throw $newLineOutput
         }
     }
@@ -2586,13 +2586,13 @@ function Resolve-PackageParameters
             if ([System.String]::IsNullOrWhiteSpace($configVal))
             {
                 $output = ($out -f $script:s_OutPath)
-                Write-Log $output -Level Error
+                Write-Log -Message $output -Level Error
                 throw $output
             }
             else
             {
                 $ParamMap[$script:s_OutPath] = $configVal
-                Write-Log ($fromConfig -f $script:s_OutPath, $configVal) -Level Verbose
+                Write-Log -Message ($fromConfig -f $script:s_OutPath, $configVal) -Level Verbose
             }
         }
 
@@ -2610,13 +2610,13 @@ function Resolve-PackageParameters
             if ([System.String]::IsNullOrWhiteSpace($configVal))
             {
                 $output = ($out -f $script:s_OutName)
-                Write-Log $output -Level Error
+                Write-Log -Message $output -Level Error
                 throw $output
             }
             else
             {
                 $ParamMap[$script:s_OutName] = $configVal
-                Write-Log ($fromConfig -f $script:s_OutName, $configVal) -Level Verbose
+                Write-Log -Message ($fromConfig -f $script:s_OutName, $configVal) -Level Verbose
             }
         }
     }
@@ -2629,7 +2629,7 @@ function Resolve-PackageParameters
         if (-not [String]::IsNullOrWhiteSpace($configVal))
         {
             $ParamMap[$script:s_Release] = $configVal
-            Write-Log ($fromConfig -f $script:s_Release, $configVal) -Level Verbose
+            Write-Log -Message ($fromConfig -f $script:s_Release, $configVal) -Level Verbose
         }
     }
 
@@ -2643,7 +2643,7 @@ function Resolve-PackageParameters
             if ($configVal.Count -gt 0)
             {
                 $ParamMap[$param] = $configVal
-                Write-Log ($fromConfig -f $param, ($configVal -join ', ')) -Level Verbose
+                Write-Log -Message ($fromConfig -f $param, ($configVal -join ', ')) -Level Verbose
             }
         }
 
@@ -2655,7 +2655,7 @@ function Resolve-PackageParameters
     if ($ParamMap[$script:s_PDPInclude].Count -eq 0)
     {
         $ParamMap[$script:s_PDPInclude] = @("*.xml")
-        Write-Log "`tUsing default value: $script:s_PDPInclude = `"*.xml`"" -Level Verbose
+        Write-Log -Message "`tUsing default value: $script:s_PDPInclude = `"*.xml`"" -Level Verbose
     }
 
     if ($SkipValidation -inotcontains $script:s_AppxPath)
@@ -2678,7 +2678,7 @@ function Resolve-PackageParameters
                     $out += "See the `"$script:s_AppxPath`" object in the config file."
 
                     $newLineOutput = ($out -join [Environment]::NewLine)
-                    Write-Log $newLineOutput -Level Error
+                    Write-Log -Message $newLineOutput -Level Error
                     throw $newLineOutput
                 }
                 else
@@ -2706,7 +2706,7 @@ function Resolve-PackageParameters
                         $out += "See the `"$script:s_AppxPath`" object in the config file."
 
                         $newLineOutput = ($out -join [Environment]::NewLine)
-                        Write-Log $newLineOutput -Level Error
+                        Write-Log -Message $newLineOutput -Level Error
                         throw $newLineOutput
                     }
                 }
@@ -2714,7 +2714,7 @@ function Resolve-PackageParameters
 
             $ParamMap[$script:s_AppxPath] = $packagePaths
             $quotedVals = $packagePaths | ForEach-Object { "`"$_`"" }
-            Write-Log ($fromConfig -f $script:s_AppxPath, ($quotedVals -join ', ')) -Level Verbose
+            Write-Log -Message ($fromConfig -f $script:s_AppxPath, ($quotedVals -join ', ')) -Level Verbose
         }
 
         # Resolve AppxPath to a list of full paths.
@@ -2735,7 +2735,7 @@ function Resolve-PackageParameters
             }
 
             $ParamMap[$script:s_DisableAutoPackageNameFormatting] = $configVal
-            Write-Log ($fromConfig -f $script:s_DisableAutoPackageNameFormatting, $configVal) -Level Verbose
+            Write-Log -Message ($fromConfig -f $script:s_DisableAutoPackageNameFormatting, $configVal) -Level Verbose
         }
     }
 
@@ -2747,7 +2747,7 @@ function Resolve-PackageParameters
         if (-not [String]::IsNullOrWhiteSpace($configVal))
         {
             $ParamMap[$script:s_MediaFallbackLanguage] = $configVal
-            Write-Log ($fromConfig -f $script:s_MediaFallbackLanguage, $configVal) -Level Verbose
+            Write-Log -Message ($fromConfig -f $script:s_MediaFallbackLanguage, $configVal) -Level Verbose
         }
     }
 
@@ -2926,17 +2926,17 @@ function Join-SubmissionPackage
     $outUnpackedZipPath = New-TemporaryDirectory
     if ($PSCmdlet.ShouldProcess($masterZipPath, "Unzip"))
     {
-        Write-Log "Unzipping archive [$masterZipPath] to [$outUnpackedZipPath]" -Level Verbose
+        Write-Log -Message "Unzipping archive [$masterZipPath] to [$outUnpackedZipPath]" -Level Verbose
         [System.IO.Compression.ZipFile]::ExtractToDirectory($masterZipPath, $outUnpackedZipPath)
-        Write-Log "Unzip complete." -Level Verbose
+        Write-Log -Message "Unzip complete." -Level Verbose
     }
 
     $additionalUnpackedZipPath = New-TemporaryDirectory
     if ($PSCmdlet.ShouldProcess($additionalZipPath, "Unzip"))
     {
-        Write-Log "Unzipping archive [$additionalZipPath] to [$additionalUnpackedZipPath]" -Level Verbose
+        Write-Log -Message "Unzipping archive [$additionalZipPath] to [$additionalUnpackedZipPath]" -Level Verbose
         [System.IO.Compression.ZipFile]::ExtractToDirectory($additionalZipPath, $additionalUnpackedZipPath)
-        Write-Log "Unzip complete." -Level Verbose
+        Write-Log -Message "Unzip complete." -Level Verbose
     }
 
     # out json content will be based off of master, so we can just consider master's json as "out"
@@ -2947,7 +2947,7 @@ function Join-SubmissionPackage
     {
         # We copy over all package changes from the "AdditionalJson", including package removals,
         # package uploads and specified retention of existing packages.
-        Write-Log "Adding applicationPackages from [$AdditionalJsonPath] to [$OutJsonPath]" -Level Verbose
+        Write-Log -Message "Adding applicationPackages from [$AdditionalJsonPath] to [$OutJsonPath]" -Level Verbose
         $outJsonContent.applicationPackages += $additionalJsonContent.applicationPackages
 
         # Copy packages from Additional over to Master
@@ -2962,14 +2962,14 @@ function Join-SubmissionPackage
                 if (Test-Path $destPath -PathType Leaf)
                 {
                     $output = "A package called [$($package.fileName)] already exists in the Master zip file."
-                    Write-Log $output -Level Error
+                    Write-Log -Message $output -Level Error
                     throw $output
                 }
 
                 $sourcePath = Join-Path $additionalUnpackedZipPath $package.fileName
-                Write-Log "Copying [$sourcePath] to [$destPath]" -Level Verbose
+                Write-Log -Message "Copying [$sourcePath] to [$destPath]" -Level Verbose
                 Copy-Item -Path $sourcePath -Destination $destPath
-                Write-Log "Copy complete." -Level Verbose
+                Write-Log -Message "Copy complete." -Level Verbose
             }
         }
     }
@@ -2980,20 +2980,20 @@ function Join-SubmissionPackage
     # Output the merged json
     if ($PSCmdlet.ShouldProcess($OutJsonPath, "Create json"))
     {
-        Write-Log "Writing merged JSON file: [$OutJsonPath]." -Level Verbose
+        Write-Log -Message "Writing merged JSON file: [$OutJsonPath]." -Level Verbose
 
         $outJsonContent |
             ConvertTo-Json -Depth $script:jsonConversionDepth -Compress |
             Out-File -Encoding utf8 -FilePath $OutJsonPath
 
-        Write-Log "Write complete." -Level Verbose
+        Write-Log -Message "Write complete." -Level Verbose
     }
 
     # Clean up the temp directories
-    Write-Log "Cleaning up temp directories..." -Level Verbose
+    Write-Log -Message "Cleaning up temp directories..." -Level Verbose
     Remove-Item -Path $outUnpackedZipPath -Recurse -Force -ErrorAction SilentlyContinue
     Remove-Item -Path $additionalUnpackedZipPath -Recurse -Force -ErrorAction SilentlyContinue
-    Write-Log "Cleaning up temp directories complete." -Level Verbose
+    Write-Log -Message "Cleaning up temp directories complete." -Level Verbose
 }
 
 function New-SubmissionPackage
@@ -3157,8 +3157,8 @@ function New-SubmissionPackage
         Add-Type -AssemblyName System.IO.Compression.FileSystem
 
         # Preamble before printing invocation parameters
-        Write-Log "New-SubmissionPackage invoked with parameters:" -Level Verbose
-        Write-Log "`t$script:s_ConfigPath = `"$ConfigPath`"" -Level Verbose
+        Write-Log -Message "New-SubmissionPackage invoked with parameters:" -Level Verbose
+        Write-Log -Message "`t$script:s_ConfigPath = `"$ConfigPath`"" -Level Verbose
 
         # Check the value of each parameter and add to parameter hashtable if not null.
         # Resolve-PackageParameters will take care of validating the values, we only need
@@ -3181,7 +3181,7 @@ function New-SubmissionPackage
                 # Treat the value as if it is an array.
                 # If it's not, it will still pretty print fine.
                 $quotedVals = $val | ForEach-Object { "`"$_`"" }
-                Write-Log "`t$param = $($quotedVals -join ', ')" -Level Verbose
+                Write-Log -Message "`t$param = $($quotedVals -join ', ')" -Level Verbose
             }
         }
 
@@ -3261,9 +3261,9 @@ function New-SubmissionPackage
     {
         if ($script:tempFolderExists)
         {
-            Write-Log "Deleting temporary directory: $script:tempFolderPath" -Level Verbose
+            Write-Log -Message "Deleting temporary directory: $script:tempFolderPath" -Level Verbose
             Remove-Item -Force -Recurse $script:tempFolderPath -ErrorAction SilentlyContinue
-            Write-Log "Deleting temporary directory complete." -Level Verbose
+            Write-Log -Message "Deleting temporary directory complete." -Level Verbose
         }
     }
 }
@@ -3397,8 +3397,8 @@ function New-InAppProductSubmissionPackage
         Add-Type -AssemblyName System.IO.Compression.FileSystem
 
         # Preamble before printing invocation parameters
-        Write-Log "New-InAppProductSubmissionPackage invoked with parameters:" -Level Verbose
-        Write-Log "`t$script:s_ConfigPath = `"$ConfigPath`"" -Level Verbose
+        Write-Log -Message "New-InAppProductSubmissionPackage invoked with parameters:" -Level Verbose
+        Write-Log -Message "`t$script:s_ConfigPath = `"$ConfigPath`"" -Level Verbose
 
         # Check the value of each parameter and add to parameter hashtable if not null.
         # Resolve-PackageParameters will take care of validating the values, we only need
@@ -3421,7 +3421,7 @@ function New-InAppProductSubmissionPackage
                 # Treat the value as if it is an array.
                 # If it's not, it will still pretty print fine.
                 $quotedVals = $val | ForEach-Object { "`"$_`"" }
-                Write-Log "`t$param = $($quotedVals -join ', ')" -Level Verbose
+                Write-Log -Message "`t$param = $($quotedVals -join ', ')" -Level Verbose
             }
         }
 
@@ -3480,9 +3480,9 @@ function New-InAppProductSubmissionPackage
     {
         if ($script:tempFolderExists)
         {
-            Write-Log "Deleting temporary directory: $script:tempFolderPath" -Level Verbose
+            Write-Log -Message "Deleting temporary directory: $script:tempFolderPath" -Level Verbose
             Remove-Item -Force -Recurse $script:tempFolderPath -ErrorAction SilentlyContinue
-            Write-Log "Deleting temporary directory complete." -Level Verbose
+            Write-Log -Message "Deleting temporary directory complete." -Level Verbose
         }
     }
 }

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -2914,12 +2914,11 @@ function Join-SubmissionPackage
     # At the moment, the only switch supported is AddPackages, but this may change over time.
     if (-not $AddPackages)
     {
-        $output = @()
-        $output += "You have not specified any `"modification`" switch for joining the packages."
-        $output += "This means that the new package payload will be identical to the Master [$MasterJsonPath]."
-        $output += "If this was not your intention, please read-up on the documentation for this command:"
-        $output += "     Get-Help Join-PackagePayload -ShowWindow"
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "You have not specified any `"modification`" switch for joining the packages.",
+            "This means that the new package payload will be identical to the Master [$MasterJsonPath].",
+            "If this was not your intention, please read-up on the documentation for this command:",
+            "     Get-Help Join-PackagePayload -ShowWindow")
     }
 
     # Unpack the zips

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -74,7 +74,7 @@ function Get-StoreBrokerConfigFileContentForIapId
         Assuming that $template has the content of the template file read in from disk and
         merged into a single string, this then gets the most recent IAP submission for
         IapId 0ABCDEF12345 and replaces the default values in the template with those from
-        that submission. 
+        that submission.
 
     .OUTPUTS
         System.String - The template content modified with the values from the
@@ -141,7 +141,7 @@ function Get-StoreBrokerConfigFileContentForIapId
     }
     catch
     {
-        Write-Log "Encountered problems getting current In-App Product submission values: $($_.Exception.Message)" -Level Error
+        Write-Log "Encountered problems getting current In-App Product submission values:" -Exception $_ -Level Error
         throw
     }
 }
@@ -248,7 +248,7 @@ function Get-StoreBrokerConfigFileContentForAppId
         Assuming that $template has the content of the template file read in from disk and
         merged into a single string, this then gets the most recent app submission for
         AppId 0ABCDEF12345 and replaces the default values in the template with those from
-        that submission. 
+        that submission.
 
     .OUTPUTS
         System.String - The template content modified with the values from the
@@ -336,7 +336,7 @@ function Get-StoreBrokerConfigFileContentForAppId
     }
     catch
     {
-        Write-Log "Encountered problems getting current application submission values: $($_.Exception.Message)" -Level Error
+        Write-Log "Encountered problems getting current application submission values:" -Exception $_ -Level Error
         throw
     }
 }
@@ -610,7 +610,7 @@ function Test-Xml
     }
 
     $reader = New-Object System.Xml.XmlTextReader $XsdFile
-    
+
     try
     {
         $schema = [System.Xml.Schema.XmlSchema]::Read($reader, $handler)
@@ -645,7 +645,7 @@ function Convert-ListingToObject
 <#
     .SYNOPSIS
         Consumes a single localized .xml file into a listing object.
-        
+
     .DESCRIPTION
         Consumes a single localized .xml file into a listing object.
         If a node has only content, then that content is assigned.
@@ -669,7 +669,7 @@ function Convert-ListingToObject
 
     .PARAMETER XmlFilePath
         A full path to the localized .xml file to be parsed.
-        
+
     .PARAMETER MediaFallbackLanguage
         Some apps may not localize all of their metadata media (images, trailers, etc..)
         across all languages.  By default, StoreBroker will look in the PDP langcode's subfolder
@@ -754,14 +754,14 @@ function Convert-ListingToObject
                     # Must be done in two steps because $baseListings can't be modified
                     # while enumerating its keys.
                     $trimKeys = $baseListing.Keys |
-                        Where-Object { ($null -ne $baseListing[$_].InnerText) -or ($baseListing[$_] -is [String]) } 
+                        Where-Object { ($null -ne $baseListing[$_].InnerText) -or ($baseListing[$_] -is [String]) }
 
-                    $trimKeys | ForEach-Object { 
+                    $trimKeys | ForEach-Object {
                         if ($null -ne $baseListing[$_].InnerText)
                         {
                             $baseListing[$_] = $baseListing[$_].InnerText
                         }
-                        
+
                         $baseListing[$_] = $baseListing[$_].Trim()
                     }
 
@@ -771,7 +771,7 @@ function Convert-ListingToObject
                     {
                         $baseListing['title'] = $null
                     }
-        
+
                     # Nodes with children need to have each value extracted into an array.
                     # When using -Confirm, PS will ask user to confirm selecting 'InnerText'.
                     # Explicitly set -Confirm:$false to prevent this dialog from reaching the user.
@@ -780,12 +780,12 @@ function Convert-ListingToObject
                         "keywords"            = $ProductDescriptionNode.Keywords;
                         "recommendedHardware" = $ProductDescriptionNode.RecommendedHardware;
                     }.GetEnumerator() | ForEach-Object {
-                        $baseListing[$_.Name] = @($_.Value.ChildNodes | 
+                        $baseListing[$_.Name] = @($_.Value.ChildNodes |
                                                     Where-Object NodeType -eq Element |
                                                     ForEach-Object -WhatIf:$false -Confirm:$false InnerText |
                                                     Where-Object { $_ -ne $null } |
                                                     ForEach-Object { $_.Trim() })
-                    }           
+                    }
 
                     # Handle screenshots and their captions.
                     $imageListings = @()
@@ -806,7 +806,7 @@ function Convert-ListingToObject
                         {
                             $imageFileName = $caption.$member
                             if (-not [System.String]::IsNullOrWhiteSpace($imageFileName))
-                            { 
+                            {
                                 # We start with the fallback language specified on an individual caption.
                                 # If one is not specified, then we'll look to see if there is one specified
                                 # for all captions on the ScreenshotCaptions element.  If one is not specified
@@ -964,7 +964,7 @@ function Get-LocalizedMediaFile
         $image = Get-ChildItem -Recurse -File -Path $mediaFallbackLanguageSourcePath -Include $Filename
         $fileRelativePackagePath = [System.IO.Path]::Combine($script:packageImageFolderName, $MediaFallbackLanguage, $Filename)
     }
-            
+
     if ($null -eq $image)
     {
         $output = "Could not find image [$Filename] in any subdirectory of [$mediaLanguageSourcePath]."
@@ -992,7 +992,7 @@ function Get-LocalizedMediaFile
         {
             New-Item -ItemType directory -Path $packageMediaFullPath | Out-Null
         }
-        
+
         Copy-Item -Path $image.FullName -Destination $fileFullPackagePath
     }
 
@@ -1050,7 +1050,7 @@ function Convert-ListingsMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true } 
+            if (Test-Path -PathType Container -Path $_) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [string] $PDPRootPath,
 
@@ -1070,7 +1070,7 @@ function Convert-ListingsMetadata
         [string[]] $LanguageExclude,
 
         [Parameter(Mandatory)]
-        [ValidateScript( { 
+        [ValidateScript( {
             if (Test-Path -PathType Container -Path $_) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [Alias('MediaRootPath')]
@@ -1097,7 +1097,7 @@ function Convert-InAppProductListingToObject
 <#
     .SYNOPSIS
         Consumes a single localized .xml file into an In-App Product listing object.
-        
+
     .DESCRIPTION
         Consumes a single localized .xml file into an In-App Product listing object.
         If a node has only content, then that content is assigned.
@@ -1197,14 +1197,14 @@ function Convert-InAppProductListingToObject
                     # Must be done in two steps because $listings can't be modified
                     # while enumerating its keys.
                     $trimKeys = $listing.Keys |
-                        Where-Object { ($null -ne $listing[$_].InnerText) -or ($listing[$_] -is [String]) } 
+                        Where-Object { ($null -ne $listing[$_].InnerText) -or ($listing[$_] -is [String]) }
 
-                    $trimKeys | ForEach-Object { 
+                    $trimKeys | ForEach-Object {
                         if ($null -ne $listing[$_].InnerText)
                         {
                             $listing[$_] = $listing[$_].InnerText
                         }
-                        
+
                         $listing[$_] = $listing[$_].Trim()
                     }
 
@@ -1214,11 +1214,11 @@ function Convert-InAppProductListingToObject
                     {
                         $listing['title'] = $null
                     }
-        
+
                     # Handle the icon for the IAP.
                     $imageFileName = $InAppProductDescriptionNode.icon.fileName
                     if (-not [System.String]::IsNullOrWhiteSpace($imageFileName))
-                    { 
+                    {
                         $requestedFallbackLanguage = $InAppProductDescriptionNode.icon.FallbackLanguage
                         if ([String]::IsNullOrWhiteSpace($requestedFallbackLanguage))
                         {
@@ -1307,7 +1307,7 @@ function Convert-InAppProductListingsMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true } 
+            if (Test-Path -PathType Container -Path $_) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [string] $PDPRootPath,
 
@@ -1327,7 +1327,7 @@ function Convert-InAppProductListingsMetadata
         [string[]] $LanguageExclude,
 
         [Parameter(Mandatory)]
-        [ValidateScript({ 
+        [ValidateScript({
             if (Test-Path -PathType Container -Path $_) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [Alias('MediaRootPath')]
@@ -1343,7 +1343,7 @@ function Convert-InAppProductListingsMetadata
     (Get-ChildItem -File $PDPRootPath -Recurse -Include $PDPInclude -Exclude $PDPExclude).FullName |
         Convert-InAppProductListingToObject -PDPRootPath $PDPRootPath -LanguageExclude $LanguageExclude -ImagesRootPath $ImagesRootPath -MediaFallbackLanguage $MediaFallbackLanguage |
         ForEach-Object { $listings[$_."lang"] = $_."listing" }
-        
+
     Write-Log "Conversion complete." -Level Verbose
 
     return $listings
@@ -1458,7 +1458,7 @@ function New-ApplicationMetadataTable
 <#
     .SYNOPSIS
         A simple utility function for creating a consistent metadata hastable.
-        
+
     .DESCRIPTION
         A simple utility function for creating a consistent metadata hastable.
 
@@ -1488,7 +1488,7 @@ function Get-TargetPlatform
 <#
     .SYNOPSIS
         Determines the target platform for a given AppxManifest.xml.
-        
+
     .DESCRIPTION
         Determines the target platform for a given AppxManifest.xml.
 
@@ -1550,7 +1550,7 @@ function Read-AppxMetadata
 <#
     .SYNOPSIS
         Reads various metadata properties about the input .appx file.
-    
+
     .DESCRIPTION
         Reads various metadata properties about the input .appx file.
 
@@ -1615,7 +1615,7 @@ function Read-AppxMetadata
 
         $metadata.targetPlatform = Get-TargetPlatform -AppxManifestPath $appxManifest
         $metadata.name           = $manifest.Package.Identity.Name -creplace '^Microsoft\.', ''
-        
+
         $metadata.languages = @()
         $metadata.languages += $manifest.Package.Resources.Resource.Language |
             Where-Object { $null -ne $_ } |
@@ -1668,7 +1668,7 @@ function Read-AppxUploadMetadata
 <#
     .SYNOPSIS
         Reads various metadata properties about the input .appxupload.
-    
+
     .DESCRIPTION
         Reads various metadata properties about the input .appxupload.
 
@@ -1767,7 +1767,7 @@ function Read-AppxBundleMetadata
 <#
     .SYNOPSIS
         Reads various metadata properties about the input .appxbundle.
-    
+
     .DESCRIPTION
         Reads various metadata properties about the input .appxbundle.
 
@@ -1831,7 +1831,7 @@ function Read-AppxBundleMetadata
         $metadata.architecture = "Neutral"  # always 'Neutral' for .appxbundle
         $metadata.name         = $manifest.Bundle.Identity.Name -creplace '^Microsoft\.', ''
 
-        $languages = ($manifest.Bundle.Packages.Package | Where-Object Type -like "resource").Resources.Resource.Language | 
+        $languages = ($manifest.Bundle.Packages.Package | Where-Object Type -like "resource").Resources.Resource.Language |
             Where-Object { $null -ne $_ } |
             ForEach-Object { $_.ToLower() } |
             Sort-Object -Unique
@@ -1972,7 +1972,7 @@ function Read-ApplicationMetadata
 <#
     .SYNOPSIS
         Reads metadata used for submission of an .appx, .appxbundle, or appxupload.
-        
+
     .DESCRIPTION
         Reads metadata used for submission of an .appx, .appxbundle, or appxupload.
 
@@ -2077,13 +2077,13 @@ function Add-AppPackagesMetadata
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateScript({ 
+        [ValidateScript({
             foreach ($path in $_)
             {
                 if (-not (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) -Path $path))
                 {
                     throw "$_ is not a file or cannot be found."
-                } 
+                }
             }
 
             return $true
@@ -2179,7 +2179,7 @@ function Remove-DeprecatedProperties
 
     # No side-effects.  We'll work off of a copy of the passed-in object
     $requestBody = DeepCopy-Object $SubmissionRequestBody
-    
+
     # hardwareRequirements was deprecated on 5/13/2016
     # Deprecated due to business reasons.  This field is not exposed from the UI.
     $requestBody.PSObject.Properties.Remove('hardwareRequirements')
@@ -2271,7 +2271,7 @@ function Get-SubmissionRequestBody
         [PSCustomObject] $ConfigObject,
 
         [string] $PDPRootPath,
-        
+
         [string] $Release,
 
         [string[]] $PDPInclude,
@@ -2279,7 +2279,7 @@ function Get-SubmissionRequestBody
         [string[]] $PDPExclude,
 
         [string[]] $LanguageExclude,
-        
+
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
 
@@ -2320,7 +2320,7 @@ function Get-SubmissionRequestBody
                 $out = @()
                 $out += "'$pathWithRelease' is not a valid directory or cannot be found."
                 $out += "Check the values of '$script:s_PDPRootPath' and '$script:s_Release' and try again."
-                
+
                 $newLineOutput = ($out -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error
                 throw $newLineOutput
@@ -2411,7 +2411,7 @@ function Get-InAppProductSubmissionRequestBody
         [PSCustomObject] $ConfigObject,
 
         [string] $PDPRootPath,
-        
+
         [string] $Release,
 
         [string[]] $PDPInclude,
@@ -2419,7 +2419,7 @@ function Get-InAppProductSubmissionRequestBody
         [string[]] $PDPExclude,
 
         [string[]] $LanguageExclude,
-        
+
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
 
@@ -2575,7 +2575,7 @@ function Resolve-PackageParameters
             throw $newLineOutput
         }
     }
-    
+
 
     if ($SkipValidation -inotcontains $script:s_OutPath)
     {
@@ -2585,7 +2585,7 @@ function Resolve-PackageParameters
             $configVal = $ConfigObject.packageParameters.OutPath
             if ([System.String]::IsNullOrWhiteSpace($configVal))
             {
-                $output = ($out -f $script:s_OutPath) 
+                $output = ($out -f $script:s_OutPath)
                 Write-Log $output -Level Error
                 throw $output
             }
@@ -2609,7 +2609,7 @@ function Resolve-PackageParameters
             $configVal = $ConfigObject.packageParameters.OutName
             if ([System.String]::IsNullOrWhiteSpace($configVal))
             {
-                $output = ($out -f $script:s_OutName) 
+                $output = ($out -f $script:s_OutName)
                 Write-Log $output -Level Error
                 throw $output
             }
@@ -2821,7 +2821,7 @@ function Convert-AppConfig
     )
 
     $lines = (Get-Content -Path $ConfigPath -Encoding UTF8 | Remove-Comment) -join ''
-        
+
     return ($lines | ConvertFrom-Json)
 }
 
@@ -2835,7 +2835,7 @@ function Join-SubmissionPackage
         Merges the specified content from an ancillary StoreBroker payload into the master payload.
         This is most useful in the scenario where you have packages that are coming from different
         builds that should all be part of the same Store submission update.
-        
+
         Users will only specify the .json files for the two payloads, with the expectation that
         the .zip will be at the same location and same name as its complementary .json file.
 
@@ -2872,7 +2872,7 @@ function Join-SubmissionPackage
         [Parameter(Mandatory=$true)]
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $MasterJsonPath,
- 
+
         [Parameter(Mandatory=$true)]
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $AdditionalJsonPath,
@@ -2880,7 +2880,7 @@ function Join-SubmissionPackage
         [Parameter(Mandatory=$true)]
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) {  throw "$_ already exists. Choose a different name." } else { $true }})]
         [string] $OutJsonPath,
-        
+
         [switch] $AddPackages
     )
 
@@ -2986,7 +2986,7 @@ function Join-SubmissionPackage
         $outJsonContent |
             ConvertTo-Json -Depth $script:jsonConversionDepth -Compress |
             Out-File -Encoding utf8 -FilePath $OutJsonPath
-        
+
         Write-Log "Write complete." -Level Verbose
     }
 
@@ -3027,12 +3027,12 @@ function New-SubmissionPackage
            2. <PDPRootPath>\<Release>\<lang-code>\...\PDP.xml
        The only difference between these two is that there is a <Release> directory after the
        <PDPRootPath> and before the <lang-code> sub-directories.
-      
+
        The first layout is generally used when your localization system will be downloading
        the localized PDP files during your build.  In that situation, it's always retrieving
        the latest version.  Alternatively, if the latest localized versions of your PDP
        files are always stored in the same location, this layout is also for you.
-      
+
        On the other hand, if you will be archiving the localized PDP's based on each release
        to the Store, then the second layout is the one that you should use.  In this scenario,
        you will specify the value of "<Release>" immediately below, or at the commandline.
@@ -3059,14 +3059,14 @@ function New-SubmissionPackage
     .PARAMETER ImagesRootPath
         Your store screenshots must be placed with this structure:
             <ImagesRootPath>\<Release>\<lang-code>\...\img.png
-        
+
         The 'Release' that will be used is NOT the value specified to StoreBroker,
         it is the 'Release' value found in the corresponding PDP file.
 
     .PARAMETER AppxPath
         Array of full paths to the architecture-neutral .appxbundle, .appxupload, or .appx
         files that will be uploaded as the new submission.
-        
+
     .PARAMETER OutPath
         Full path to a directory where the Packaging Tool can write the .json submission request
         body and .zip package to upload.
@@ -3090,20 +3090,20 @@ function New-SubmissionPackage
 
     .EXAMPLE
         New-SubmissionPackage -ConfigPath 'C:\Config\StoreBrokerConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\App.appxbundle'
-        
+
         This example creates the submission request body and .zip file for the architecture-neutral
         '.appxbundle' located at 'C:\bin\App.appxbundle'.  Two files will be placed under 'C:\Out\Path\',
         'Upload.json' and 'Upload.zip'
 
     .EXAMPLE
         New-SubmissionPackage -ConfigPath 'C:\Config\StoreBrokerConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\App.appxbundle' -Verbose
-        
+
         This example is the same except it specifies Verbose logging and the function will output a
         detailed report of its actions.
 
     .EXAMPLE
         New-SubmissionPackage -ConfigPath 'C:\Config\StoreBrokerConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -AppxPath 'C:\bin\x86\App_x86.appxupload', 'C:\Other\Path\Arm\App_arm.appxupload'
-        
+
         This example is the same except it specifies an x86 and Arm build.  Multiple files to
         include can be passed to 'AppxPath' by separating with a comma.
 #>
@@ -3129,13 +3129,13 @@ function New-SubmissionPackage
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
 
-        [ValidateScript({ 
+        [ValidateScript({
             foreach ($path in $_)
             {
                 if (-not (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) -Path $path))
                 {
                     throw "$_ cannot be found or is not a supported extension: $($script:supportedExtensions -join ", ")."
-                } 
+                }
             }
 
             return $true
@@ -3153,7 +3153,7 @@ function New-SubmissionPackage
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    try 
+    try
     {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
 
@@ -3174,18 +3174,18 @@ function New-SubmissionPackage
 
             # ([string] $null) -ne $null, is true.
             # Explicitly check the type of the value to avoid printing [string] params that are $null.
-            if ((($val -isnot [System.String]) -and ($null -ne $val)) -or 
+            if ((($val -isnot [System.String]) -and ($null -ne $val)) -or
                 (($val -is [System.String]) -and (-not [String]::IsNullOrWhiteSpace($val))))
             {
                 $packageParams[$param] = $val
-                
+
                 # Treat the value as if it is an array.
                 # If it's not, it will still pretty print fine.
                 $quotedVals = $val | ForEach-Object { "`"$_`"" }
                 Write-Log "`t$param = $($quotedVals -join ', ')" -Level Verbose
             }
         }
-        
+
         # Convert the Config.json
         $config = Convert-AppConfig -ConfigPath $ConfigPath
 
@@ -3201,7 +3201,7 @@ function New-SubmissionPackage
         $script:tempFolderPath = New-TemporaryDirectory
 
         # It may not actually exist due to What-If support.
-        $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and 
+        $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and
                                    (Test-Path -PathType Container $script:tempFolderPath)
 
         # Get the submission request object
@@ -3228,7 +3228,7 @@ function New-SubmissionPackage
         # Record the telemetry for this event.
         $stopwatch.Stop()
         $telemetryMetrics = @{ [StoreBrokerTelemetryMetric]::Duration = $stopwatch.Elapsed.TotalSeconds }
-        
+
         # We may have app info for multiple packages.  Let's normalize it.
         # By the very nature of how the Store works, all the packages have to be for the same app.
         # There can be multiple versions being submitted in a single submission.  For our purposes,
@@ -3254,7 +3254,7 @@ function New-SubmissionPackage
         }
 
         Set-TelemetryException -Exception $_.Exception -ErrorBucket "New-SubmissionPackage" -Properties $telemetryProperties
-        Write-Log $($_.Exception.Message) -Level Error
+        Write-Log -Exception $_ -Level Error
 
         throw
     }
@@ -3297,12 +3297,12 @@ function New-InAppProductSubmissionPackage
            2. <PDPRootPath>\<Release>\<lang-code>\...\PDP.xml
        The only difference between these two is that there is a <Release> directory after the
        <PDPRootPath> and before the <lang-code> sub-directories.
-      
+
        The first layout is generally used when your localization system will be downloading
        the localized PDP files during your build.  In that situation, it's always retrieving
        the latest version.  Alternatively, if the latest localized versions of your PDP
        files are always stored in the same location, this layout is also for you.
-      
+
        On the other hand, if you will be archiving the localized PDP's based on each release
        to the Store, then the second layout is the one that you should use.  In this scenario,
        you will specify the value of "<Release>" immediately below, or at the commandline.
@@ -3329,7 +3329,7 @@ function New-InAppProductSubmissionPackage
     .PARAMETER ImagesRootPath
         Your icons must be placed with this structure:
             <ImagesRootPath>\<Release>\<lang-code>\...\icon.png
-        
+
         The 'Release' that will be used is NOT the value specified to StoreBroker,
         it is the 'Release' value found in the corresponding PDP file.
 
@@ -3351,13 +3351,13 @@ function New-InAppProductSubmissionPackage
 
     .EXAMPLE
         New-InAppProductSubmissionPackage -ConfigPath 'C:\Config\StoreBrokerIAPConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease
-        
+
         This example creates the submission request body and .zip file for the IAP.Two files will
         be placed under 'C:\Out\Path\', 'Upload.json' and 'Upload.zip'
 
     .EXAMPLE
         New-InAppProductSubmissionPackage -ConfigPath 'C:\Config\StoreBrokerIAPConfig.json' -OutPath 'C:\Out\Path\' -OutName 'Upload' -Release MarchRelease -Verbose
-        
+
         This example is the same except it specifies Verbose logging and the function will output a
         detailed report of its actions.
 #>
@@ -3393,7 +3393,7 @@ function New-InAppProductSubmissionPackage
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    try 
+    try
     {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
 
@@ -3414,18 +3414,18 @@ function New-InAppProductSubmissionPackage
 
             # ([string] $null) -ne $null, is true.
             # Explicitly check the type of the value to avoid printing [string] params that are $null.
-            if ((($val -isnot [System.String]) -and ($null -ne $val)) -or 
+            if ((($val -isnot [System.String]) -and ($null -ne $val)) -or
                 (($val -is [System.String]) -and (-not [String]::IsNullOrWhiteSpace($val))))
             {
                 $packageParams[$param] = $val
-                
+
                 # Treat the value as if it is an array.
                 # If it's not, it will still pretty print fine.
                 $quotedVals = $val | ForEach-Object { "`"$_`"" }
                 Write-Log "`t$param = $($quotedVals -join ', ')" -Level Verbose
             }
         }
-        
+
         # Convert the Config.json
         $config = Convert-AppConfig -ConfigPath $ConfigPath
 
@@ -3441,7 +3441,7 @@ function New-InAppProductSubmissionPackage
         $script:tempFolderPath = New-TemporaryDirectory
 
         # It may not actually exist due to What-If support.
-        $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and 
+        $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and
                                    (Test-Path -PathType Container $script:tempFolderPath)
 
         # Get the submission request object
@@ -3467,13 +3467,13 @@ function New-InAppProductSubmissionPackage
         # Record the telemetry for this event.
         $stopwatch.Stop()
         $telemetryMetrics = @{ [StoreBrokerTelemetryMetric]::Duration = $stopwatch.Elapsed.TotalSeconds }
-        
+
         Set-TelemetryEvent -EventName New-InAppProductSubmissionPackage -Metrics $telemetryMetrics
     }
     catch
     {
         Set-TelemetryException -Exception $_.Exception -ErrorBucket "New-InAppProductSubmissionPackage"
-        Write-Log $($_.Exception.Message) -Level Error
+        Write-Log -Exception $_ -Level Error
 
         throw
     }

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.13.0'
+    ModuleVersion = '1.14.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -410,10 +410,10 @@ function Get-AccessToken
     $credential = $script:authCredential
     if ($null -eq $credential)
     {
-        $output = @()
-        $output += "Prompting for credentials."
-        $output += "To avoid doing this every time, consider using Set-StoreBrokerAuthentication to cache the values for this session."
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Prompting for credentials.",
+            "To avoid doing this every time, consider using Set-StoreBrokerAuthentication to cache the values for this session.")
+
         $credential = Get-Credential -Message "Enter your client id as your username, and your client secret as your password. ***To avoid getting this prompt every time, consider using Set-StoreBrokerAuthentication.***"
     }
 
@@ -1377,7 +1377,7 @@ function Start-SubmissionMonitor
                     $shouldMonitor = $false
                 }
 
-                Write-Log $($body -join [Environment]::NewLine)
+                Write-Log $body
 
                 if ($EmailNotifyTo.Count -gt 0)
                 {

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -223,20 +223,20 @@ function Set-StoreBrokerAuthentication
         [string] $TenantName = $null
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     if ($UseProxy)
     {
         if ((-not [String]::IsNullOrWhiteSpace($TenantId)) -and (-not [String]::IsNullOrWhiteSpace($TenantName)))
         {
             $message = "You cannot set both TenantId and TenantName.  Only provide one of them."
-            Write-Log $message -Level Error
+            Write-Log -Message $message -Level Error
             throw $message
         }
 
         if ($null -ne $script:authCredential)
         {
-            Write-Log "Your cached credentials will no longer be used since you have enabled Proxy usage." -Level Warning
+            Write-Log -Message "Your cached credentials will no longer be used since you have enabled Proxy usage." -Level Warning
         }
 
         if ($ProxyEndpoint.EndsWith('/') -or $ProxyEndpoint.EndsWith('\'))
@@ -285,7 +285,7 @@ function Set-StoreBrokerAuthentication
     {
         if (-not $OnlyCacheTenantId)
         {
-            Write-Log "No credential provided.  Not changing current cached credential." -Level Error
+            Write-Log -Message "No credential provided.  Not changing current cached credential." -Level Error
         }
     }
     else
@@ -324,7 +324,7 @@ function Clear-StoreBrokerAuthentication
 
     Set-TelemetryEvent -EventName Clear-StoreBrokerAuthentication
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     if ($PSCmdlet.ShouldProcess("", "Clear tenantId"))
     {
@@ -402,7 +402,7 @@ function Get-AccessToken
         $output += "   http://aka.ms/StoreBroker"
 
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
 
@@ -420,7 +420,7 @@ function Get-AccessToken
     if ($null -eq $credential)
     {
         $output = "You must supply valid credentials (client id and secret) to use this module."
-        Write-Log  $output -Level Error
+        Write-Log -Message  $output -Level Error
         throw $output
     }
 
@@ -446,7 +446,7 @@ function Get-AccessToken
     try
     {
         Write-Log -Message "Getting access token..." -Level Verbose
-        Write-Log "Accessing [POST] $url" -Level Verbose
+        Write-Log -Message "Accessing [POST] $url" -Level Verbose
 
         if ($NoStatus)
         {
@@ -506,7 +506,7 @@ function Get-AccessToken
         $output += "$($_.ErrorDetails | ConvertFrom-JSON | Out-String)"
 
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
     catch [System.Management.Automation.RuntimeException]
@@ -526,7 +526,7 @@ function Get-AccessToken
         }
 
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
 }
@@ -567,11 +567,11 @@ function Get-ServiceEndpoint
         {
             # Specifically logging this at the normal level because we want this to be SUPER clear
             # to users so that they don't get confused by the results of their commands.
-            Write-Log "Using PROXY INT service endpoint. Return to PROD by setting `$global:SBUseInt = `$false"
+            Write-Log -Message "Using PROXY INT service endpoint. Return to PROD by setting `$global:SBUseInt = `$false"
         }
         else
         {
-            Write-Log "Using PROXY PROD service endpoint" -Level Verbose
+            Write-Log -Message "Using PROXY PROD service endpoint" -Level Verbose
         }
 
         # The endpoint is the same for both in the Proxy case.  But we'll add an additional
@@ -583,12 +583,12 @@ function Get-ServiceEndpoint
     {
         # Specifically logging this at the normal level because we want this to be SUPER clear
         # to users so that they don't get confused by the results of their commands.
-        Write-Log "Using INT service endpoint. Return to PROD by setting `$global:SBUseInt = `$false"
+        Write-Log -Message "Using INT service endpoint. Return to PROD by setting `$global:SBUseInt = `$false"
         return $serviceEndpointInt
     }
     else
     {
-        Write-Log "Using PROD service endpoint" -Level Verbose
+        Write-Log -Message "Using PROD service endpoint" -Level Verbose
         return $serviceEndpointProd
     }
 }
@@ -782,9 +782,9 @@ function Set-SubmissionPackage
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::PackagePath = (Get-PiiSafeString -PlainText $PackagePath) }
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
-    Write-Log "Attempting to upload the package ($PackagePath) for the submission to $UploadUrl..." -Level Verbose
+    Write-Log -Message "Attempting to upload the package ($PackagePath) for the submission to $UploadUrl..." -Level Verbose
 
     $azureStorageDll = Get-AzureStorageDllPath -NoStatus:$NoStatus
     $azureStorageDataMovementDll = Get-AzureStorageDataMovementDllPath -NoStatus:$NoStatus
@@ -887,7 +887,7 @@ function Set-SubmissionPackage
 
         Set-TelemetryException -Exception $_.Exception -ErrorBucket Set-SubmissionPackage -Properties $telemetryProperties
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
     catch
@@ -903,7 +903,7 @@ function Set-SubmissionPackage
 
         Set-TelemetryException -Exception $_.Exception -ErrorBucket Set-SubmissionPackage -Properties $telemetryProperties
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
     finally
@@ -912,7 +912,7 @@ function Set-SubmissionPackage
         [System.Net.ServicePointManager]::Expect100Continue = $origExpect100Continue
     }
 
-    Write-Log "Successfully uploaded the application package." -Level Verbose
+    Write-Log -Message "Successfully uploaded the application package." -Level Verbose
 }
 
 function Get-SubmissionPackage
@@ -978,9 +978,9 @@ function Get-SubmissionPackage
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::PackagePath = (Get-PiiSafeString -PlainText $PackagePath) }
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
-    Write-Log "Attempting to download the contents of $UploadUrl to $PackagePath..." -Level Verbose
+    Write-Log -Message "Attempting to download the contents of $UploadUrl to $PackagePath..." -Level Verbose
 
     $azureStorageDll = Get-AzureStorageDllPath -NoStatus:$NoStatus
     $azureStorageDataMovementDll = Get-AzureStorageDataMovementDllPath -NoStatus:$NoStatus
@@ -1083,7 +1083,7 @@ function Get-SubmissionPackage
 
         Set-TelemetryException -Exception $_.Exception -ErrorBucket Get-SubmissionPackage -Properties $telemetryProperties
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
     catch
@@ -1099,7 +1099,7 @@ function Get-SubmissionPackage
 
         Set-TelemetryException -Exception $_.Exception -ErrorBucket Get-SubmissionPackage -Properties $telemetryProperties
         $newLineOutput = ($output -join [Environment]::NewLine)
-        Write-Log $newLineOutput -Level Error
+        Write-Log -Message $newLineOutput -Level Error
         throw $newLineOutput
     }
     finally
@@ -1108,7 +1108,7 @@ function Get-SubmissionPackage
         [System.Net.ServicePointManager]::Expect100Continue = $origExpect100Continue
     }
 
-    Write-Log "Successfully downloaded the blob contents." -Level Verbose
+    Write-Log -Message "Successfully downloaded the blob contents." -Level Verbose
 }
 
 function Start-SubmissionMonitor
@@ -1215,7 +1215,7 @@ function Start-SubmissionMonitor
         [switch] $PassThru
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     # Telemetry-related
     $telemetryProperties = @{
@@ -1377,7 +1377,7 @@ function Start-SubmissionMonitor
                     $shouldMonitor = $false
                 }
 
-                Write-Log $body
+                Write-Log -Message $body
 
                 if ($EmailNotifyTo.Count -gt 0)
                 {
@@ -1392,7 +1392,7 @@ function Start-SubmissionMonitor
             # "The operation has timed out.", but this wording could clearly change over time.
             if ($_.Exception.Message -ilike "*timed*")
             {
-                Write-Log "Got exception while trying to check on submission and will try again. The exception was:" -Exception $_ -Level Warning
+                Write-Log -Message "Got exception while trying to check on submission and will try again. The exception was:" -Exception $_ -Level Warning
             }
             else
             {
@@ -1403,7 +1403,7 @@ function Start-SubmissionMonitor
         if ($shouldMonitor)
         {
             $secondsBetweenChecks = 60
-            Write-Log "Status is [$lastStatus]. Waiting $secondsBetweenChecks seconds before checking again..."
+            Write-Log -Message "Status is [$lastStatus]. Waiting $secondsBetweenChecks seconds before checking again..."
             Start-Sleep -Seconds $secondsBetweenChecks
         }
     }
@@ -1486,7 +1486,7 @@ function Open-DevPortal
 
     Set-TelemetryEvent -EventName Open-DevPortal -Properties $telemetryProperties
 
-    Write-Log "Opening Dev Portal in default web browser."
+    Write-Log -Message "Opening Dev Portal in default web browser."
 
     $appUrl        = "https://developer.microsoft.com/en-us/dashboard/apps/$AppId"
     $submissionUrl = "https://developer.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$SubmissionId/"
@@ -1558,7 +1558,7 @@ function Open-Store()
         $uri = $webUri
     }
 
-    Write-Log "Launching $uri" -Level Verbose
+    Write-Log -Message "Launching $uri" -Level Verbose
     Start-Process -FilePath $uri
 }
 
@@ -1790,8 +1790,8 @@ function Invoke-SBRestMethod
 
         try
         {
-            Write-Log $Description -Level Verbose
-            Write-Log "Accessing [$Method] $url [Timeout = $global:SBWebRequestTimeoutSec]" -Level Verbose
+            Write-Log -Message $Description -Level Verbose
+            Write-Log -Message "Accessing [$Method] $url [Timeout = $global:SBWebRequestTimeoutSec]" -Level Verbose
 
             if ($NoStatus)
             {
@@ -1814,7 +1814,7 @@ function Invoke-SBRestMethod
                     $result = Invoke-WebRequest @params
                     if ($Method -eq 'delete')
                     {
-                        Write-Log "Successfully removed." -Level Verbose
+                        Write-Log -Message "Successfully removed." -Level Verbose
                     }
                 }
             }
@@ -1873,7 +1873,7 @@ function Invoke-SBRestMethod
                             }
                             catch
                             {
-                                Write-Log "Unable to retrieve the raw HTTP Web Response:" -Exception $_ -Level Warning
+                                Write-Log -Message "Unable to retrieve the raw HTTP Web Response:" -Exception $_ -Level Warning
                             }
 
                             if ($_.Exception.Response.Headers.Count -gt 0)
@@ -1905,14 +1905,14 @@ function Invoke-SBRestMethod
 
                 if ($Method -eq 'delete')
                 {
-                    Write-Log "Successfully removed." -Level Verbose
+                    Write-Log -Message "Successfully removed." -Level Verbose
                 }
             }
 
             $correlationId = $result.Headers[$script:headerMSCorrelationId]
             if (-not [String]::IsNullOrEmpty($correlationId))
             {
-                Write-Log "$($script:headerMSCorrelationId) : $correlationId" -Level Verbose
+                Write-Log -Message "$($script:headerMSCorrelationId) : $correlationId" -Level Verbose
             }
 
             # Record the telemetry for this event.
@@ -1962,7 +1962,7 @@ function Invoke-SBRestMethod
                 }
                 catch
                 {
-                    Write-Log "Unable to retrieve the raw HTTP Web Response:" -Exception $_ -Level Warning
+                    Write-Log -Message "Unable to retrieve the raw HTTP Web Response:" -Exception $_ -Level Warning
                 }
 
                 if ($ex.Response.Headers.Count -gt 0)
@@ -2067,7 +2067,7 @@ function Invoke-SBRestMethod
             if (-not [String]::IsNullOrEmpty($correlationId))
             {
                 $output += $script:headerMSCorrelationId + ': ' + $correlationId
-                Write-Log "$($script:headerMSCorrelationId): $correlationId" -Level Verbose
+                Write-Log -Message "$($script:headerMSCorrelationId): $correlationId" -Level Verbose
             }
 
             $newLineOutput = ($output -join [Environment]::NewLine)
@@ -2075,8 +2075,8 @@ function Invoke-SBRestMethod
             {
                 if ($numRetries -ge $global:SBMaxAutoRetries)
                 {
-                    Write-Log $newLineOutput -Level Error
-                    Write-Log "Maximum retries for request has been reached ($global:SBMaxAutoRetries).  Will now fail." -Level Error
+                    Write-Log -Message $newLineOutput -Level Error
+                    Write-Log -Message "Maximum retries for request has been reached ($global:SBMaxAutoRetries).  Will now fail." -Level Error
                     Set-TelemetryException -Exception $ex -ErrorBucket $errorBucket -Properties $localTelemetryProperties
                     throw $newLineOutput
                 }
@@ -2085,15 +2085,15 @@ function Invoke-SBRestMethod
                     $numRetries++
                     $localTelemetryProperties[[StoreBrokerTelemetryProperty]::NumRetries] = $numRetries
                     $localTelemetryProperties[[StoreBrokerTelemetryProperty]::RetryStatusCode] = $statusCode
-                    Write-Log $newLineOutput -Level Warning
-                    Write-Log "This status code ($statusCode) is configured to auto-retry (via `$global:SBAutoRetryErrorCodes).  StoreBroker will auto-retry (attempt #$numRetries) in $retryDelayMin minute(s). Sleeping..." -Level Warning
+                    Write-Log -Message $newLineOutput -Level Warning
+                    Write-Log -Message "This status code ($statusCode) is configured to auto-retry (via `$global:SBAutoRetryErrorCodes).  StoreBroker will auto-retry (attempt #$numRetries) in $retryDelayMin minute(s). Sleeping..." -Level Warning
                     Start-Sleep -Seconds ($retryDelayMin * 60)
                     $retryDelayMin = $retryDelayMin * 2 # Exponential sleep increase for next retry
                 }
             }
             else
             {
-                Write-Log $newLineOutput -Level Error
+                Write-Log -Message $newLineOutput -Level Error
                 Set-TelemetryException -Exception $ex -ErrorBucket $errorBucket -Properties $localTelemetryProperties
                 throw $newLineOutput
             }

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -514,7 +514,7 @@ function Get-AccessToken
         # This type of exception occurs when NOT using -NoStatus
         $output = @()
         $output += "Be sure to check that your client id/secret are valid."
-        $output += Out-String -InputObject $_
+        $output += $_.Exception.Message
         if ($_.ErrorDetails.Message)
         {
             $message = ($_.ErrorDetails.Message | ConvertFrom-Json)
@@ -874,7 +874,7 @@ function Set-SubmissionPackage
         # This type of exception occurs when NOT using -NoStatus
 
         $output = @()
-        $output += Out-String -InputObject $_
+        $output += $_.Exception.Message
         if ($_.ErrorDetails.Message)
         {
             $message = ($_.ErrorDetails.Message | ConvertFrom-Json)
@@ -1070,7 +1070,7 @@ function Get-SubmissionPackage
         # This type of exception occurs when NOT using -NoStatus
 
         $output = @()
-        $output += Out-String -InputObject $_
+        $output += $_.Exception.Message
         if ($_.ErrorDetails.Message)
         {
             $message = ($_.ErrorDetails.Message | ConvertFrom-Json)
@@ -1863,7 +1863,7 @@ function Invoke-SBRestMethod
                             # that is just a JSON object with the data that we'll later extract for processing in
                             # the main catch.
                             $ex = @{}
-                            $ex.Message = Out-String -InputObject $_
+                            $ex.Message = $_.Exception.Message
                             $ex.StatusCode = $_.Exception.Response.StatusCode
                             $ex.StatusDescription = $_.Exception.Response.StatusDescription
                             $ex.InnerMessage = $_.ErrorDetails.Message
@@ -1952,7 +1952,7 @@ function Invoke-SBRestMethod
             if ($_.Exception -is [System.Net.WebException])
             {
                 $ex = $_.Exception
-                $message = Out-String -InputObject $_
+                $message = $_.Exception.Message
                 $statusCode = $ex.Response.StatusCode.value__ # Note that value__ is not a typo.
                 $statusDescription = $ex.Response.StatusDescription
                 $innerMessage = $_.ErrorDetails.Message

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -221,7 +221,7 @@ function Get-Application
     param(
         [Parameter(Mandatory=$true)]
         [string] $AppId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -357,10 +357,10 @@ function Get-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -579,10 +579,10 @@ function Get-ApplicationSubmissionStatus
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -653,7 +653,7 @@ function Remove-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -668,7 +668,7 @@ function Remove-ApplicationSubmission
         [StoreBrokerTelemetryProperty]::AppId = $AppId
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
     }
-    
+
     $params = @{
         "UriFragment" = "applications/$AppId/submissions/$SubmissionId"
         "Method" = "Delete"
@@ -750,7 +750,7 @@ function New-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [ValidateSet('NoAction', 'Finalize', 'Halt')]
         [string] $ExistingPackageRolloutAction = $script:keywordNoAction,
 
@@ -1010,7 +1010,7 @@ function Update-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $SubmissionDataPath,
@@ -1019,7 +1019,7 @@ function Update-ApplicationSubmission
         [string] $PackagePath = $null,
 
         [switch] $AutoCommit,
-        
+
         [string] $SubmissionId = "",
 
         [ValidateSet('Default', 'Immediate', 'Manual', 'SpecificDate')]
@@ -1096,7 +1096,7 @@ function Update-ApplicationSubmission
             $output = @()
             $output += "The AppId [$($submission.appId)] in the submission content [$SubmissionDataPath] does not match the intended AppId [$AppId]."
             $output += "You either entered the wrong AppId at the commandline, or you're referencing the wrong submission content to upload."
-            
+
             $newLineOutput = ($output -join [Environment]::NewLine)
             Write-Log $newLineOutput -Level Error
             throw $newLineOutput
@@ -1142,7 +1142,7 @@ function Update-ApplicationSubmission
                 $output = @()
                 $output += "We can only modify a submission that is in the '$script:keywordPendingCommit' state."
                 $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
-                
+
                 $newLineOutput = ($output -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error
                 throw $newLineOutput
@@ -1257,7 +1257,7 @@ function Update-ApplicationSubmission
     }
     catch
     {
-        Write-Log $_ -Level Error 
+        Write-Log -Exception $_ -Level Error
         throw
     }
 }
@@ -1379,7 +1379,7 @@ function Patch-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [PSCustomObject] $ClonedSubmission,
-        
+
         [Parameter(Mandatory)]
         [PSCustomObject] $NewSubmission,
 
@@ -1414,8 +1414,8 @@ function Patch-ApplicationSubmission
 
         [switch] $UpdateNotesForCertification
     )
-    
-    Write-Log "Patching the content of the submission." -Level Verbose 
+
+    Write-Log "Patching the content of the submission." -Level Verbose
 
     # Our method should have zero side-effects -- we don't want to modify any parameter
     # that was passed-in to us.  To that end, we'll create a deep copy of the ClonedSubmisison,
@@ -1456,13 +1456,13 @@ function Patch-ApplicationSubmission
     if (($AddPackages -or $ReplacePackages) -and ($NewSubmission.applicationPackages.Count -eq 0))
     {
         $output = @()
-        $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages." 
+        $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages."
         $output += "Please check your input settings to New-SubmissionPackage and ensure you're providing a value for AppxPath."
         $output = $output -join [Environment]::NewLine
         Write-Log $output -Level Error
         throw $output
     }
-    
+
     # When updating packages, we'll simply add the new packages to the list of existing packages.
     # At some point when the API provides more signals to us with regard to what platform/OS
     # an existing package is for, we may want to mark "older" packages for the same platform
@@ -1497,7 +1497,7 @@ function Patch-ApplicationSubmission
         $PatchedSubmission.listings = DeepCopy-Object $NewSubmission.listings
 
         # Now we'll update the screenshots in the existing listings
-        # to indicate that they should all be deleted. We'll also add 
+        # to indicate that they should all be deleted. We'll also add
         # all of these deleted images to the corresponding listing
         # in the patched submission.
         #
@@ -1576,7 +1576,7 @@ function Patch-ApplicationSubmission
         $PatchedSubmission.targetPublishDate = $NewSubmission.targetPublishDate
         $PatchedSubmission.visibility = Get-ProperEnumCasing -EnumValue ($NewSubmission.visibility)
     }
-    
+
     # If users pass in a different value for any of the publish/visibility values at the commandline,
     # they override those coming from the config.
     if ($TargetPublishMode -ne $script:keywordDefault)
@@ -1584,7 +1584,7 @@ function Patch-ApplicationSubmission
         if (($TargetPublishMode -eq $script:keywordSpecificDate) -and ($null -eq $TargetPublishDate))
         {
             $output = "TargetPublishMode was set to '$script:keywordSpecificDate' but TargetPublishDate was not specified."
-            Write-Log $output -Level Error 
+            Write-Log $output -Level Error
             throw $output
         }
 
@@ -1596,7 +1596,7 @@ function Patch-ApplicationSubmission
         if ($TargetPublishMode -ne $script:keywordSpecificDate)
         {
             $output = "A TargetPublishDate was specified, but the TargetPublishMode was [$TargetPublishMode],  not '$script:keywordSpecificDate'."
-            Write-Log $output -Level Error 
+            Write-Log $output -Level Error
             throw $output
         }
 
@@ -1635,11 +1635,11 @@ function Patch-ApplicationSubmission
     # To better assist with debugging, we'll store exactly the original and modified JSON submission bodies.
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($ClonedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose 
+    Write-Log "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
 
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($PatchedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The patched JSON content can be found here: [$tempFile]" -Level Verbose 
+    Write-Log "The patched JSON content can be found here: [$tempFile]" -Level Verbose
 
     return $PatchedSubmission
 }
@@ -1706,7 +1706,7 @@ function Set-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [PSCustomObject] $UpdatedSubmission,
 
@@ -1715,7 +1715,7 @@ function Set-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $submissionId = $UpdatedSubmission.id
     $body = [string]($UpdatedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth)
@@ -1787,16 +1787,16 @@ function Complete-ApplicationSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -1815,7 +1815,7 @@ function Complete-ApplicationSubmission
             "NoStatus" = $NoStatus
         }
 
-        $null = Invoke-SBRestMethod @params 
+        $null = Invoke-SBRestMethod @params
 
         $output = @()
         $output += "The submission has been successfully committed."
@@ -1829,7 +1829,7 @@ function Complete-ApplicationSubmission
         $output += "    Start-ApplicationSubmissionMonitor -AppId $AppId -SubmissionId $submissionId -EmailNotifyTo $env:username"
         $output += ""
         $output += $script:manualPublishWarning -f 'Update-ApplicationSubmission'
-        Write-Log $($output -join [Environment]::NewLine) 
+        Write-Log $($output -join [Environment]::NewLine)
     }
     catch [System.InvalidOperationException]
     {
@@ -1885,7 +1885,7 @@ function Get-ApplicationSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -1894,7 +1894,7 @@ function Get-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -1972,7 +1972,7 @@ function Update-ApplicationSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -1985,7 +1985,7 @@ function Update-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2075,16 +2075,16 @@ function Stop-ApplicationSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2173,16 +2173,16 @@ function Complete-ApplicationSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -89,7 +89,7 @@ function Get-Applications
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $params = @{
         "UriFragment" = "applications"
@@ -144,7 +144,7 @@ function Format-Applications
     {
         Set-TelemetryEvent -EventName Format-Applications
 
-        Write-Log "Displaying Applications..." -Level Verbose
+        Write-Log -Message "Displaying Applications..." -Level Verbose
 
         $publishedDateField = @{ label="firstPublishedDate"; Expression={ Get-Date -Date $_.firstPublishedDate -Format G }; }
         $publishedSubmissionField = @{ label="lastPublishedSubmission"; Expression={ $_.lastPublishedApplicationSubmission.id }; }
@@ -160,7 +160,7 @@ function Format-Applications
 
     End
     {
-        Write-Log $($apps | Sort-Object primaryName | Format-Table primaryName, id, packagefamilyname, $publishedDateField, $publishedSubmissionField, $pendingSubmissionField | Out-String)
+        Write-Log -Message $($apps | Sort-Object primaryName | Format-Table primaryName, id, packagefamilyname, $publishedDateField, $publishedSubmissionField, $pendingSubmissionField | Out-String)
     }
 }
 
@@ -227,7 +227,7 @@ function Get-Application
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
 
@@ -282,7 +282,7 @@ function Format-Application
     {
         Set-TelemetryEvent -EventName Format-Application
 
-        Write-Log "Displaying Application..." -Level Verbose
+        Write-Log -Message "Displaying Application..." -Level Verbose
 
         $output = @()
     }
@@ -300,7 +300,7 @@ function Format-Application
 
     End
     {
-       Write-Log $output
+       Write-Log -Message $output
     }
 }
 
@@ -366,7 +366,7 @@ function Get-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -424,7 +424,7 @@ function Format-ApplicationSubmission
     {
         Set-TelemetryEvent -EventName Format-ApplicationSubmission
 
-        Write-Log "Displaying Application Submission..." -Level Verbose
+        Write-Log -Message "Displaying Application Submission..." -Level Verbose
 
         $indentLength = 5
         $output = @()
@@ -524,7 +524,7 @@ function Format-ApplicationSubmission
 
     End
     {
-        Write-Log $output
+        Write-Log -Message $output
     }
 }
 
@@ -588,7 +588,7 @@ function Get-ApplicationSubmissionStatus
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -662,7 +662,7 @@ function Remove-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -761,7 +761,7 @@ function New-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
     {
@@ -779,7 +779,7 @@ function New-ApplicationSubmission
 
             if ($Force -and ($null -ne $pendingSubmissionId))
             {
-                Write-Log "Force creation requested. Removing pending submission." -Level Verbose
+                Write-Log -Message "Force creation requested. Removing pending submission." -Level Verbose
                 Remove-ApplicationSubmission -AppId $AppId -SubmissionId $pendingSubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
             }
 
@@ -792,12 +792,12 @@ function New-ApplicationSubmission
                 {
                     if ($ExistingPackageRolloutAction -eq 'Finalize')
                     {
-                        Write-Log "Finalizing package rollout for existing submission before continuing." -Level Verbose
+                        Write-Log -Message "Finalizing package rollout for existing submission before continuing." -Level Verbose
                         Complete-ApplicationSubmissionPackageRollout -AppId $AppId -SubmissionId $publishedSubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
                     }
                     elseif ($ExistingPackageRolloutAction -eq 'Halt')
                     {
-                        Write-Log "Halting package rollout for existing submission before continuing." -Level Verbose
+                        Write-Log -Message "Halting package rollout for existing submission before continuing." -Level Verbose
                         Stop-ApplicationSubmissionPackageRollout -AppId $AppId -SubmissionId $publishedSubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
                     }
                 }
@@ -1066,9 +1066,9 @@ function Update-ApplicationSubmission
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
-    Write-Log "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
+    Write-Log -Message "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
     if ($PSCmdlet.ShouldProcess($SubmissionDataPath, "Get-Content"))
     {
         $submission = [string](Get-Content $SubmissionDataPath -Encoding UTF8) | ConvertFrom-Json
@@ -1097,7 +1097,7 @@ function Update-ApplicationSubmission
             $output += "You either entered the wrong AppId at the commandline, or you're referencing the wrong submission content to upload."
 
             $newLineOutput = ($output -join [Environment]::NewLine)
-            Write-Log $newLineOutput -Level Error
+            Write-Log -Message $newLineOutput -Level Error
             throw $newLineOutput
         }
     }
@@ -1142,7 +1142,7 @@ function Update-ApplicationSubmission
                 $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
 
                 $newLineOutput = ($output -join [Environment]::NewLine)
-                Write-Log $newLineOutput -Level Error
+                Write-Log -Message $newLineOutput -Level Error
                 throw $newLineOutput
             }
         }
@@ -1196,7 +1196,7 @@ function Update-ApplicationSubmission
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
-            Write-Log "Uploading the package [$PackagePath] since it was provided." -Level Verbose
+            Write-Log -Message "Uploading the package [$PackagePath] since it was provided." -Level Verbose
             Set-SubmissionPackage -PackagePath $PackagePath -UploadUrl $uploadUrl -NoStatus:$NoStatus
         }
         elseif (!$AutoCommit)
@@ -1217,7 +1217,7 @@ function Update-ApplicationSubmission
                 $AccessToken = $null
             }
 
-            Write-Log "Commiting the submission since -AutoCommit was requested." -Level Verbose
+            Write-Log -Message "Commiting the submission since -AutoCommit was requested." -Level Verbose
             Complete-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId -AccessToken $AccessToken -NoStatus:$NoStatus
         }
         else
@@ -1410,7 +1410,7 @@ function Patch-ApplicationSubmission
         [switch] $UpdateNotesForCertification
     )
 
-    Write-Log "Patching the content of the submission." -Level Verbose
+    Write-Log -Message "Patching the content of the submission." -Level Verbose
 
     # Our method should have zero side-effects -- we don't want to modify any parameter
     # that was passed-in to us.  To that end, we'll create a deep copy of the ClonedSubmisison,
@@ -1443,7 +1443,7 @@ function Patch-ApplicationSubmission
         }
         else
         {
-            Write-Log "MandatoryUpdateEffectiveDate specified without indicating IsMandatoryUpdate.  The value will be ignored." -Level Warning
+            Write-Log -Message "MandatoryUpdateEffectiveDate specified without indicating IsMandatoryUpdate.  The value will be ignored." -Level Warning
         }
     }
 
@@ -1453,7 +1453,7 @@ function Patch-ApplicationSubmission
         $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages."
         $output += "Please check your input settings to New-SubmissionPackage and ensure you're providing a value for AppxPath."
         $output = $output -join [Environment]::NewLine
-        Write-Log $output -Level Error
+        Write-Log -Message $output -Level Error
         throw $output
     }
 
@@ -1578,7 +1578,7 @@ function Patch-ApplicationSubmission
         if (($TargetPublishMode -eq $script:keywordSpecificDate) -and ($null -eq $TargetPublishDate))
         {
             $output = "TargetPublishMode was set to '$script:keywordSpecificDate' but TargetPublishDate was not specified."
-            Write-Log $output -Level Error
+            Write-Log -Message $output -Level Error
             throw $output
         }
 
@@ -1590,7 +1590,7 @@ function Patch-ApplicationSubmission
         if ($TargetPublishMode -ne $script:keywordSpecificDate)
         {
             $output = "A TargetPublishDate was specified, but the TargetPublishMode was [$TargetPublishMode],  not '$script:keywordSpecificDate'."
-            Write-Log $output -Level Error
+            Write-Log -Message $output -Level Error
             throw $output
         }
 
@@ -1629,11 +1629,11 @@ function Patch-ApplicationSubmission
     # To better assist with debugging, we'll store exactly the original and modified JSON submission bodies.
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($ClonedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
+    Write-Log -Message "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
 
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($PatchedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The patched JSON content can be found here: [$tempFile]" -Level Verbose
+    Write-Log -Message "The patched JSON content can be found here: [$tempFile]" -Level Verbose
 
     return $PatchedSubmission
 }
@@ -1709,7 +1709,7 @@ function Set-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $submissionId = $UpdatedSubmission.id
     $body = [string]($UpdatedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth)
@@ -1790,7 +1790,7 @@ function Complete-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -1887,7 +1887,7 @@ function Get-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -1978,7 +1978,7 @@ function Update-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2000,7 +2000,7 @@ function Update-ApplicationSubmissionPackageRollout
 
         $null = Invoke-SBRestMethod @params
 
-        Write-Log "Package rollout for this submission has been updated to $Percentage%."
+        Write-Log -Message "Package rollout for this submission has been updated to $Percentage%."
 
         if ($Percentage -eq 100)
         {
@@ -2076,7 +2076,7 @@ function Stop-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2172,7 +2172,7 @@ function Complete-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2193,7 +2193,7 @@ function Complete-ApplicationSubmissionPackageRollout
 
         $null = Invoke-SBRestMethod @params
 
-        Write-Log "Package rollout for this submission has been finalized.  All users will now receive these packages."
+        Write-Log -Message "Package rollout for this submission has been finalized.  All users will now receive these packages."
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -300,7 +300,7 @@ function Format-Application
 
     End
     {
-       Write-Log $($output -join [Environment]::NewLine)
+       Write-Log $output
     }
 }
 
@@ -524,7 +524,7 @@ function Format-ApplicationSubmission
 
     End
     {
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
 }
 
@@ -1079,15 +1079,14 @@ function Update-ApplicationSubmission
     {
         $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
 
-        $output = @()
-        $output += "The config file used to generate this submission did not have an AppId defined in it."
-        $output += "The AppId entry in the config helps ensure that payloads are not submitted to the wrong application."
-        $output += "Please update your app's StoreBroker config file by adding an `"appId`" property with"
-        $output += "your app's AppId to the `"appSubmission`" section.  If you're unclear on what change"
-        $output += "needs to be done, you can re-generate your config file using"
-        $output += "   New-StoreBrokerConfigFile -AppId $AppId -Path `"$configPath`""
-        $output += "and then diff the new config file against your current one to see the requested appId change."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "The config file used to generate this submission did not have an AppId defined in it.",
+            "The AppId entry in the config helps ensure that payloads are not submitted to the wrong application.",
+            "Please update your app's StoreBroker config file by adding an `"appId`" property with",
+            "your app's AppId to the `"appSubmission`" section.  If you're unclear on what change",
+            "needs to be done, you can re-generate your config file using",
+            "   New-StoreBrokerConfigFile -AppId $AppId -Path `"$configPath`"",
+            "and then diff the new config file against your current one to see the requested appId change.")
     }
     else
     {
@@ -1115,12 +1114,11 @@ function Update-ApplicationSubmission
         (-not $UpdateAppProperties) -and
         (-not $UpdateNotesForCertification))
     {
-        $output = @()
-        $output += "You have not specified any `"modification`" switch for updating the submission."
-        $output += "This means that the new submission will be identical to the current one."
-        $output += "If this was not your intention, please read-up on the documentation for this command:"
-        $output += "     Get-Help Update-ApplicationSubmission -ShowWindow"
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "You have not specified any `"modification`" switch for updating the submission.",
+            "This means that the new submission will be identical to the current one.",
+            "If this was not your intention, please read-up on the documentation for this command:",
+            "     Get-Help Update-ApplicationSubmission -ShowWindow")
     }
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
@@ -1187,15 +1185,14 @@ function Update-ApplicationSubmission
         $submissionId = $replacedSubmission.id
         $uploadUrl = $replacedSubmission.fileUploadUrl
 
-        $output = @()
-        $output += "Successfully cloned the existing submission and modified its content."
-        $output += "You can view it on the Dev Portal here:"
-        $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
-        $output += "or by running this command:"
-        $output += "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission"
-        $output += ""
-        $output += $script:manualPublishWarning -f 'Update-ApplicationSubmission'
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Successfully cloned the existing submission and modified its content.",
+            "You can view it on the Dev Portal here:",
+            "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "or by running this command:",
+            "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission",
+            "",
+            $script:manualPublishWarning -f 'Update-ApplicationSubmission')
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
@@ -1204,10 +1201,9 @@ function Update-ApplicationSubmission
         }
         elseif (!$AutoCommit)
         {
-            $output = @()
-            $output += "Your next step is to upload the package using:"
-            $output += "  Upload-SubmissionPackage -PackagePath <package> -UploadUrl `"$uploadUrl`""
-            Write-Log $($output -join [Environment]::NewLine)
+            Write-Log -Message @(
+                "Your next step is to upload the package using:",
+                "  Upload-SubmissionPackage -PackagePath <package> -UploadUrl `"$uploadUrl`"")
         }
 
         if ($AutoCommit)
@@ -1226,10 +1222,9 @@ function Update-ApplicationSubmission
         }
         else
         {
-            $output = @()
-            $output += "When you're ready to commit, run this command:"
-            $output += "  Commit-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId"
-            Write-Log $($output -join [Environment]::NewLine)
+            Write-Log -Message @(
+                "When you're ready to commit, run this command:",
+                "  Commit-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId")
         }
 
         # Record the telemetry for this event.
@@ -1431,13 +1426,12 @@ function Patch-ApplicationSubmission
         $PatchedSubmission.packageDeliveryOptions.packageRollout.isPackageRollout = $true
         $PatchedSubmission.packageDeliveryOptions.packageRollout.packageRolloutPercentage = $PackageRolloutPercentage
 
-        $output = @()
-        $output += "Your rollout selections apply to all of your packages, but will only apply to your customers running OS"
-        $output += "versions that support package flights (Windows.Desktop build 10586 or later; Windows.Mobile build 10586.63"
-        $output += "or later, and Xbox), including any customers who get the app via Store-managed licensing via the"
-        $output += "Windows Store for Business.  When using gradual package rollout, customers on earlier OS versions will not"
-        $output += "get packages from the latest submission until you finalize the package rollout."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "Your rollout selections apply to all of your packages, but will only apply to your customers running OS",
+            "versions that support package flights (Windows.Desktop build 10586 or later; Windows.Mobile build 10586.63",
+            "or later, and Xbox), including any customers who get the app via Store-managed licensing via the",
+            "Windows Store for Business.  When using gradual package rollout, customers on earlier OS versions will not",
+            "get packages from the latest submission until you finalize the package rollout.")
     }
 
     $PatchedSubmission.packageDeliveryOptions.isMandatoryUpdate = [bool]$IsMandatoryUpdate
@@ -1817,19 +1811,18 @@ function Complete-ApplicationSubmission
 
         $null = Invoke-SBRestMethod @params
 
-        $output = @()
-        $output += "The submission has been successfully committed."
-        $output += "This is just the beginning though."
-        $output += "It still has multiple phases of validation to get through, and there's no telling how long that might take."
-        $output += "You can view the progress of the submission validation on the Dev Portal here:"
-        $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
-        $output += "or by running this command:"
-        $output += "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission"
-        $output += "You can automatically monitor this submission with this command:"
-        $output += "    Start-ApplicationSubmissionMonitor -AppId $AppId -SubmissionId $submissionId -EmailNotifyTo $env:username"
-        $output += ""
-        $output += $script:manualPublishWarning -f 'Update-ApplicationSubmission'
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "The submission has been successfully committed.",
+            "This is just the beginning though.",
+            "It still has multiple phases of validation to get through, and there's no telling how long that might take.",
+            "You can view the progress of the submission validation on the Dev Portal here:",
+            "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "or by running this command:",
+            "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission",
+            "You can automatically monitor this submission with this command:",
+            "    Start-ApplicationSubmissionMonitor -AppId $AppId -SubmissionId $submissionId -EmailNotifyTo $env:username",
+            "",
+            $script:manualPublishWarning -f 'Update-ApplicationSubmission')
     }
     catch [System.InvalidOperationException]
     {
@@ -2011,13 +2004,12 @@ function Update-ApplicationSubmissionPackageRollout
 
         if ($Percentage -eq 100)
         {
-            $output = @()
-            $output += "Changing the rollout percentage to 100% does not ensure that all of your customers will get the"
-            $output += "packages from the latest submissions, because some customers may be on OS versions that don't"
-            $output += "support rollout. You must finalize the rollout in order to stop distributing the older packages"
-            $output += "and update all existing customers to the newer ones by calling"
-            $output += "    Complete-ApplicationFlightSubmissionPackageRollout -AppId $AppId -FlightId $FlightId -SubmissionId $SubmissionId"
-            Write-Log $($output -join [Environment]::NewLine) -Level Warning
+            Write-Log -Level Warning -Message @(
+                "Changing the rollout percentage to 100% does not ensure that all of your customers will get the",
+                "packages from the latest submissions, because some customers may be on OS versions that don't",
+                "support rollout. You must finalize the rollout in order to stop distributing the older packages",
+                "and update all existing customers to the newer ones by calling",
+                "    Complete-ApplicationFlightSubmissionPackageRollout -AppId $AppId -FlightId $FlightId -SubmissionId $SubmissionId")
         }
     }
     catch [System.InvalidOperationException]
@@ -2105,18 +2097,16 @@ function Stop-ApplicationSubmissionPackageRollout
 
         $result = Invoke-SBRestMethod @params
 
-        $output = @()
-        $output += "Package rollout for this submission has been halted."
-        $output += "Users will now receive the packages from SubmissionId: $($result.fallbackSubmissionId)"
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Package rollout for this submission has been halted.",
+            "Users will now receive the packages from SubmissionId: $($result.fallbackSubmissionId)")
 
-        $output = @()
-        $output += "Any customers who already have the newer packages will keep those packages; they won't be rolled back to the previous version."
-        $output += "To provide an update to these customers, you'll need to create a new submission with the packages you'd like them to get."
-        $output += "Note that if you use a gradual rollout in your next submission, customers who had the package you halted will be offered"
-        $output += "the new update in the same order they were offered the halted package.  The new rollout will be between your last finalized"
-        $output += "submission and your newest submission; once you halt a package rollout, those packages will no longer be distributed to any customers."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "Any customers who already have the newer packages will keep those packages; they won't be rolled back to the previous version.",
+            "To provide an update to these customers, you'll need to create a new submission with the packages you'd like them to get.",
+            "Note that if you use a gradual rollout in your next submission, customers who had the package you halted will be offered",
+            "the new update in the same order they were offered the halted package.  The new rollout will be between your last finalized",
+            "submission and your newest submission; once you halt a package rollout, those packages will no longer be distributed to any customers.")
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -88,7 +88,7 @@ function Get-ApplicationFlights
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
 
@@ -149,7 +149,7 @@ function Format-ApplicationFlights
     {
         Set-TelemetryEvent -EventName Format-ApplicationFlights
 
-        Write-Log "Displaying Application Flights..." -Level Verbose
+        Write-Log -Message "Displaying Application Flights..." -Level Verbose
 
         $publishedSubmissionField = @{ label="lastPublishedSubmission"; Expression={ if ([String]::IsNullOrEmpty($_.lastPublishedFlightSubmission.id)) { "<None>" } else { $_.lastPublishedFlightSubmission.id } }; }
         $pendingSubmissionField = @{ label="pendingSubmission"; Expression={ if ($null -eq $_.pendingFlightSubmission) { "<None>" } else { $_.pendingFlightSubmission.id } }; }
@@ -164,7 +164,7 @@ function Format-ApplicationFlights
 
     End
     {
-        Write-Log $($flights | Format-Table friendlyName, flightId, rankHigherThan, $publishedSubmissionField, $pendingSubmissionField, groupIds | Out-String)
+        Write-Log -Message $($flights | Format-Table friendlyName, flightId, rankHigherThan, $publishedSubmissionField, $pendingSubmissionField, groupIds | Out-String)
     }
 }
 
@@ -235,7 +235,7 @@ function Get-ApplicationFlight
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -295,7 +295,7 @@ function Format-ApplicationFlight
     {
         Set-TelemetryEvent -EventName Format-ApplicationFlight
 
-        Write-Log "Displaying Application Flight..." -Level Verbose
+        Write-Log -Message "Displaying Application Flight..." -Level Verbose
 
         $indentLength = 5
         $output = @()
@@ -321,7 +321,7 @@ function Format-ApplicationFlight
 
     End
     {
-        Write-Log $output
+        Write-Log -Message $output
     }
 }
 
@@ -350,13 +350,13 @@ function Get-FlightGroups
 
     Set-TelemetryEvent -EventName Get-FlightGroups
 
-    Write-Log "Opening the Dev Portal UI in your default browser to view flight groups because there is currently no API access for this data."
-    Write-Log "The FlightGroupID is the number at the end of the URL when you click on any flight group name."
+    Write-Log -Message "Opening the Dev Portal UI in your default browser to view flight groups because there is currently no API access for this data."
+    Write-Log -Message "The FlightGroupID is the number at the end of the URL when you click on any flight group name."
 
     if (-not [String]::IsNullOrWhiteSpace($global:SBInternalGroupIds))
     {
-        Write-Log "For the Microsoft-internal pre-defined flight group ids, see below:"
-        Write-Log "`n$($global:SBInternalGroupIds | Format-Table Name, @{ label="FlightGroupId"; Expression={ $_.Value }; }| Out-String)"
+        Write-Log -Message "For the Microsoft-internal pre-defined flight group ids, see below:"
+        Write-Log -Message "`n$($global:SBInternalGroupIds | Format-Table Name, @{ label="FlightGroupId"; Expression={ $_.Value }; }| Out-String)"
     }
 
     Start-Process -FilePath "https://developer.microsoft.com/en-us/dashboard/groups"
@@ -428,7 +428,7 @@ function New-ApplicationFlight
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     # Convert the input into a Json body.
     $hashBody = @{}
@@ -526,7 +526,7 @@ function Remove-ApplicationFlight
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -619,7 +619,7 @@ function Get-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -678,7 +678,7 @@ function Format-ApplicationFlightSubmission
     {
         Set-TelemetryEvent -EventName Format-ApplicationFlightSubmission
 
-        Write-Log "Displaying Application Submission..." -Level Verbose
+        Write-Log -Message "Displaying Application Submission..." -Level Verbose
 
         $indentLength = 5
         $output = @()
@@ -733,7 +733,7 @@ function Format-ApplicationFlightSubmission
 
     End
     {
-        Write-Log $output
+        Write-Log -Message $output
     }
 }
 
@@ -804,7 +804,7 @@ function Get-ApplicationFlightSubmissionStatus
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -887,7 +887,7 @@ function Remove-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -991,7 +991,7 @@ function New-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
     {
@@ -1009,7 +1009,7 @@ function New-ApplicationFlightSubmission
 
             if ($Force -and ($null -ne $pendingSubmissionId))
             {
-                Write-Log "Force creation requested. Removing pending submission." -Level Verbose
+                Write-Log -Message "Force creation requested. Removing pending submission." -Level Verbose
                 Remove-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $pendingSubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
             }
 
@@ -1022,12 +1022,12 @@ function New-ApplicationFlightSubmission
                 {
                     if ($ExistingPackageRolloutAction -eq 'Finalize')
                     {
-                        Write-Log "Finalizing package rollout for existing submission before continuing." -Level Verbose
+                        Write-Log -Message "Finalizing package rollout for existing submission before continuing." -Level Verbose
                         Complete-ApplicationFlightSubmissionPackageRollout -AppId $AppId -FlightId $FlightId -SubmissionId $publishedSubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
                     }
                     elseif ($ExistingPackageRolloutAction -eq 'Halt')
                     {
-                        Write-Log "Halting package rollout for existing submission before continuing." -Level Verbose
+                        Write-Log -Message "Halting package rollout for existing submission before continuing." -Level Verbose
                         Stop-ApplicationFlightSubmissionPackageRollout -AppId $AppId -FlightId $FlightId -SubmissionId $publishedSubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
                     }
                 }
@@ -1270,9 +1270,9 @@ function Update-ApplicationFlightSubmission
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
-    Write-Log "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
+    Write-Log -Message "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
     if ($PSCmdlet.ShouldProcess($SubmissionDataPath, "Get-Content"))
     {
         $submission = [string](Get-Content $SubmissionDataPath -Encoding UTF8) | ConvertFrom-Json
@@ -1302,7 +1302,7 @@ function Update-ApplicationFlightSubmission
             $output += "You either entered the wrong AppId at the commandline, or you're referencing the wrong submission content to upload."
 
             $newLineOutput = ($output -join [Environment]::NewLine)
-            Write-Log $newLineOutput -Level Error
+            Write-Log -Message $newLineOutput -Level Error
             throw $newLineOutput
         }
     }
@@ -1344,7 +1344,7 @@ function Update-ApplicationFlightSubmission
                 $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
 
                 $newLineOutput = ($output -join [Environment]::NewLine)
-                Write-Log $newLineOutput -Level Error
+                Write-Log -Message $newLineOutput -Level Error
                 throw $newLineOutput
             }
         }
@@ -1394,7 +1394,7 @@ function Update-ApplicationFlightSubmission
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
-            Write-Log "Uploading the package [$PackagePath] since it was provided." -Level Verbose
+            Write-Log -Message "Uploading the package [$PackagePath] since it was provided." -Level Verbose
             Set-SubmissionPackage -PackagePath $PackagePath -UploadUrl $uploadUrl -NoStatus:$NoStatus
         }
         elseif (!$AutoCommit)
@@ -1415,7 +1415,7 @@ function Update-ApplicationFlightSubmission
                 $AccessToken = $null
             }
 
-            Write-Log "Commiting the submission since -AutoCommit was requested." -Level Verbose
+            Write-Log -Message "Commiting the submission since -AutoCommit was requested." -Level Verbose
             Complete-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId -AccessToken $AccessToken -NoStatus:$NoStatus
         }
         else
@@ -1583,7 +1583,7 @@ function Patch-ApplicationFlightSubmission
         [switch] $UpdateNotesForCertification
     )
 
-    Write-Log "Patching the content of the submission." -Level Verbose
+    Write-Log -Message "Patching the content of the submission." -Level Verbose
 
     # Our method should have zero side-effects -- we don't want to modify any parameter
     # that was passed-in to us.  To that end, we'll create a deep copy of the ClonedSubmisison,
@@ -1616,7 +1616,7 @@ function Patch-ApplicationFlightSubmission
         }
         else
         {
-            Write-Log "MandatoryUpdateEffectiveDate specified without indicating IsMandatoryUpdate.  The value will be ignored." -Level Warning
+            Write-Log -Message "MandatoryUpdateEffectiveDate specified without indicating IsMandatoryUpdate.  The value will be ignored." -Level Warning
         }
     }
 
@@ -1626,7 +1626,7 @@ function Patch-ApplicationFlightSubmission
         $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages."
         $output += "Please check your input settings to New-SubmissionPackage and ensure you're providing a value for AppxPath."
         $output = $output -join [Environment]::NewLine
-        Write-Log $output -Level Error
+        Write-Log -Message $output -Level Error
         throw $output
     }
 
@@ -1660,7 +1660,7 @@ function Patch-ApplicationFlightSubmission
         if (($TargetPublishMode -eq $script:keywordSpecificDate) -and ($null -eq $TargetPublishDate))
         {
             $output = "TargetPublishMode was set to '$script:keywordSpecificDate' but TargetPublishDate was not specified."
-            Write-Log $output -Level Error
+            Write-Log -Message $output -Level Error
             throw $output
         }
 
@@ -1672,7 +1672,7 @@ function Patch-ApplicationFlightSubmission
         if ($TargetPublishMode -ne $script:keywordSpecificDate)
         {
             $output = "A TargetPublishDate was specified, but the TargetPublishMode was [$TargetPublishMode],  not '$script:keywordSpecificDate'."
-            Write-Log $output -Level Error
+            Write-Log -Message $output -Level Error
             throw $output
         }
 
@@ -1687,11 +1687,11 @@ function Patch-ApplicationFlightSubmission
     # To better assist with debugging, we'll store exactly the original and modified JSON submission bodies.
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($ClonedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
+    Write-Log -Message "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
 
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($PatchedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The patched JSON content can be found here: [$tempFile]" -Level Verbose
+    Write-Log -Message "The patched JSON content can be found here: [$tempFile]" -Level Verbose
 
     return $PatchedSubmission
 }
@@ -1765,7 +1765,7 @@ function Set-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $submissionId = $UpdatedSubmission.id
     $flightId = $UpdatedSubmission.flightId
@@ -1859,7 +1859,7 @@ function Complete-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2049,7 +2049,7 @@ function Get-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2148,7 +2148,7 @@ function Update-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2171,7 +2171,7 @@ function Update-ApplicationFlightSubmissionPackageRollout
 
         $null = Invoke-SBRestMethod @params
 
-        Write-Log "Package rollout for this submission has been updated to $Percentage%."
+        Write-Log -Message "Package rollout for this submission has been updated to $Percentage%."
 
         if ($Percentage -eq 100)
         {
@@ -2255,7 +2255,7 @@ function Stop-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2359,7 +2359,7 @@ function Complete-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2381,7 +2381,7 @@ function Complete-ApplicationFlightSubmissionPackageRollout
 
         $null = Invoke-SBRestMethod @params
 
-        Write-Log "Package rollout for this submission has been finalized.  All users in this flight will now receive these packages."
+        Write-Log -Message "Package rollout for this submission has been finalized.  All users in this flight will now receive these packages."
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -74,7 +74,7 @@ function Get-ApplicationFlights
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [ValidateScript({if ($_ -gt 0) { $true } else { throw "Must be greater than 0." }})]
         [int] $MaxResults = 100,
 
@@ -226,7 +226,7 @@ function Get-ApplicationFlight
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
@@ -379,7 +379,7 @@ function New-ApplicationFlight
 
     .PARAMETER GroupIds
         The list of Flight Group Ids that should be part of this new Flight.
- 
+
     .PARAMETER RankHigherThan
         The friendlyName of the Flight that this should be ranked higher than.
         If not provided, this will be ranked highest of all current flights.
@@ -414,7 +414,7 @@ function New-ApplicationFlight
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FriendlyName,
 
@@ -438,7 +438,7 @@ function New-ApplicationFlight
     {
         $hashBody["rankHigherThan"] = $RankHigherThan
     }
-    
+
     $body = $hashBody | ConvertTo-Json
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
@@ -518,7 +518,7 @@ function Remove-ApplicationFlight
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
@@ -533,7 +533,7 @@ function Remove-ApplicationFlight
         [StoreBrokerTelemetryProperty]::AppId = $AppId
         [StoreBrokerTelemetryProperty]::FlightId = $FlightId
     }
-    
+
     $params = @{
         "UriFragment" = "applications/$AppId/flights/$FlightId"
         "Method" = "Delete"
@@ -608,13 +608,13 @@ function Get-ApplicationFlightSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -793,13 +793,13 @@ function Get-ApplicationFlightSubmissionStatus
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -876,7 +876,7 @@ function Remove-ApplicationFlightSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
@@ -978,7 +978,7 @@ function New-ApplicationFlightSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
@@ -1216,7 +1216,7 @@ function Update-ApplicationFlightSubmission
             Mandatory,
             Position=0)]
         [string] $AppId,
-        
+
         [Parameter(
             Mandatory,
             Position=1)]
@@ -1248,7 +1248,7 @@ function Update-ApplicationFlightSubmission
         [DateTime] $MandatoryUpdateEffectiveDate,
 
         [switch] $AutoCommit,
-        
+
         [string] $SubmissionId = "",
 
         [ValidateScript({if ([System.String]::IsNullOrEmpty($SubmissionId) -or !$_) { $true } else { throw "Can't use -Force and supply a SubmissionId." }})]
@@ -1302,7 +1302,7 @@ function Update-ApplicationFlightSubmission
             $output = @()
             $output += "The AppId [$($submission.appId)] in the submission content [$SubmissionDataPath] does not match the intended AppId [$AppId]."
             $output += "You either entered the wrong AppId at the commandline, or you're referencing the wrong submission content to upload."
-            
+
             $newLineOutput = ($output -join [Environment]::NewLine)
             Write-Log $newLineOutput -Level Error
             throw $newLineOutput
@@ -1345,7 +1345,7 @@ function Update-ApplicationFlightSubmission
                 $output = @()
                 $output += "We can only modify a submission that is in the '$script:keywordPendingCommit' state."
                 $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
-                
+
                 $newLineOutput = ($output -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error
                 throw $newLineOutput
@@ -1455,7 +1455,7 @@ function Update-ApplicationFlightSubmission
     }
     catch
     {
-        Write-Log $_ -Level Error
+        Write-Log -Exception $_ -Level Error
         throw
     }
 }
@@ -1556,7 +1556,7 @@ function Patch-ApplicationFlightSubmission
     param(
         [Parameter(Mandatory)]
         [PSCustomObject] $ClonedSubmission,
-        
+
         [Parameter(Mandatory)]
         [PSCustomObject] $NewSubmission,
 
@@ -1588,7 +1588,7 @@ function Patch-ApplicationFlightSubmission
 
         [switch] $UpdateNotesForCertification
     )
-    
+
     Write-Log "Patching the content of the submission." -Level Verbose
 
     # Our method should have zero side-effects -- we don't want to modify any parameter
@@ -1630,7 +1630,7 @@ function Patch-ApplicationFlightSubmission
     if (($AddPackages -or $ReplacePackages) -and ($NewSubmission.applicationPackages.Count -eq 0))
     {
         $output = @()
-        $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages." 
+        $output += "Your submission doesn't contain any packages, so you cannot Add or Replace packages."
         $output += "Please check your input settings to New-SubmissionPackage and ensure you're providing a value for AppxPath."
         $output = $output -join [Environment]::NewLine
         Write-Log $output -Level Error
@@ -1713,7 +1713,7 @@ function Set-ApplicationFlightSubmission
     .DESCRIPTION
         Replaces the content of an existing application flight submission with the supplied
         submission content.
-    
+
         This should be called after having cloned an application flight submission via
         New-ApplicationFlightSubmission.
 
@@ -1763,7 +1763,7 @@ function Set-ApplicationFlightSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [PSCustomObject] $UpdatedSubmission,
 
@@ -1854,13 +1854,13 @@ function Complete-ApplicationFlightSubmission
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
 
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -1980,7 +1980,7 @@ function Start-ApplicationFlightSubmissionMonitor
 
         [Parameter(Mandatory)]
         [string] $FlightId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -2046,10 +2046,10 @@ function Get-ApplicationFlightSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -2058,7 +2058,7 @@ function Get-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2141,10 +2141,10 @@ function Update-ApplicationFlightSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -2157,7 +2157,7 @@ function Update-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2253,19 +2253,19 @@ function Stop-ApplicationFlightSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -2290,7 +2290,7 @@ function Stop-ApplicationFlightSubmissionPackageRollout
         $output = @()
         $output += "Package rollout for this submission has been halted."
         $output += "All users in this flight will now receive the packages from SubmissionId: $($result.fallbackSubmissionId)"
-        Write-Log $($output -join [Environment]::NewLine) 
+        Write-Log $($output -join [Environment]::NewLine)
 
         $output = @()
         $output += "Any customers who already have the newer packages will keep those packages; they won't be rolled back to the previous version."
@@ -2359,19 +2359,19 @@ function Complete-ApplicationFlightSubmissionPackageRollout
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [Parameter(Mandatory)]
         [string] $FlightId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose 
+    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -321,7 +321,7 @@ function Format-ApplicationFlight
 
     End
     {
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
 }
 
@@ -458,14 +458,13 @@ function New-ApplicationFlight
     {
         $result = Invoke-SBRestMethod @params
 
-        $output = @()
-        $output += "The new flight has been successfully created."
-        $output += "As a result of creating this new flight, a new submission has already been started."
-        $output += "For the *first* submission, instead of using the `"-Force`" parameter with Update-ApplicationFlightSubmission"
-        $output += "to remove a pre-existing pending submission before starting a new one, you should"
-        $output += "instead use the -SubmissionId parameter and reference this pre-existing submission like so:"
-        $output += "    Update-ApplicationSubmission -AppId $AppId -Flight $($result.flightId) -SubmissionId $($result.pendingFlightSubmission.id) <your additional parameters>"
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "The new flight has been successfully created.",
+            "As a result of creating this new flight, a new submission has already been started.",
+            "For the *first* submission, instead of using the `"-Force`" parameter with Update-ApplicationFlightSubmission",
+            "to remove a pre-existing pending submission before starting a new one, you should",
+            "instead use the -SubmissionId parameter and reference this pre-existing submission like so:",
+            "    Update-ApplicationSubmission -AppId $AppId -Flight $($result.flightId) -SubmissionId $($result.pendingFlightSubmission.id) <your additional parameters>")
 
         return $result
     }
@@ -734,7 +733,7 @@ function Format-ApplicationFlightSubmission
 
     End
     {
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
 }
 
@@ -1285,15 +1284,14 @@ function Update-ApplicationFlightSubmission
     {
         $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
 
-        $output = @()
-        $output += "The config file used to generate this submission did not have an AppId defined in it."
-        $output += "The AppId entry in the config helps ensure that payloads are not submitted to the wrong application."
-        $output += "Please update your app's StoreBroker config file by adding an `"appId`" property with"
-        $output += "your app's AppId to the `"appSubmission`" section.  If you're unclear on what change"
-        $output += "needs to be done, you can re-generate your config file using"
-        $output += "   New-PackageToolConfigFile -AppId $AppId -Path `"$configPath`""
-        $output += "and then diff the new config file against your current one to see the requested appId change."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "The config file used to generate this submission did not have an AppId defined in it.",
+            "The AppId entry in the config helps ensure that payloads are not submitted to the wrong application.",
+            "Please update your app's StoreBroker config file by adding an `"appId`" property with",
+            "your app's AppId to the `"appSubmission`" section.  If you're unclear on what change",
+            "needs to be done, you can re-generate your config file using",
+            "   New-PackageToolConfigFile -AppId $AppId -Path `"$configPath`"",
+            "and then diff the new config file against your current one to see the requested appId change.")
     }
     else
     {
@@ -1318,12 +1316,11 @@ function Update-ApplicationFlightSubmission
         (-not $UpdatePublishMode) -and
         (-not $UpdateNotesForCertification))
     {
-        $output = @()
-        $output += "You have not specified any `"modification`" switch for updating the submission."
-        $output += "This means that the new submission will be identical to the current one."
-        $output += "If this was not your intention, please read-up on the documentation for this command:"
-        $output += "     Get-Help Update-ApplicationFlightSubmission -ShowWindow"
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "You have not specified any `"modification`" switch for updating the submission.",
+            "This means that the new submission will be identical to the current one.",
+            "If this was not your intention, please read-up on the documentation for this command:",
+            "     Get-Help Update-ApplicationFlightSubmission -ShowWindow")
     }
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
@@ -1386,15 +1383,14 @@ function Update-ApplicationFlightSubmission
         $submissionId = $replacedSubmission.id
         $uploadUrl = $replacedSubmission.fileUploadUrl
 
-        $output = @()
-        $output += "Successfully cloned the existing submission and modified its content."
-        $output += "You can view it on the Dev Portal here:"
-        $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
-        $output += "or by running this command:"
-        $output += "    Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission"
-        $output += ""
-        $output += $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission'
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Successfully cloned the existing submission and modified its content.",
+            "You can view it on the Dev Portal here:",
+            "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "or by running this command:",
+            "    Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission",
+            "",
+            $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission')
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
@@ -1403,10 +1399,9 @@ function Update-ApplicationFlightSubmission
         }
         elseif (!$AutoCommit)
         {
-            $output = @()
-            $output += "Your next step is to upload the package using:"
-            $output += "  Upload-SubmissionPackage -PackagePath <package> -UploadUrl `"$uploadUrl`""
-            Write-Log $($output -join [Environment]::NewLine)
+            Write-Log -Message @(
+                "Your next step is to upload the package using:",
+                "  Upload-SubmissionPackage -PackagePath <package> -UploadUrl `"$uploadUrl`"")
         }
 
         if ($AutoCommit)
@@ -1425,10 +1420,9 @@ function Update-ApplicationFlightSubmission
         }
         else
         {
-            $output = @()
-            $output += "When you're ready to commit, run this command:"
-            $output += "  Commit-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId"
-            Write-Log $($output -join [Environment]::NewLine)
+            Write-Log -Message @(
+                "When you're ready to commit, run this command:",
+                "  Commit-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId")
         }
 
         # Record the telemetry for this event.
@@ -1605,13 +1599,12 @@ function Patch-ApplicationFlightSubmission
         $PatchedSubmission.packageDeliveryOptions.packageRollout.isPackageRollout = $true
         $PatchedSubmission.packageDeliveryOptions.packageRollout.packageRolloutPercentage = $PackageRolloutPercentage
 
-        $output = @()
-        $output += "Your rollout selections apply to all of your packages, but will only apply to your customers running OS"
-        $output += "versions that support package flights (Windows.Desktop build 10586 or later; Windows.Mobile build 10586.63"
-        $output += "or later, and Xbox), including any customers who get the app via Store-managed licensing via the"
-        $output += "Windows Store for Business.  When using gradual package rollout, customers on earlier OS versions will not"
-        $output += "get packages from the latest submission until you finalize the package rollout."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "Your rollout selections apply to all of your packages, but will only apply to your customers running OS",
+            "versions that support package flights (Windows.Desktop build 10586 or later; Windows.Mobile build 10586.63",
+            "or later, and Xbox), including any customers who get the app via Store-managed licensing via the",
+            "Windows Store for Business.  When using gradual package rollout, customers on earlier OS versions will not",
+            "get packages from the latest submission until you finalize the package rollout.")
     }
 
     $PatchedSubmission.packageDeliveryOptions.isMandatoryUpdate = [bool]$IsMandatoryUpdate
@@ -1888,20 +1881,18 @@ function Complete-ApplicationFlightSubmission
 
         $null = Invoke-SBRestMethod @params
 
-        $output = @()
-        $output += "The submission has been successfully committed."
-        $output += "This is just the beginning though."
-        $output += "It still has multiple phases of validation to get through, and there's no telling how long that might take."
-        $output += "You can view the progress of the submission validation on the Dev Portal here:"
-        $output += "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/"
-        $output += "or by running this command:"
-        $output += "    Get-ApplicationFlightSubmission -AppId $AppId -Flight $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission"
-        $output += "You can automatically monitor this submission with this command:"
-        $output += "    Start-ApplicationFlightSubmissionMonitor -AppId $AppId -Flight $FlightId -SubmissionId $submissionId -EmailNotifyTo $env:username"
-        $output += ""
-        $output += $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission'
-
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "The submission has been successfully committed.",
+            "This is just the beginning though.",
+            "It still has multiple phases of validation to get through, and there's no telling how long that might take.",
+            "You can view the progress of the submission validation on the Dev Portal here:",
+            "    https://dev.windows.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "or by running this command:",
+            "    Get-ApplicationFlightSubmission -AppId $AppId -Flight $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission",
+            "You can automatically monitor this submission with this command:",
+            "    Start-ApplicationFlightSubmissionMonitor -AppId $AppId -Flight $FlightId -SubmissionId $submissionId -EmailNotifyTo $env:username",
+            "",
+            $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission')
     }
     catch [System.InvalidOperationException]
     {
@@ -2184,13 +2175,12 @@ function Update-ApplicationFlightSubmissionPackageRollout
 
         if ($Percentage -eq 100)
         {
-            $output = @()
-            $output += "Changing the rollout percentage to 100% does not ensure that all of your customers will get the"
-            $output += "packages from the latest submissions, because some customers may be on OS versions that don't"
-            $output += "support rollout. You must finalize the rollout in order to stop distributing the older packages"
-            $output += "and update all existing customers to the newer ones by calling"
-            $output += "    Complete-ApplicationFlightSubmissionPackageRollout -AppId $AppId -FlightId $FlightId -SubmissionId $SubmissionId"
-            Write-Log $($output -join [Environment]::NewLine) -Level Warning
+            Write-Log -Level Warning -Message @(
+                "Changing the rollout percentage to 100% does not ensure that all of your customers will get the",
+                "packages from the latest submissions, because some customers may be on OS versions that don't",
+                "support rollout. You must finalize the rollout in order to stop distributing the older packages",
+                "and update all existing customers to the newer ones by calling",
+                "    Complete-ApplicationFlightSubmissionPackageRollout -AppId $AppId -FlightId $FlightId -SubmissionId $SubmissionId")
         }
     }
     catch [System.InvalidOperationException]
@@ -2287,18 +2277,16 @@ function Stop-ApplicationFlightSubmissionPackageRollout
 
         $result = Invoke-SBRestMethod @params
 
-        $output = @()
-        $output += "Package rollout for this submission has been halted."
-        $output += "All users in this flight will now receive the packages from SubmissionId: $($result.fallbackSubmissionId)"
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Package rollout for this submission has been halted.",
+            "All users in this flight will now receive the packages from SubmissionId: $($result.fallbackSubmissionId)")
 
-        $output = @()
-        $output += "Any customers who already have the newer packages will keep those packages; they won't be rolled back to the previous version."
-        $output += "To provide an update to these customers, you'll need to create a new submission with the packages you'd like them to get."
-        $output += "Note that if you use a gradual rollout in your next submission, customers who had the package you halted will be offered"
-        $output += "the new update in the same order they were offered the halted package.  The new rollout will be between your last finalized"
-        $output += "submission and your newest submission; once you halt a package rollout, those packages will no longer be distributed to any customers."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "Any customers who already have the newer packages will keep those packages; they won't be rolled back to the previous version.",
+            "To provide an update to these customers, you'll need to create a new submission with the packages you'd like them to get.",
+            "Note that if you use a gradual rollout in your next submission, customers who had the package you halted will be offered",
+            "the new update in the same order they were offered the halted package.  The new rollout will be between your last finalized",
+            "submission and your newest submission; once you halt a package rollout, those packages will no longer be distributed to any customers.")
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -296,7 +296,7 @@ function Format-InAppProduct
 
     End
     {
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
 }
 
@@ -854,7 +854,7 @@ function Format-InAppProductSubmission
 
     End
     {
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log $output
     }
 }
 
@@ -1312,15 +1312,14 @@ function Update-InAppProductSubmission
     {
         $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
 
-        $output = @()
-        $output += "The config file used to generate this submission did not have an IapId defined in it."
-        $output += "The IapId entry in the config helps ensure that payloads are not submitted to the wrong In-App Product."
-        $output += "Please update your app's StoreBroker config file by adding an `"iapId`" property with"
-        $output += "your IAP's IapId to the `"iapSubmission`" section.  If you're unclear on what change"
-        $output += "needs to be done, you can re-generate your config file using"
-        $output += "   New-StoreBrokerInAppProductConfigFile -IapId $IapId -Path `"$configPath`""
-        $output += "and then diff the new config file against your current one to see the requested iapId change."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "The config file used to generate this submission did not have an IapId defined in it.",
+            "The IapId entry in the config helps ensure that payloads are not submitted to the wrong In-App Product.",
+            "Please update your app's StoreBroker config file by adding an `"iapId`" property with",
+            "your IAP's IapId to the `"iapSubmission`" section.  If you're unclear on what change",
+            "needs to be done, you can re-generate your config file using",
+            "   New-StoreBrokerInAppProductConfigFile -IapId $IapId -Path `"$configPath`"",
+            "and then diff the new config file against your current one to see the requested iapId change.")
     }
     else
     {
@@ -1345,12 +1344,11 @@ function Update-InAppProductSubmission
         (-not $UpdatePricingAndAvailability) -and
         (-not $UpdateProperties))
     {
-        $output = @()
-        $output += "You have not specified any `"modification`" switch for updating the submission."
-        $output += "This means that the new submission will be identical to the current one."
-        $output += "If this was not your intention, please read-up on the documentation for this command:"
-        $output += "     Get-Help Update-InAppProductSubmission -ShowWindow"
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        Write-Log -Level Warning -Message @(
+            "You have not specified any `"modification`" switch for updating the submission.",
+            "This means that the new submission will be identical to the current one.",
+            "If this was not your intention, please read-up on the documentation for this command:",
+            "     Get-Help Update-InAppProductSubmission -ShowWindow")
     }
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
@@ -1408,15 +1406,14 @@ function Update-InAppProductSubmission
         $submissionId = $replacedSubmission.id
         $uploadUrl = $replacedSubmission.fileUploadUrl
 
-        $output = @()
-        $output += "Successfully cloned the existing submission and modified its content."
-        $output += "You can view it on the Dev Portal here:"
-        $output += "    https://dev.windows.com/en-us/dashboard/iaps/$IapId/submissions/$submissionId/"
-        $output += "or by running this command:"
-        $output += "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission"
-        $output += ""
-        $output += $script:manualPublishWarning -f 'Update-InAppProductSubmission'
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "Successfully cloned the existing submission and modified its content.",
+            "You can view it on the Dev Portal here:",
+            "    https://dev.windows.com/en-us/dashboard/iaps/$IapId/submissions/$submissionId/",
+            "or by running this command:",
+            "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission",
+            "",
+            $script:manualPublishWarning -f 'Update-InAppProductSubmission')
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
@@ -1425,10 +1422,9 @@ function Update-InAppProductSubmission
         }
         elseif (!$AutoCommit)
         {
-            $output = @()
-            $output += "Your next step is to upload the package using:"
-            $output += "  Upload-SubmissionPackage -PackagePath <package> -UploadUrl `"$uploadUrl`""
-            Write-Log $($output -join [Environment]::NewLine)
+            Write-Log -Message @(
+                "Your next step is to upload the package using:",
+                "  Upload-SubmissionPackage -PackagePath <package> -UploadUrl `"$uploadUrl`"")
         }
 
         if ($AutoCommit)
@@ -1447,10 +1443,9 @@ function Update-InAppProductSubmission
         }
         else
         {
-            $output = @()
-            $output += "When you're ready to commit, run this command:"
-            $output += "  Commit-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId"
-            Write-Log $($output -join [Environment]::NewLine)
+            Write-Log -Message @(
+                "When you're ready to commit, run this command:",
+                "  Commit-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId")
         }
 
         # Record the telemetry for this event.
@@ -1877,19 +1872,18 @@ function Complete-InAppProductSubmission
 
         $null = Invoke-SBRestMethod @params
 
-        $output = @()
-        $output += "The submission has been successfully committed."
-        $output += "This is just the beginning though."
-        $output += "It still has multiple phases of validation to get through, and there's no telling how long that might take."
-        $output += "You can view the progress of the submission validation on the Dev Portal here:"
-        $output += "    https://dev.windows.com/en-us/dashboard/iaps/$IapId/submissions/$submissionId/"
-        $output += "or by running this command:"
-        $output += "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission"
-        $output += "You can automatically monitor this submission with this command:"
-        $output += "    Start-InAppProductSubmissionMonitor -IapId $IapId -SubmissionId $submissionId -EmailNotifyTo $env:username"
-        $output += ""
-        $output += $script:manualPublishWarning -f 'Update-InAppProductSubmission'
-        Write-Log $($output -join [Environment]::NewLine)
+        Write-Log -Message @(
+            "The submission has been successfully committed.",
+            "This is just the beginning though.",
+            "It still has multiple phases of validation to get through, and there's no telling how long that might take.",
+            "You can view the progress of the submission validation on the Dev Portal here:",
+            "    https://dev.windows.com/en-us/dashboard/iaps/$IapId/submissions/$submissionId/",
+            "or by running this command:",
+            "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission",
+            "You can automatically monitor this submission with this command:",
+            "    Start-InAppProductSubmissionMonitor -IapId $IapId -SubmissionId $submissionId -EmailNotifyTo $env:username",
+            "",
+            $script:manualPublishWarning -f 'Update-InAppProductSubmission')
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -212,7 +212,7 @@ function Get-InAppProduct
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -374,7 +374,7 @@ function Get-ApplicationInAppProducts
     param(
         [Parameter(Mandatory)]
         [string] $AppId,
-        
+
         [ValidateScript({if ($_ -gt 0) { $true } else { throw "Must be greater than 0." }})]
         [int] $MaxResults = 100,
 
@@ -483,7 +483,7 @@ function New-InAppProduct
     .PARAMETER ProductType
         Indicates what kind of IAP this is.
         One of: NotSet, Consumable, Durable, Subscription
- 
+
     .PARAMETER ApplicationIds
         The list of Application ID's that this IAP should be associated with.
 
@@ -536,14 +536,14 @@ function New-InAppProduct
     $hashBody["productId"] = $ProductId
     $hashBody["productType"] = $ProductType
     $hashBody["applicationIds"] = $ApplicationIds
-    
+
     $body = $hashBody | ConvertTo-Json
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::ProductId = $ProductId
         [StoreBrokerTelemetryProperty]::ProductType = $ProductType
     }
-    
+
     $params = @{
         "UriFragment" = "inappproducts/"
         "Method" = "Post"
@@ -599,7 +599,7 @@ function Remove-InAppProduct
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -680,10 +680,10 @@ function Get-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -695,7 +695,7 @@ function Get-InAppProductSubmission
         [StoreBrokerTelemetryProperty]::IapId = $IapId
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
     }
-    
+
     $params = @{
         "UriFragment" = "inappproducts/$IapId/submissions/$SubmissionId"
         "Method" = "Get"
@@ -909,10 +909,10 @@ function Get-InAppProductSubmissionStatus
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus
@@ -924,7 +924,7 @@ function Get-InAppProductSubmissionStatus
         [StoreBrokerTelemetryProperty]::IapId = $IapId
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
     }
-    
+
     $params = @{
         "UriFragment" = "inappproducts/$IapId/submissions/$SubmissionId/status"
         "Method" = "Get"
@@ -986,7 +986,7 @@ function Remove-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
@@ -1001,7 +1001,7 @@ function Remove-InAppProductSubmission
         [StoreBrokerTelemetryProperty]::IapId = $IapId
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
     }
-    
+
     $params = @{
         "UriFragment" = "inappproducts/$IapId/submissions/$SubmissionId"
         "Method" = "Delete"
@@ -1075,7 +1075,7 @@ function New-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [switch] $Force,
 
         [string] $AccessToken = "",
@@ -1261,7 +1261,7 @@ function Update-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [Parameter(Mandatory)]
         [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
         [string] $SubmissionDataPath,
@@ -1278,7 +1278,7 @@ function Update-InAppProductSubmission
         [string] $Visibility = $script:keywordDefault,
 
         [switch] $AutoCommit,
-        
+
         [string] $SubmissionId = "",
 
         [ValidateScript({if ([System.String]::IsNullOrEmpty($SubmissionId) -or !$_) { $true } else { throw "Can't use -Force and supply a SubmissionId." }})]
@@ -1311,7 +1311,7 @@ function Update-InAppProductSubmission
     if ([String]::IsNullOrWhiteSpace($submission.iapId))
     {
         $configPath = Join-Path -Path ([System.Environment]::GetFolderPath('Desktop')) -ChildPath 'newconfig.json'
-        
+
         $output = @()
         $output += "The config file used to generate this submission did not have an IapId defined in it."
         $output += "The IapId entry in the config helps ensure that payloads are not submitted to the wrong In-App Product."
@@ -1329,7 +1329,7 @@ function Update-InAppProductSubmission
             $output = @()
             $output += "The IapId [$($submission.iapId)] in the submission content [$SubmissionDataPath] does not match the intended IapId [$IapId]."
             $output += "You either entered the wrong IapId at the commandline, or you're referencing the wrong submission content to upload."
-            
+
             $newLineOutput = ($output -join [Environment]::NewLine)
             Write-Log $newLineOutput -Level Error
             throw $newLineOutput
@@ -1372,7 +1372,7 @@ function Update-InAppProductSubmission
                 $output = @()
                 $output += "We can only modify a submission that is in the '$script:keywordPendingCommit' state."
                 $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
-                
+
                 $newLineOutput = ($output -join [Environment]::NewLine)
                 Write-Log $newLineOutput -Level Error
                 throw $newLineOutput
@@ -1474,7 +1474,7 @@ function Update-InAppProductSubmission
     }
     catch
     {
-        Write-Log $_ -Level Error
+        Write-Log -Exception $_ -Level Error
         throw
     }
 }
@@ -1570,7 +1570,7 @@ function Patch-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [PSCustomObject] $ClonedSubmission,
-        
+
         [Parameter(Mandatory)]
         [PSCustomObject] $NewSubmission,
 
@@ -1590,7 +1590,7 @@ function Patch-InAppProductSubmission
 
         [switch] $UpdateProperties
     )
-    
+
     Write-Log "Patching the content of the submission." -Level Verbose
 
     # Our method should have zero side-effects -- we don't want to modify any parameter
@@ -1635,7 +1635,7 @@ function Patch-InAppProductSubmission
                     }
                 }
     }
-    
+
     # For the remaining switches, simply copy the field if it is a scalar, or
     # DeepCopy-Object if it is an object.
     if ($UpdatePublishModeAndVisibility)
@@ -1711,7 +1711,7 @@ function Set-InAppProductSubmission
     .DESCRIPTION
         Replaces the content of an existing In-App Product submission with the supplied
         submission content.
-    
+
         This should be called after having cloned an In-App Product submission via
         New-InAppProductSubmission.
 
@@ -1761,7 +1761,7 @@ function Set-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [Parameter(Mandatory)]
         [PSCustomObject] $UpdatedSubmission,
 
@@ -1847,10 +1847,10 @@ function Complete-InAppProductSubmission
     param(
         [Parameter(Mandatory)]
         [string] $IapId,
-        
+
         [Parameter(Mandatory)]
         [string] $SubmissionId,
-        
+
         [string] $AccessToken = "",
 
         [switch] $NoStatus

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -82,7 +82,7 @@ function Get-InAppProducts
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $params = @{
         "UriFragment" = "inappproducts/"
@@ -141,7 +141,7 @@ function Format-InAppProducts
     {
         Set-TelemetryEvent -EventName Format-InAppProducts
 
-        Write-Log "Displaying IAP's..." -Level Verbose
+        Write-Log -Message "Displaying IAP's..." -Level Verbose
 
         $publishedSubmissionField = @{ label="lastPublishedSubmission"; Expression={ if (([String]::IsNullOrEmpty($_.lastPublishedInAppProductSubmission.id)) -or ($_.lastPublishedInAppProductSubmission.id -eq "0")) { "<None>" } else { $_.lastPublishedInAppProductSubmission.id } }; }
         $pendingSubmissionField = @{ label="pendingSubmission"; Expression={ if (($null -eq $_.pendingInAppProductSubmission) -or ($_.pendingInAppProductSubmission.id -eq "0")) { "<None>" } else { $_.pendingInAppProductSubmission.id } }; }
@@ -157,7 +157,7 @@ function Format-InAppProducts
 
     End
     {
-        Write-Log $($iaps | Sort-Object productId | Format-Table id, productId, productType, $publishedSubmissionField, $pendingSubmissionField, $applicationsField | Out-String)
+        Write-Log -Message $($iaps | Sort-Object productId | Format-Table id, productId, productType, $publishedSubmissionField, $pendingSubmissionField, $applicationsField | Out-String)
     }
 }
 
@@ -218,7 +218,7 @@ function Get-InAppProduct
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::IapId = $IapId }
 
@@ -276,7 +276,7 @@ function Format-InAppProduct
     {
         Set-TelemetryEvent -EventName Format-InAppProduct
 
-        Write-Log "Displaying IAP..." -Level Verbose
+        Write-Log -Message "Displaying IAP..." -Level Verbose
 
         $indentLength = 5
         $output = @()
@@ -296,7 +296,7 @@ function Format-InAppProduct
 
     End
     {
-        Write-Log $output
+        Write-Log -Message $output
     }
 }
 
@@ -388,7 +388,7 @@ function Get-ApplicationInAppProducts
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
 
@@ -450,7 +450,7 @@ function Format-ApplicationInAppProducts
     {
         Set-TelemetryEvent -EventName Format-ApplicationInAppProducts
 
-        Write-Log "Displaying Application IAP's..." -Level Verbose
+        Write-Log -Message "Displaying Application IAP's..." -Level Verbose
 
         $iaps = @()
     }
@@ -462,7 +462,7 @@ function Format-ApplicationInAppProducts
 
     End
     {
-        Write-Log $($iaps | Format-Table inAppProductId | Out-String)
+        Write-Log -Message $($iaps | Format-Table inAppProductId | Out-String)
     }
 }
 
@@ -529,7 +529,7 @@ function New-InAppProduct
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     # Convert the input into a Json body.
     $hashBody = @{}
@@ -605,7 +605,7 @@ function Remove-InAppProduct
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::IapId = $IapId }
 
@@ -689,7 +689,7 @@ function Get-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::IapId = $IapId
@@ -750,7 +750,7 @@ function Format-InAppProductSubmission
     {
         Set-TelemetryEvent -EventName Format-InAppProductSubmission
 
-        Write-Log "Displaying IAP Submission..." -Level Verbose
+        Write-Log -Message "Displaying IAP Submission..." -Level Verbose
 
         $indentLength = 5
         $output = @()
@@ -854,7 +854,7 @@ function Format-InAppProductSubmission
 
     End
     {
-        Write-Log $output
+        Write-Log -Message $output
     }
 }
 
@@ -918,7 +918,7 @@ function Get-InAppProductSubmissionStatus
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::IapId = $IapId
@@ -995,7 +995,7 @@ function Remove-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::IapId = $IapId
@@ -1083,7 +1083,7 @@ function New-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
     {
@@ -1095,7 +1095,7 @@ function New-InAppProductSubmission
         # The Force switch tells us that we need to remove any pending submission
         if ($Force)
         {
-            Write-Log "Force creation requested.  Ensuring that there is no existing pending submission." -Level Verbose
+            Write-Log -Message "Force creation requested.  Ensuring that there is no existing pending submission." -Level Verbose
 
             $iap = Get-InAppProduct -IapId $IapId -AccessToken $AccessToken -NoStatus:$NoStatus
             $pendingSubmissionId = $iap.pendingInAppProductSubmission.id
@@ -1299,9 +1299,9 @@ function Update-InAppProductSubmission
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
-    Write-Log "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
+    Write-Log -Message "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
     if ($PSCmdlet.ShouldProcess($SubmissionDataPath, "Get-Content"))
     {
         $submission = [string](Get-Content $SubmissionDataPath -Encoding UTF8) | ConvertFrom-Json
@@ -1330,7 +1330,7 @@ function Update-InAppProductSubmission
             $output += "You either entered the wrong IapId at the commandline, or you're referencing the wrong submission content to upload."
 
             $newLineOutput = ($output -join [Environment]::NewLine)
-            Write-Log $newLineOutput -Level Error
+            Write-Log -Message $newLineOutput -Level Error
             throw $newLineOutput
         }
     }
@@ -1372,7 +1372,7 @@ function Update-InAppProductSubmission
                 $output += "The submission that you requested to modify ($SubmissionId) is in '$($submissionToUpdate.status)' state."
 
                 $newLineOutput = ($output -join [Environment]::NewLine)
-                Write-Log $newLineOutput -Level Error
+                Write-Log -Message $newLineOutput -Level Error
                 throw $newLineOutput
             }
         }
@@ -1417,7 +1417,7 @@ function Update-InAppProductSubmission
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
-            Write-Log "Uploading the package [$PackagePath] since it was provided." -Level Verbose
+            Write-Log -Message "Uploading the package [$PackagePath] since it was provided." -Level Verbose
             Set-SubmissionPackage -PackagePath $PackagePath -UploadUrl $uploadUrl -NoStatus:$NoStatus
         }
         elseif (!$AutoCommit)
@@ -1438,7 +1438,7 @@ function Update-InAppProductSubmission
                 $AccessToken = $null
             }
 
-            Write-Log "Commiting the submission since -AutoCommit was requested." -Level Verbose
+            Write-Log -Message "Commiting the submission since -AutoCommit was requested." -Level Verbose
             Complete-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId -AccessToken $AccessToken -NoStatus:$NoStatus
         }
         else
@@ -1586,7 +1586,7 @@ function Patch-InAppProductSubmission
         [switch] $UpdateProperties
     )
 
-    Write-Log "Patching the content of the submission." -Level Verbose
+    Write-Log -Message "Patching the content of the submission." -Level Verbose
 
     # Our method should have zero side-effects -- we don't want to modify any parameter
     # that was passed-in to us.  To that end, we'll create a deep copy of the ClonedSubmisison,
@@ -1647,7 +1647,7 @@ function Patch-InAppProductSubmission
         if (($TargetPublishMode -eq $script:keywordSpecificDate) -and ($null -eq $TargetPublishDate))
         {
             $output = "TargetPublishMode was set to '$script:keywordSpecificDate' but TargetPublishDate was not specified."
-            Write-Log $output -Level Error
+            Write-Log -Message $output -Level Error
             throw $output
         }
 
@@ -1659,7 +1659,7 @@ function Patch-InAppProductSubmission
         if ($TargetPublishMode -ne $script:keywordSpecificDate)
         {
             $output = "A TargetPublishDate was specified, but the TargetPublishMode was [$TargetPublishMode],  not '$script:keywordSpecificDate'."
-            Write-Log $output -Level Error
+            Write-Log -Message $output -Level Error
             throw $output
         }
 
@@ -1687,11 +1687,11 @@ function Patch-InAppProductSubmission
     # To better assist with debugging, we'll store exactly the original and modified JSON submission bodies.
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($ClonedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
+    Write-Log -Message "The original cloned JSON content can be found here: [$tempFile]" -Level Verbose
 
     $tempFile = [System.IO.Path]::GetTempFileName() # New-TemporaryFile requires PS 5.0
     ($PatchedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth) | Set-Content -Path $tempFile -Encoding UTF8
-    Write-Log "The patched JSON content can be found here: [$tempFile]" -Level Verbose
+    Write-Log -Message "The patched JSON content can be found here: [$tempFile]" -Level Verbose
 
     return $PatchedSubmission
 }
@@ -1765,7 +1765,7 @@ function Set-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $submissionId = $UpdatedSubmission.id
     $body = [string]($UpdatedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth)
@@ -1851,7 +1851,7 @@ function Complete-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -68,7 +68,7 @@ function Initialize-TelemetryGlobalVariables
 
     .NOTES
         Internal-only helper method.
-    
+
         The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
         which can only be applied to functions.  Otherwise, we would have just had the relevant
         initialization code directly above the function that references the variable.
@@ -167,14 +167,14 @@ function Get-ApplicationInsightsDllPath
         on the machine, and returns the path to it.
 
         This will first look for the assembly in the module's script directory.
-        
+
         Next it will look for the assembly in the location defined by
         $SBAlternateAssemblyDir.  This value would have to be defined by the user
         prior to execution of this cmdlet.
-        
+
         If not found there, it will look in a temp folder established during this
         PowerShell session.
-        
+
         If still not found, it will download the nuget package
         for it to a temp folder accessible during this PowerShell session.
 
@@ -228,14 +228,14 @@ function Get-DiagnosticsTracingDllPath
         on the machine, and returns the path to it.
 
         This will first look for the assembly in the module's script directory.
-        
+
         Next it will look for the assembly in the location defined by
         $SBAlternateAssemblyDir.  This value would have to be defined by the user
         prior to execution of this cmdlet.
-        
+
         If not found there, it will look in a temp folder established during this
         PowerShell session.
-        
+
         If still not found, it will download the nuget package
         for it to a temp folder accessible during this PowerShell session.
 
@@ -289,14 +289,14 @@ function Get-ThreadingTasksDllPath
         on the machine, and returns the path to it.
 
         This will first look for the assembly in the module's script directory.
-        
+
         Next it will look for the assembly in the location defined by
         $SBAlternateAssemblyDir.  This value would have to be defined by the user
         prior to execution of this cmdlet.
-        
+
         If not found there, it will look in a temp folder established during this
         PowerShell session.
-        
+
         If still not found, it will download the nuget package
         for it to a temp folder accessible during this PowerShell session.
 
@@ -351,16 +351,16 @@ function Get-TelemetryClient
 
         If the singleton hasn't been initialized yet, this will ensure all dependenty assemblies
         are available on the machine, create the client and initialize its properties.
-        
+
         This will first look for the dependent assemblies in the module's script directory.
-        
+
         Next it will look for the assemblies in the location defined by
         $SBAlternateAssemblyDir.  This value would have to be defined by the user
         prior to execution of this cmdlet.
-        
+
         If not found there, it will look in a temp folder established during this
         PowerShell session.
-        
+
         If still not found, it will download the nuget package
         for it to a temp folder accessible during this PowerShell session.
 
@@ -520,7 +520,7 @@ function Set-TelemetryEvent
     {
         # Telemetry should be best-effort.  Failures while trying to handle telemetry should not
         # cause exceptions in the app itself.
-        Write-Log "Set-TelemetryEvent failed: $($_.Exception.Message)" -Level Error
+        Write-Log "Set-TelemetryEvent failed:" -Exception $_ -Level Error
     }
 }
 
@@ -629,7 +629,7 @@ function Set-TelemetryException
     {
         # Telemetry should be best-effort.  Failures while trying to handle telemetry should not
         # cause exceptions in the app itself.
-        Write-Log "Set-TelemetryException failed: $($_.Exception.Message)" -Level Error
+        Write-Log "Set-TelemetryException failed:" -Exception $_ -Level Error
     }
 }
 
@@ -689,7 +689,7 @@ function Flush-TelemetryClient
     }
     catch [System.Net.WebException]
     {
-        Write-Log "Encountered exception while trying to flush telemetry events. [$($_.Exception.Message)]" -Level Warning
+        Write-Log "Encountered exception while trying to flush telemetry events:" -Exception $_ -Level Warning
 
         Set-TelemetryException -Exception ($_.Exception) -ErrorBucket "TelemetryFlush" -NoFlush -NoStatus:$NoStatus
     }
@@ -698,7 +698,7 @@ function Flush-TelemetryClient
         # Any other scenario is one that we want to identify and fix so that we don't miss telemetry
         $output = @()
         $output += "Encountered a problem while trying to record telemetry events."
-        $output += $_.Exception.Message
+        $output += Out-String -InputObject $_
         $output += "This is non-fatal, but it would be helpful if you could report this problem"
         $output += "to the StoreBroker team for further investigation."
         Write-Log $($output -join [Environment]::NewLine) -Level Warning

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -397,8 +397,8 @@ function Get-TelemetryClient
 
     if ($null -eq $script:SBTelemetryClient)
     {
-        Write-Log "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information."
-        Write-Log "Initializing telemetry client." -Level Verbose
+        Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information."
+        Write-Log -Message "Initializing telemetry client." -Level Verbose
 
         $dlls = @(
                     (Get-ThreadingTasksDllPath -NoStatus:$NoStatus),
@@ -494,11 +494,11 @@ function Set-TelemetryEvent
 
     if ($global:SBDisableTelemetry)
     {
-        Write-Log "Telemetry has been disabled via `$global:SBDisableTelemetry. Skipping reporting event." -Level Verbose
+        Write-Log -Message "Telemetry has been disabled via `$global:SBDisableTelemetry. Skipping reporting event." -Level Verbose
         return
     }
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -520,7 +520,7 @@ function Set-TelemetryEvent
     {
         # Telemetry should be best-effort.  Failures while trying to handle telemetry should not
         # cause exceptions in the app itself.
-        Write-Log "Set-TelemetryEvent failed:" -Exception $_ -Level Error
+        Write-Log -Message "Set-TelemetryEvent failed:" -Exception $_ -Level Error
     }
 }
 
@@ -597,11 +597,11 @@ function Set-TelemetryException
 
     if ($global:SBDisableTelemetry)
     {
-        Write-Log "Telemetry has been disabled via `$global:SBDisableTelemetry. Skipping reporting event." -Level Verbose
+        Write-Log -Message "Telemetry has been disabled via `$global:SBDisableTelemetry. Skipping reporting event." -Level Verbose
         return
     }
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     try
     {
@@ -629,7 +629,7 @@ function Set-TelemetryException
     {
         # Telemetry should be best-effort.  Failures while trying to handle telemetry should not
         # cause exceptions in the app itself.
-        Write-Log "Set-TelemetryException failed:" -Exception $_ -Level Error
+        Write-Log -Message "Set-TelemetryException failed:" -Exception $_ -Level Error
     }
 }
 
@@ -675,11 +675,11 @@ function Flush-TelemetryClient
 
     if ($global:SBDisableTelemetry)
     {
-        Write-Log "Telemetry has been disabled via `$global:SBDisableTelemetry. Skipping reporting event." -Level Verbose
+        Write-Log -Message "Telemetry has been disabled via `$global:SBDisableTelemetry. Skipping reporting event." -Level Verbose
         return
     }
 
-    Write-Log "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
 
     $telemetryClient = Get-TelemetryClient -NoStatus:$NoStatus
 
@@ -689,7 +689,7 @@ function Flush-TelemetryClient
     }
     catch [System.Net.WebException]
     {
-        Write-Log "Encountered exception while trying to flush telemetry events:" -Exception $_ -Level Warning
+        Write-Log -Message "Encountered exception while trying to flush telemetry events:" -Exception $_ -Level Warning
 
         Set-TelemetryException -Exception ($_.Exception) -ErrorBucket "TelemetryFlush" -NoFlush -NoStatus:$NoStatus
     }

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -698,9 +698,8 @@ function Flush-TelemetryClient
         # Any other scenario is one that we want to identify and fix so that we don't miss telemetry
         $output = @()
         $output += "Encountered a problem while trying to record telemetry events."
-        $output += Out-String -InputObject $_
         $output += "This is non-fatal, but it would be helpful if you could report this problem"
-        $output += "to the StoreBroker team for further investigation."
-        Write-Log $($output -join [Environment]::NewLine) -Level Warning
+        $output += "to the StoreBroker team for further investigation:"
+        Write-Log $($output -join [Environment]::NewLine) -Exception $_ -Level Warning
     }
 }

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -696,10 +696,9 @@ function Flush-TelemetryClient
     catch
     {
         # Any other scenario is one that we want to identify and fix so that we don't miss telemetry
-        $output = @()
-        $output += "Encountered a problem while trying to record telemetry events."
-        $output += "This is non-fatal, but it would be helpful if you could report this problem"
-        $output += "to the StoreBroker team for further investigation:"
-        Write-Log $($output -join [Environment]::NewLine) -Exception $_ -Level Warning
+        Write-Log -Level Warning -Exception $_ -Message @(
+            "Encountered a problem while trying to record telemetry events.",
+            "This is non-fatal, but it would be helpful if you could report this problem",
+            "to the StoreBroker team for further investigation:")
     }
 }


### PR DESCRIPTION
Previously, users of Write-Log were left to handle creating messages themselves when logging an exception.  Typically, our use has been to extract the exception's message and log this string. The issue with this approach is that we lose other valuable information, such as the originating script, line, exception type, etc.

With this change, Write-Log now accepts a -Exception parameter and handles logging the full exception information.  This new functionality works in combination with the existing -Message parameter, so that users can log some context before logging the exception information.  We hope that this change will make debugging StoreBroker issues faster and more intuitive for the reader.

Additional changes:
- Write-Log properly handles pipelining multiple strings to the -Message parameter.
- Existing uses of Write-Log have been modified to use the new -Exception parameter where applicable.
- Spaces have been made uniform across touched files.