### PR TITLE
Fix broken logging when -Message array includes a format operation.

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.14.1'
+    ModuleVersion = '1.14.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1192,7 +1192,7 @@ function Update-ApplicationSubmission
             "or by running this command:",
             "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission",
             "",
-            $script:manualPublishWarning -f 'Update-ApplicationSubmission')
+            ($script:manualPublishWarning -f 'Update-ApplicationSubmission'))
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
@@ -1822,7 +1822,7 @@ function Complete-ApplicationSubmission
             "You can automatically monitor this submission with this command:",
             "    Start-ApplicationSubmissionMonitor -AppId $AppId -SubmissionId $submissionId -EmailNotifyTo $env:username",
             "",
-            $script:manualPublishWarning -f 'Update-ApplicationSubmission')
+            ($script:manualPublishWarning -f 'Update-ApplicationSubmission'))
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1390,7 +1390,7 @@ function Update-ApplicationFlightSubmission
             "or by running this command:",
             "    Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission",
             "",
-            $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission')
+            ($script:manualPublishWarning -f 'Update-ApplicationFlightSubmission'))
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
@@ -1892,7 +1892,7 @@ function Complete-ApplicationFlightSubmission
             "You can automatically monitor this submission with this command:",
             "    Start-ApplicationFlightSubmissionMonitor -AppId $AppId -Flight $FlightId -SubmissionId $submissionId -EmailNotifyTo $env:username",
             "",
-            $script:manualPublishWarning -f 'Update-ApplicationFlightSubmission')
+            ($script:manualPublishWarning -f 'Update-ApplicationFlightSubmission'))
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -1413,7 +1413,7 @@ function Update-InAppProductSubmission
             "or by running this command:",
             "    Get-InAppProductSubmission -IapId $IapId -SubmissionId $submissionId | Format-InAppProductSubmission",
             "",
-            $script:manualPublishWarning -f 'Update-InAppProductSubmission')
+            ($script:manualPublishWarning -f 'Update-InAppProductSubmission'))
 
         if (![System.String]::IsNullOrEmpty($PackagePath))
         {
@@ -1883,7 +1883,7 @@ function Complete-InAppProductSubmission
             "You can automatically monitor this submission with this command:",
             "    Start-InAppProductSubmissionMonitor -IapId $IapId -SubmissionId $submissionId -EmailNotifyTo $env:username",
             "",
-            $script:manualPublishWarning -f 'Update-InAppProductSubmission')
+            ($script:manualPublishWarning -f 'Update-InAppProductSubmission'))
     }
     catch [System.InvalidOperationException]
     {


### PR DESCRIPTION
- Fix broken logging when -Message array includes a format operation.

After the recent changes to Write-Log, logging was broken for specific cases where -Message was an arrayband included a format operation. The issue was our misunderstanding of the functionality of the format operator. The operator can operate with an array on the left-hand side. In this case, the elements of the array are joined and each string in the array may be formatted. When using the format operation while trying to create an array, we were inadvertently joining the contents of the array into a single string when we actually intended the format operation to be restricted to one line of the array.

The fix is to wrap the format operation in parentheses, to make the expression explicit. In the future, we should be more diligent about using parentheses for the same effect.