### PR TITLE
Add -Force switch to Join-SubmissionPackage

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.15.0'
+    ModuleVersion = '1.15.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Currently, `Join-SubmissionPackage` prevents you from outputting
to a file that already exists.  Now with the `-Force` switch, you
can overwrite the same file if you want to.

This was a user request for when they are chaining together multiple
`Join-SubmissionPackage` commands in a row, where the request is to
be able to use the same intermedia file as both the output for one
command, as well as the input (and then output again) of the next
command.