### PR TITLE
Fix parsing of trailer titles when there is no inner comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 
 ------
 
+## [1.16.2](https://github.com/Microsoft/StoreBroker/tree/1.16.2) - (2018/04/06)
+### Fixes:
+
+- Fixed error (`You cannot call a method on a null-valued expression.`) seen during packaging
+  if a trailer element didn't have loc comments/attributes in it.  Packaging should now be
+  completely agnostic to whether loc comments/attributes exist or not.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/112) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
+
 ## [1.16.1](https://github.com/Microsoft/StoreBroker/tree/1.16.1) - (2018/02/15)
 ### Fixes:
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.16.1'
+    ModuleVersion = '1.16.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
The XML DOM that PowerShell returns treats inner text of an `XMLElement`
differently depending on whether it has any attributes/comments on it
vs just purely having text inside.

In the case of a `<Caption />` element, we know it will always have at
least one attribute on it.  That means that getting the caption text
will always be by querying for the `InnerText` of that element. The same
goes for the `<Image />` element for trailers: there must always be an
attribute specifying the image file, thus any text within the element
will always be accessed via `InnerText`.

For the `<Title />` element of a `<Trailer />`, things are different.
There are no attributes on that, so accessing the actual text of the
trailer will be different depending on whether the element has a
comment within the node or not.  At the moment, StoreBroker expected
there to always be that Loc comment within the `<Title />` element:

     <!-- _locComment_text="{MaxLength=255} Trailer title 1" -->

Thus, it always accessed the text via `InnerText.Trim()`.

A StoreBroker user ran into an issue when processing their trailers
when their localized PDP files did _not_ have this comment, as
packaging failed with this error:

     Convert-TrailersToObject : You cannot call a method on a null-valued expression.
     At StoreBroker\PackageTool.ps1:1432 char:9

In this scenario, calling `InnerText` returned `$null`, and so we were calling
`$null.Trim()` which resulted in the error.

The fix is to simply check if we're working with a String (the scenario when
there is no inner comment), and if not, to then proceed with getting the `InnerText`.
To ensure we don't have the problem anywhere else, I've made the fix more generic
with a helper method, and updated all of the places where we currently attempt
to access the text content of an `XMLElement`.