### PR TITLE
Add remaining localizable text fields

### DIFF
--- a/Documentation/PDP.md
+++ b/Documentation/PDP.md
@@ -7,6 +7,7 @@
 
 *   [Overview](#overview)
 *   [Sections](#sections)
+    *   [AppStoreName](#appstorename)
     *   [Screenshots and Captions](#screenshots-and-captions)
         *   [Folder Structure](#folder-structure)
     *   [Additional Assets](#additional-assets)
@@ -51,15 +52,25 @@ are as follows:
  * AppStoreName
  * Keywords
  * Description
+ * ShortDescription
+ * ShortTitle
+ * SortTitle
+ * VoiceTitle
+ * DevStudio
  * ReleaseNotes
  * ScreenshotCaptions
+ * AdditionalAssets
  * AppFeatures
  * RecommendedHardware
+ * MinimumHardware
  * CopyrightAndTrademark
  * AdditionalLicenseTerms
  * WebsiteURL
  * SupportContactInfo
  * PrivacyPolicyURL
+
+**Additional Sections if your app has Advanced Listing support**
+ * Trailers
 
 **For In-App Product (IAP) ("add-on") Submissions**
  * Title
@@ -69,6 +80,31 @@ are as follows:
 These should map fairly clearly to the sections you're already familiar with in the DevPortal.
 For additional requirements on number of elements or length of individual elements, refer to
 the schema (or sample file).
+
+### AppStoreName
+
+> The `AppStoreName` property in the PDP file is often a source of confusion for users, so it's recommended
+> that you pay close attention this expanded explanation below.
+
+`AppStoreName` maps to the
+[`DisplayName`](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-displayname)
+property from your application's AppxManifest.xml file.  The Store will automatically grab this for every language
+that your application has a listing for, meaining that in most scenarios, you never need to provide a value within
+the PDP.  The only time you should ever specify a value for this in the PDP, is if you will be providing a listing
+for a language that your application isn't explicitly being localized to.
+
+If you provide this value in a PDP for a language that your application already has a `DisplayName` value for,
+your submission will eventually fail after it has been committed because of this name conflict.
+
+**Re-stated again**, you can _only_ successfully provide the `AppStoreName` if _that PDP language_ does not have
+a corresponding `DisplayName` entry within your application package.
+
+If you're in the scenario where you _do_ need to do this for _some_ languages, you'll likely want to follow the
+[FAQ](./USAGE.md#faq) ("Does StoreBroker support adding region-specific listings for languages that the app itself
+doesn't directly support?") which explains how to use mulitple PDP's within your project, each localized to a
+different set of languages.  In that scenario, you'd have a PDP with the `AppStoreName` uncommented and localized,
+but only for the set of languages that needs it; a different PDP would be used for the other languages, and in that
+other PDP, the `AppStoreName` would remain empty/commented-out.
 
 ### Screenshots and Captions
 

--- a/Extensions/ConvertFrom-ExistingSubmission.ps1
+++ b/Extensions/ConvertFrom-ExistingSubmission.ps1
@@ -365,16 +365,14 @@ function Add-AppStoreName
     $paramSet = @{
         "Element"   = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
-        "Comment"   = ($script:CommentFormat -f $maxChars, "App $elementName");
+        "Comment"   = @(
+            ' This is optional.  AppStoreName is typically extracted from your package''s AppxManifest DisplayName property. ',
+            ' Uncomment (and localize) this Store name if your application package does not contain a localization for the DisplayName in this language. ',
+            ' Leaving this uncommented for a language that your application package DOES contain a DisplayName for will result in a submission failure with the API. ',
+            ($script:CommentFormat -f $maxChars, "App $elementName"));
     }
 
     Add-ToElement @paramSet
-
-    $comment = $elementNode.OwnerDocument.CreateComment(' Uncomment the Store name if you wish to specify one explicitly instead. ')
-    $elementNode.PrependChild($comment) | Out-Null
-
-    $comment = $elementNode.OwnerDocument.CreateComment(' This is optional.  AppStoreName is typically extracted from your package''s AppxManifest DisplayName property. ')
-    $elementNode.PrependChild($comment) | Out-Null
 }
 
 function Add-Keywords
@@ -458,6 +456,191 @@ function Add-Description
         "Element" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
         "Comment" = ($script:CommentFormat -f $maxChars, "App $elementName");
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-ShortDescription
+{
+<#
+    .SYNOPSIS
+        Creates the ShortDescription node
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "ShortDescription"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.shortDescription
+
+    # Add comment to parent
+    $maxChars = 500
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
+        "Comment" = @(
+            ' Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. ',
+            ($script:CommentFormat -f $maxChars, "App $elementName"));
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-ShortTitle
+{
+<#
+    .SYNOPSIS
+        Creates the ShortTitle node
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "ShortTitle"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.shortTitle
+
+    # Add comment to parent
+    $maxChars = 50
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
+        "Comment" = @(
+            ' A shorter version of your product''s name. If provided, this shorter name may appear in various places on Xbox One (during installation, in Achievements, etc.) in place of the full title of your product. ',
+            ($script:CommentFormat -f $maxChars, "App $elementName"));
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-SortTitle
+{
+<#
+    .SYNOPSIS
+        Creates the SortTitle node
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "SortTitle"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.sortTitle
+
+    # Add comment to parent
+    $maxChars = 255
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
+        "Comment" = @(
+            ' If your product could be alphabetized in different ways, you can enter another version here. This may help customers find the product more quickly when searching. ',
+            ($script:CommentFormat -f $maxChars, "App $elementName"));
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-VoiceTitle
+{
+<#
+    .SYNOPSIS
+        Creates the VoiceTitle node
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "VoiceTitle"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.voiceTitle
+
+    # Add comment to parent
+    $maxChars = 255
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
+        "Comment" = @(
+            ' An alternate name for your product that, if provided, may be used in the audio experience on Xbox One when using Kinect or a headset. ',
+            ($script:CommentFormat -f $maxChars, "App $elementName"));
+    }
+
+    Add-ToElement @paramSet
+}
+
+function Add-DevStudio
+{
+<#
+    .SYNOPSIS
+        Creates the DevStudio node
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "DevStudio"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    $elementNode.InnerText = $Listing.devStudio
+
+    # Add comment to parent
+    $maxChars = 255
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f $elementName) };
+        "Comment" = @(
+            ' Specify this value if you want to include a "Developed by" field in the listing. (The "Published by" field will list the publisher display name associated with your account, whether or not you provide a devStudio value.) ',
+            ($script:CommentFormat -f $maxChars, "App $elementName"));
     }
 
     Add-ToElement @paramSet
@@ -784,7 +967,7 @@ function Add-Trailers
                 $titleElement.InnerText = $title
                 $trailerElement.AppendChild($titleElement) | Out-Null
 
-                $maxChars = 200
+                $maxChars = 255
                 $paramSet = @{
                     "Element"   = $titleElement;
                     "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f "trailerTitle") + $trailerCount };
@@ -916,6 +1099,56 @@ function Add-RecommendedHardware
         "Parent" = $elementNode;
         "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f "RecommendedHW") + "{0}" };
         "Comment" = ($script:CommentFormatN -f $maxChars, "App Recommended Hardware") + $script:CommentFormatNClose;
+    }
+
+    Add-ToChildren @paramSet
+}
+
+function Add-MinimumHardware
+{
+<#
+    .SYNOPSIS
+        Creates the minimum hardware nodes
+
+    .PARAMETER Xml
+        The XmlDocument to modify.
+
+    .PARAMETER Listing
+        The base listing from the submission for a specific Lang.
+#>
+    param(
+        [Parameter(Mandatory)]
+        [System.Xml.XmlDocument] $Xml,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Listing
+    )
+
+    $elementName = "MinimumHardware"
+    $elementNode = Ensure-RootChild -Xml $Xml -Element $elementName
+    foreach ($minimumRequirement in $Listing.minimumHardware)
+    {
+        $child = $Xml.CreateElement("MinimumRequirement", $xml.productDescription.NamespaceURI)
+        $child.InnerText = $minimumRequirement
+        $elementNode.AppendChild($child) | Out-Null
+    }
+
+    # Add comment to parent
+    $maxChars = 200
+    $maxChildren = 11
+    $paramSet = @{
+        "Element" = $elementNode;
+        "Comment" = $script:SectionCommentFormat -f $maxChars, $maxChildren;
+    }
+
+    Add-ToElement @paramSet
+
+    # Add comment to children
+    $maxChars = 200
+    $paramSet = @{
+        "Parent" = $elementNode;
+        "Attribute" = @{ $script:LocIdAttribute = ($script:LocIdFormat -f "MinimumRequirementHW") + "{0}" };
+        "Comment" = ($script:CommentFormatN -f $maxChars, "App Minimum Required Hardware") + $script:CommentFormatNClose;
     }
 
     Add-ToChildren @paramSet
@@ -1163,12 +1396,18 @@ function ConvertFrom-Listing
     Add-AppStoreName -Xml $Xml -Listing $Listing
     Add-Keywords -Xml $Xml -Listing $Listing
     Add-Description -Xml $Xml -Listing $Listing
+    Add-ShortDescription -Xml $Xml -Listing $Listing
+    Add-ShortTitle -Xml $Xml -Listing $Listing
+    Add-SortTitle -Xml $Xml -Listing $Listing
+    Add-VoiceTitle -Xml $Xml -Listing $Listing
+    Add-DevStudio -Xml $Xml -Listing $Listing
     Add-ReleaseNotes -Xml $Xml -Listing $Listing
     $screenshotFileNames = Add-ScreenshotCaptions -Xml $xml -Listing $Listing
     $additionalAssetFileNames = Add-AdditionalAssets -Xml $xml -Listing $Listing
     $trailerFileNames = Add-Trailers -Xml $xml -Submission $Submission -Lang $Lang
     Add-AppFeatures -Xml $Xml -Listing $Listing
     Add-RecommendedHardware -Xml $Xml -Listing $Listing
+    Add-MinimumHardware -Xml $Xml -Listing $Listing
     Add-CopyrightAndTrademark -Xml $Xml -Listing $Listing
     Add-AdditionalLicenseTerms -Xml $Xml -Listing $Listing
     Add-WebsiteUrl -Xml $Xml -Listing $Listing

--- a/PDP/ProductDescription.xml
+++ b/PDP/ProductDescription.xml
@@ -18,10 +18,36 @@
     <Keyword _locID="App_keyword4"><!-- _locComment_text="{MaxLength=30} App keyword 4" -->Soundtrack</Keyword>
     <Keyword _locID="App_keyword5"><!-- _locComment_text="{MaxLength=30} App keyword 5" -->Video sharing</Keyword>
   </Keywords>
+
    <!-- Valid length: 10000 character limit -->
    <Description _locID="App_Description"><!-- _locComment_text="{MaxLength=10000} App Description" -->
-     Turn any video into a memorable moment you’ll love to share. With this app, you can trim your video to your favorite parts, highlight key moments with captions and effects, and set the mood with music.
+     Turn any video into a memorable moment you'll love to share. With this app, you can trim your video to your favorite parts, highlight key moments with captions and effects, and set the mood with music.
    </Description>
+
+   <!-- Valid length: 500 character limit -->
+   <!-- Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. -->
+   <ShortDescription _locID="App_ShortDescription"><!-- _locComment_text="{MaxLength=500} App Short Description" -->
+   </ShortDescription>
+
+   <!-- Valid length: 50 character limit -->
+   <!-- A shorter version of your product's name. If provided, this shorter name may appear in various places on Xbox One (during installation, in Achievements, etc.) in place of the full title of your product. -->
+   <ShortTitle _locID="App_ShortTitle"><!-- _locComment_text="{MaxLength=50} App Short Title" -->
+   </ShortTitle>
+
+   <!-- Valid length: 255 character limit -->
+   <!-- If your product could be alphabetized in different ways, you can enter another version here. This may help customers find the product more quickly when searching. -->
+   <SortTitle _locID="App_SortTitle"><!-- _locComment_text="{MaxLength=255} App Sort Title" -->
+   </SortTitle>
+
+   <!-- Valid length: 255 character limit -->
+   <!-- An alternate name for your product that, if provided, may be used in the audio experience on Xbox One when using Kinect or a headset. -->
+   <VoiceTitle _locID="App_VoiceTitle"><!-- _locComment_text="{MaxLength=255} App Voice Title" -->
+   </VoiceTitle>
+
+   <!-- Valid length: 255 character limit -->
+   <!-- Specify this value if you want to include a "Developed by" field in the listing. (The "Published by" field will list the publisher display name associated with your account, whether or not you provide a devStudio value.) -->
+   <DevStudio _locID="App_DevStudio"><!-- _locComment_text="{MaxLength=255} App Dev Studio" -->
+   </DevStudio>
 
    <!-- Valid length: 1500 character limit, optional -->
    <ReleaseNotes _locID="App_ReleaseNotes"><!-- _locComment_text="{MaxLength=1500} App Release Note" -->
@@ -62,7 +88,7 @@
 
    <Trailers>
      <Trailer FileName="trailer1.mp4">
-        <Title _locID="App_trailerTitle1"><!-- _locComment_text="{MaxLength=200} Trailer title 1" -->This is Trailer 1's title.</Title>
+        <Title _locID="App_trailerTitle1"><!-- _locComment_text="{MaxLength=255} Trailer title 1" -->This is Trailer 1's title.</Title>
         <Images> <!-- Current maximum of 1 image per trailer allowed -->
           <Image FileName="trailer1screenshot.png"><!-- _locComment_text="{Locked} Trailer Image 1 description" -->Description of trailer 1's screenshot that no user will ever see.</Image>
         </Images>
@@ -73,9 +99,15 @@
      <!-- Valid length: 200 character limit, up to 20 -->
      <AppFeature _locID="App_feature1"><!-- _locComment_text="{MaxLength=200} App Feature 1" -->Pick your favorite 60 seconds. You can trim from the beginning, middle, or end.</AppFeature>
      <AppFeature _locID="App_feature2"><!-- _locComment_text="{MaxLength=200} App Feature 2" -->Highlight your favorite moments with fun, colorful captions in a range of styles.</AppFeature>
-     <AppFeature _locID="App_feature3"><!-- _locComment_text="{MaxLength=200} App Feature 3" -->Add music that matches the moment. We’ve included a few songs for different moods, or you can use songs from your collection.</AppFeature>
+     <AppFeature _locID="App_feature3"><!-- _locComment_text="{MaxLength=200} App Feature 3" -->Add music that matches the moment. We've included a few songs for different moods, or you can use songs from your collection.</AppFeature>
      <AppFeature _locID="App_feature4"><!-- _locComment_text="{MaxLength=200} App Feature 4" -->When your movie is exactly how you want it, share it with family and friends right from the app.</AppFeature>
    </AppFeatures>
+
+   <MinimumHardware>
+      <!-- Valid length: 200 character limit, up to 11 -->
+      <MinimumRequirement _locID="App_MinimumRequirementHW1"><!-- _locComment_text="{MaxLength=200} App Minimum Required Hardware 1" -->Computer</MinimumRequirement>
+      <MinimumRequirement _locID="App_MinimumRequirementHW2"><!-- _locComment_text="{MaxLength=200} App Minimum Required Hardware 2" -->Keyboard</MinimumRequirement>
+   </MinimumHardware>
 
    <RecommendedHardware>
       <!-- Valid length: 200 character limit, up to 11 -->

--- a/PDP/ProductDescription.xsd
+++ b/PDP/ProductDescription.xsd
@@ -129,7 +129,7 @@
 
   <xs:simpleType name="TrailerTitleString">
     <xs:restriction base="tns:NonNullNormalizedString">
-      <xs:pattern value="\s*(\S(\r|\n|.){0,199}\s*)?"/>
+      <xs:pattern value="\s*(\S(\r|\n|.){0,254}\s*)?"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -140,6 +140,42 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+
+  <xs:simpleType name="ShortDescriptionString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,499}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ShortTitleString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,49}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="SortTitleString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,254}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="VoiceTitleString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,254}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="DevStudioString">
+    <xs:restriction base="xs:normalizedString">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,254}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="RequirementString">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\s*(\S(\r|\n|.){0,199}\s*)?"/>
+    </xs:restriction>
+  </xs:simpleType>
 
   <xs:simpleType name="RecommendationString">
     <xs:restriction base="xs:string">
@@ -357,6 +393,81 @@
           </xs:complexType>
         </xs:element>
 
+        <xs:element name="ShortDescription" minOccurs="0">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional, Only used for games. This description appears in the Information section of the Game Hub on Xbox One, and helps customers understand more about your game. May not exceed 500 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:ShortDescriptionString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="ShortTitle" minOccurs="0">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional,  A shorter version of your product's name. If provided, this shorter name may appear in various places on Xbox One (during installation, in Achievements, etc.) in place of the full title of your product.  May not exceed 50 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:ShortTitleString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="SortTitle" minOccurs="0">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional,  If your product could be alphabetized in different ways, you can enter another version here. This may help customers find the product more quickly when searching.  May not exceed 255 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:SortTitleString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="VoiceTitle" minOccurs="0">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional,  An alternate name for your product that, if provided, may be used in the audio experience on Xbox One when using Kinect or a headset.   May not exceed 255 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:VoiceTitleString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="DevStudio" minOccurs="0">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                Optional,  Specify this value if you want to include a "Developed by" field in the listing. (The "Published by" field will list the publisher display name associated with your account, whether or not you provide a DevStudio value.)  May not exceed 255 characters.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+              <xs:extension base="tns:DevStudioString">
+                <xs:attributeGroup ref="tns:LocIdAttribute"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+
         <!-- Windows client only section-->
 
         <xs:element name="AppFeatures" minOccurs="0">
@@ -385,16 +496,15 @@
           </xs:complexType>
         </xs:element>
 
-
         <xs:element name="RecommendedHardware" minOccurs="0">
           <xs:annotation>
             <xs:documentation>
-              Optional, may contain up to 20 feature elements
+              Optional, may contain up to 11 elements
             </xs:documentation>
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="Recommendation" minOccurs="0" maxOccurs="10">
+              <xs:element name="Recommendation" minOccurs="0" maxOccurs="11">
                 <xs:complexType>
                   <xs:annotation>
                     <xs:documentation>
@@ -403,6 +513,32 @@
                   </xs:annotation>
                   <xs:simpleContent>
                     <xs:extension base="tns:RecommendationString">
+                      <xs:attributeGroup ref="tns:LocIdAttribute"/>
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="MinimumHardware" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              Optional, may contain up to 11 elements
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="MinimumRequirement" minOccurs="0" maxOccurs="11">
+                <xs:complexType>
+                  <xs:annotation>
+                    <xs:documentation>
+                      Each requirement may not exceed 200 characters
+                    </xs:documentation>
+                  </xs:annotation>
+                  <xs:simpleContent>
+                    <xs:extension base="tns:RequirementString">
                       <xs:attributeGroup ref="tns:LocIdAttribute"/>
                     </xs:extension>
                   </xs:simpleContent>

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -779,6 +779,11 @@ function Convert-ListingToObject
                         "websiteUrl"                = $ProductDescriptionNode.WebsiteURL;
                         "title"                     = $ProductDescriptionNode.AppStoreName;
                         "description"               = $ProductDescriptionNode.Description;
+                        "shortDescription"          = $ProductDescriptionNode.ShortDescription;
+                        "shortTitle"                = $ProductDescriptionNode.ShortTitle;
+                        "sortTitle"                 = $ProductDescriptionNode.SortTitle;
+                        "voiceTitle"                = $ProductDescriptionNode.VoiceTitle;
+                        "devStudio"                 = $ProductDescriptionNode.DevStudio;
                         "releaseNotes"              = $ProductDescriptionNode.ReleaseNotes;
                     }
 
@@ -811,6 +816,7 @@ function Convert-ListingToObject
                         "features"            = $ProductDescriptionNode.AppFeatures;
                         "keywords"            = $ProductDescriptionNode.Keywords;
                         "recommendedHardware" = $ProductDescriptionNode.RecommendedHardware;
+                        "minimumHardware"     = $ProductDescriptionNode.MinimumHardware;
                     }.GetEnumerator() | ForEach-Object {
                         $baseListing[$_.Name] = @($_.Value.ChildNodes |
                                                     Where-Object NodeType -eq Element |

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.15.1'
+    ModuleVersion = '1.16.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -512,20 +512,33 @@ function Format-ApplicationSubmission
         foreach ($listing in ($listings | Get-Member -type NoteProperty))
         {
             $lang = $listing.Name
+            $baseListing = $listings.$lang.baseListing
             $output += ""
             $output += "$(" " * $indentLength)$lang"
             $output += "$(" " * $indentLength)----------"
-            $output += "$(" " * $indentLength)Description         : $($listings.$lang.baseListing.description)"
-            $output += "$(" " * $indentLength)Copyright/Trademark : $($listings.$lang.baseListing.copyrightAndTrademarkInfo)"
-            $output += "$(" " * $indentLength)Keywords            : $($listings.$lang.baseListing.keywords -join "; ")"
-            $output += "$(" " * $indentLength)License Terms       : $($listings.$lang.baseListing.licenseTerms)"
-            $output += "$(" " * $indentLength)Privacy Policy      : $($listings.$langbaseListing.privacyPolicy)"
-            $output += "$(" " * $indentLength)Support Contact     : $($listings.$lang.baseListing.supportContact)"
-            $output += "$(" " * $indentLength)Website Url         : $($listings.$lang.baseListing.websiteUrl)"
-            $output += "$(" " * $indentLength)Features            : $($listings.$lang.baseListing.features -join "; ")"
-            $output += "$(" " * $indentLength)Release Notes       : $($listings.$lang.baseListing.releaseNotes)"
-            $output += "$(" " * $indentLength)Images              : {0}" -f $(if ($listings.$lang.baseListing.images.count -eq 0) { "<None>" } else { "" })
-            $output += $listings.$lang.baseListing.images | Format-SimpleTableString -IndentationLevel $($indentLength * 2)
+            $output += "$(" " * $indentLength)Title               : $($baseListing.title)"
+            $output += "$(" " * $indentLength)ShortTitle          : $($baseListing.shortTitle)"
+            $output += "$(" " * $indentLength)SortTitle           : $($baseListing.sortTitle)"
+            $output += "$(" " * $indentLength)Voice Title         : $($baseListing.voiceTitle)"
+            $output += "$(" " * $indentLength)Dev Studio          : $($baseListing.devStudio)"
+            $output += "$(" " * $indentLength)Description         : $($baseListing.description)"
+            $output += "$(" " * $indentLength)Short Description   : $($baseListing.shortDescription)"
+            $output += "$(" " * $indentLength)Copyright/Trademark : $($baseListing.copyrightAndTrademarkInfo)"
+            $output += "$(" " * $indentLength)Keywords            : $($baseListing.keywords -join "; ")"
+            $output += "$(" " * $indentLength)License Terms       : $($baseListing.licenseTerms)"
+            $output += "$(" " * $indentLength)Privacy Policy      : $($baseListing.privacyPolicy)"
+            $output += "$(" " * $indentLength)Support Contact     : $($baseListing.supportContact)"
+            $output += "$(" " * $indentLength)Website Url         : $($baseListing.websiteUrl)"
+            $output += "$(" " * $indentLength)Features            : $($baseListing.features -join "; ")"
+            $output += "$(" " * $indentLength)Release Notes       : $($baseListing.releaseNotes)"
+            $output += "$(" " * $indentLength)Minimum Hardware    : {0}" -f $(if ($baseListing.minimumHardware.count -eq 0) { "<None>" } else { "" })
+            $output += $baseListing.minimumHardware | Format-SimpleTableString -IndentationLevel $($indentLength * 2)
+            $output += ""
+            $output += "$(" " * $indentLength)Recommended Hardware: {0}" -f $(if ($baseListing.recommendedHardware.count -eq 0) { "<None>" } else { "" })
+            $output += $baseListing.recommendedHardware | Format-SimpleTableString -IndentationLevel $($indentLength * 2)
+            $output += ""
+            $output += "$(" " * $indentLength)Images              : {0}" -f $(if ($baseListing.images.count -eq 0) { "<None>" } else { "" })
+            $output += $baseListing.images | Format-SimpleTableString -IndentationLevel $($indentLength * 2)
             $output += ""
 
             # Only show the Trailers section if the application has advanced listing support
@@ -547,19 +560,20 @@ function Format-ApplicationSubmission
         # (the section will be null / won't exist if the app doesn't have that support)
         if ($null -ne $ApplicationSubmissionData.gamingOptions)
         {
+            $gamingOptions = $ApplicationSubmissionData.gamingOptions
             $output += "Gaming Options"
-            $output += "$(" " * $indentLength)Genres                          : $($ApplicationSubmissionData.gamingOptions.genres -join ', ')"
-            $output += "$(" " * $indentLength)isLocalMultiplayer              : $($ApplicationSubmissionData.gamingOptions.isLocalMultiplayer)"
-            $output += "$(" " * $indentLength)isLocalCooperative              : $($ApplicationSubmissionData.gamingOptions.isLocalCooperative)"
-            $output += "$(" " * $indentLength)isOnlineMultiplayer             : $($ApplicationSubmissionData.gamingOptions.isOnlineMultiplayer)"
-            $output += "$(" " * $indentLength)isOnlineCooperative             : $($ApplicationSubmissionData.gamingOptions.isOnlineCooperative)"
-            $output += "$(" " * $indentLength)localMultiplayerMinPlayers      : $($ApplicationSubmissionData.gamingOptions.localMultiplayerMinPlayers)"
-            $output += "$(" " * $indentLength)localMultiplayerMaxPlayers      : $($ApplicationSubmissionData.gamingOptions.localMultiplayerMaxPlayers)"
-            $output += "$(" " * $indentLength)localCooperativeMinPlayers      : $($ApplicationSubmissionData.gamingOptions.localCooperativeMinPlayers)"
-            $output += "$(" " * $indentLength)localCooperativeMaxPlayers      : $($ApplicationSubmissionData.gamingOptions.localCooperativeMaxPlayers)"
-            $output += "$(" " * $indentLength)isBroadcastingPrivilegeGranted  : $($ApplicationSubmissionData.gamingOptions.isBroadcastingPrivilegeGranted)"
-            $output += "$(" " * $indentLength)isCrossPlayEnabled              : $($ApplicationSubmissionData.gamingOptions.isCrossPlayEnabled)"
-            $output += "$(" " * $indentLength)kinectDataForExternal           : $($ApplicationSubmissionData.gamingOptions.kinectDataForExternal)"
+            $output += "$(" " * $indentLength)Genres                          : $($gamingOptions.genres -join ', ')"
+            $output += "$(" " * $indentLength)isLocalMultiplayer              : $($gamingOptions.isLocalMultiplayer)"
+            $output += "$(" " * $indentLength)isLocalCooperative              : $($gamingOptions.isLocalCooperative)"
+            $output += "$(" " * $indentLength)isOnlineMultiplayer             : $($gamingOptions.isOnlineMultiplayer)"
+            $output += "$(" " * $indentLength)isOnlineCooperative             : $($gamingOptions.isOnlineCooperative)"
+            $output += "$(" " * $indentLength)localMultiplayerMinPlayers      : $($gamingOptions.localMultiplayerMinPlayers)"
+            $output += "$(" " * $indentLength)localMultiplayerMaxPlayers      : $($gamingOptions.localMultiplayerMaxPlayers)"
+            $output += "$(" " * $indentLength)localCooperativeMinPlayers      : $($gamingOptions.localCooperativeMinPlayers)"
+            $output += "$(" " * $indentLength)localCooperativeMaxPlayers      : $($gamingOptions.localCooperativeMaxPlayers)"
+            $output += "$(" " * $indentLength)isBroadcastingPrivilegeGranted  : $($gamingOptions.isBroadcastingPrivilegeGranted)"
+            $output += "$(" " * $indentLength)isCrossPlayEnabled              : $($gamingOptions.isCrossPlayEnabled)"
+            $output += "$(" " * $indentLength)kinectDataForExternal           : $($gamingOptions.kinectDataForExternal)"
             $output += ""
         }
 


### PR DESCRIPTION
New localizable text fields have been added to the
[application listing object](https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#listing-object).

This update enables those to be updated via StoreBroker.
 * **`minimumHardware`** - Similar in structure to `recommendedHardware`,
   but denotes the minimum required hardware for the application/game
   to run.

 * **`shortDescription`** - Only used for games. This description appears in the Information section
   of the Game Hub on Xbox One, and helps customers understand more about your game.

 * **`shortTitle`** - A shorter version of your products name. If provided, this
   shorter name may appear in various places on Xbox One (during installation, in Achievements, etc.)
   in place of the full title of your product.

 * **`sortTitle`** - If your product could be alphabetized in different ways, you can enter another
   version here. This may help customers find the product more quickly when searching.

 * **`voiceTitle`** - An alternate name for your product that, if provided, may be
   used in the audio experience on Xbox One when using Kinect or a headset.

 * **`devStudio`** - Specify this value if you want to include a "Developed by" field in the listing.
   (The "Published by" field will list the publisher display name associated with your account,
   whether or not you provide a devStudio value.)

Additionally clarifies the usage of `AppStoreName` in both the generated PDP comments, as well as the
PDP.md documentation.

Resolves #107 - Add additional listing metadata for games