### PR TITLE
Make polling SubmissionMonitor polling interval configurable

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.14.0'
+    ModuleVersion = '1.14.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'
@@ -135,7 +135,7 @@
 
     #VariablesToExport = '*'
 
-    # Private data to pass to the module specified in RootModule/ModuleToProcess. 
+    # Private data to pass to the module specified in RootModule/ModuleToProcess.
     PrivateData = @{
         # Hashtable with additional module metadata used by PowerShell.
         PSData = @{

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1145,6 +1145,10 @@ function Start-SubmissionMonitor
         If provided, this will treat the submission being monitored as an In-App Product
         submission as opposed to an application submission.
 
+    .PARAMETER PollingInterval
+        The number of minutes that SubmissionMonitor should sleep before re-polling for
+        status again.
+
     .PARAMETER NoStatus
         If this switch is specified, long-running commands will run on the main thread
         with no commandline status update.  When not specified, those commands run in
@@ -1209,6 +1213,8 @@ function Start-SubmissionMonitor
             ParameterSetName="Iap",
             Position=0)]
         [string] $IapId,
+
+        [int] $PollingInterval = 5,
 
         [switch] $NoStatus,
 
@@ -1402,7 +1408,7 @@ function Start-SubmissionMonitor
 
         if ($shouldMonitor)
         {
-            $secondsBetweenChecks = 60
+            $secondsBetweenChecks = $PollingInterval * 60
             Write-Log -Message "Status is [$lastStatus]. Waiting $secondsBetweenChecks seconds before checking again..."
             Start-Sleep -Seconds $secondsBetweenChecks
         }


### PR DESCRIPTION
...and change the default from 1 minute to 5 minutes.
This is in an effort to work around potential race conditions in the
API that return incorrect status codes shortly after a submission
has been committed.