### PR TITLE
Ensure that loc comments in PDP's are immediately before their content

### DIFF
--- a/Extensions/ConvertFrom-ExistingIapSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingIapSubmission.ps1
@@ -206,7 +206,9 @@ function Add-Title
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = @($script:CommentFormat -f $maxChars, "IAP $elementName"; " [required] ")
+        "Comment" = @(
+            " [required] ",
+            ($script:CommentFormat -f $maxChars, "IAP $elementName"))
     }
 
     Add-ToElement @paramSet
@@ -241,7 +243,9 @@ function Add-Description
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = @("$script:CommentFormat" -f $maxChars, "IAP $elementName"; " [optional] ")
+        "Comment" = @(
+            " [optional] ",
+            ($script:CommentFormat -f $maxChars, "IAP $elementName"))
     }
 
     Add-ToElement @paramSet
@@ -471,7 +475,7 @@ function Show-ImageFileNames
     }
 
     # If there are no images being used at all, then we can also early return
-    $imageCount = 0;
+    $imageCount = 0
     foreach ($lang in $LangImageNames.GetEnumerator())
     {
         $imageCount += $lang.Value.Count

--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -302,21 +302,21 @@ function Add-AppStoreName
     $comment = $elementNode.OwnerDocument.CreateComment(" $($Listing.title) ")
     $elementNode.PrependChild($comment) | Out-Null
 
-    $comment = $elementNode.OwnerDocument.CreateComment(' Uncomment this next line if you wish to specify one explicitly instead. ')
+    # Add loc comment to parent (we need loc comments to be directly before the content)
+    $maxChars = 200
+    $paramSet = @{
+        "Element"   = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
+        "Comment"   = ($script:CommentFormat -f $maxChars, "App $elementName");
+    }
+
+    Add-ToElement @paramSet
+
+    $comment = $elementNode.OwnerDocument.CreateComment(' Uncomment the Store name if you wish to specify one explicitly instead. ')
     $elementNode.PrependChild($comment) | Out-Null
 
     $comment = $elementNode.OwnerDocument.CreateComment(' This is optional.  AppStoreName is typically extracted from your package''s AppxManifest DisplayName property. ')
     $elementNode.PrependChild($comment) | Out-Null
-
-    # Add comment to parent
-    $maxChars = 200
-    $paramSet = @{
-        "Element" = $elementNode;
-        "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = $script:CommentFormat -f $maxChars, "App $elementName";
-    }
-
-    Add-ToElement @paramSet
 }
 
 function Add-Keywords
@@ -354,7 +354,7 @@ function Add-Keywords
     $maxChildren = 7
     $paramSet = @{
         "Element" = $elementNode;
-        "Comment" = $script:SectionCommentFormat -f $maxChars, $maxChildren;
+        "Comment" = ($script:SectionCommentFormat -f $maxChars, $maxChildren);
     }
 
     Add-ToElement @paramSet
@@ -399,7 +399,7 @@ function Add-Description
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = $script:CommentFormat -f $maxChars, "App $elementName";
+        "Comment" = ($script:CommentFormat -f $maxChars, "App $elementName");
     }
 
     Add-ToElement @paramSet
@@ -435,7 +435,7 @@ function Add-ReleaseNotes
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = $script:CommentFormat -f $maxChars, "App Release Note";
+        "Comment" = ($script:CommentFormat -f $maxChars, "App Release Note");
     }
 
     Add-ToElement @paramSet
@@ -699,7 +699,7 @@ function Add-CopyrightAndTrademark
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f "CopyrightandTrademark" };
-        "Comment" = $script:CommentFormat -f $maxChars, "Copyright and Trademark";
+        "Comment" = ($script:CommentFormat -f $maxChars, "Copyright and Trademark");
     }
 
     Add-ToElement @paramSet
@@ -735,7 +735,7 @@ function Add-AdditionalLicenseTerms
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = $script:CommentFormat -f $maxChars, "Additional License Terms";
+        "Comment" = ($script:CommentFormat -f $maxChars, "Additional License Terms");
     }
 
     Add-ToElement @paramSet
@@ -770,7 +770,7 @@ function Add-WebsiteUrl
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = $script:CommentFormat -f $maxChars, $elementName;
+        "Comment" = ($script:CommentFormat -f $maxChars, $elementName);
     }
 
     Add-ToElement @paramSet
@@ -805,7 +805,7 @@ function Add-SupportContact
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f $elementName };
-        "Comment" = $script:CommentFormat -f $maxChars, "Support Contact Info";
+        "Comment" = ($script:CommentFormat -f $maxChars, "Support Contact Info");
     }
 
     Add-ToElement @paramSet
@@ -840,7 +840,7 @@ function Add-PrivacyPolicy
     $paramSet = @{
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = $script:LocIdFormat -f "PrivacyURL" };
-        "Comment" = $script:CommentFormat -f $maxChars, "Privacy Policy URL";
+        "Comment" = ($script:CommentFormat -f $maxChars, "Privacy Policy URL");
     }
 
     Add-ToElement @paramSet

--- a/PDP/InAppProductDescription.xml
+++ b/PDP/InAppProductDescription.xml
@@ -5,15 +5,15 @@
     Release="1611">
 
   <!-- Valid length: 100 character limit -->
-  <Title _locID="Iap_Title">
+  <Title _locID="Iap_Title"><!-- [required] -->
     <!-- _locComment_text="{MaxLength=100} IAP Title"-->
-    <!-- [required] -->My Localized App Add-on IAP
+    My Localized App Add-on IAP
   </Title>
 
    <!-- Valid length: 200 character limit -->
-   <Description _locID="Iap_Description">
+   <Description _locID="Iap_Description"><!-- [optional] -->
      <!-- _locComment_text="{MaxLength=200} IAP Description" -->
-     <!-- [optional] -->This add-on will provide you with 200 extra coins.
+     This add-on will provide you with 200 extra coins.
    </Description>
 
   <!-- [optional] Specifying an icon is optional. If provided, the icon must be a 300 x 300 png file. -->

--- a/PDP/ProductDescription.xml
+++ b/PDP/ProductDescription.xml
@@ -7,7 +7,7 @@
   <!-- Valid length: 200 character limit -->
   <AppStoreName _locID="App_StoreName">
     <!-- This is optional.  AppStoreName is typically extracted from your package's AppxManifest DisplayName property. -->
-    <!-- _locComment_text="{MaxLength=200} App StoreName"-->My Localized AppName
+    <!-- _locComment_text="{MaxLength=200} App StoreName" -->My Localized AppName
   </AppStoreName>
 
   <Keywords>
@@ -19,12 +19,12 @@
     <Keyword _locID="App_keyword5"><!-- _locComment_text="{MaxLength=30} App keyword 5" -->Video sharing</Keyword>
   </Keywords>
    <!-- Valid length: 10000 character limit -->
-   <Description _locID="App_Description"><!-- _locComment_text="{MaxLength=10000} App Description" --> 
-     Turn any video into a memorable moment you’ll love to share. With this app, you can trim your video to your favorite parts, highlight key moments with captions and effects, and set the mood with music. 
+   <Description _locID="App_Description"><!-- _locComment_text="{MaxLength=10000} App Description" -->
+     Turn any video into a memorable moment you’ll love to share. With this app, you can trim your video to your favorite parts, highlight key moments with captions and effects, and set the mood with music.
    </Description>
 
    <!-- Valid length: 1500 character limit, optional -->
-   <ReleaseNotes _locID="App_ReleaseNotes"><!-- _locComment_text="{MaxLength=1500} App Release Note" --> 
+   <ReleaseNotes _locID="App_ReleaseNotes"><!-- _locComment_text="{MaxLength=1500} App Release Note" -->
       Various performance optimiazations, this app is wicked-fast now.
    </ReleaseNotes>
 
@@ -68,11 +68,11 @@
    <CopyrightAndTrademark _locID="App_CopyrightandTrademark"><!-- _locComment_text="{MaxLength=200} Copyright and Trademark" -->
      (c) Contoso LLC.
    </CopyrightAndTrademark>
-  
+
    <!-- Valid length: 10000 character limit -->
    <AdditionalLicenseTerms _locID="App_AddtionalLiceseTerms"><!-- _locComment_text="{MaxLength=10000} Additional License Terms" -->
    </AdditionalLicenseTerms>
-  
+
    <!-- Valid length: 2048 character limit -->
    <WebsiteURL _locID="App_WebsiteURL"><!-- _locComment_text="{MaxLength=2048} WebsiteURL" -->
      http://www.contoso.com/App

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.14.2'
+    ModuleVersion = '1.14.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The Loc team's parser expects the loc comments to be directly before the content
that the comment refers to.