### PR TITLE
Fix -UpdateTrailers support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 
 ------
 
+## [1.16.3](https://github.com/Microsoft/StoreBroker/tree/1.16.3) - (2018/04/10)
+### Fixes:
+
+- There was an error in `Update-ApplicationSubmission`) where it checked for
+  `-UpdateGamingOptions` for both updating gaming options as well as for
+  updating trailers, where it should have been checking `-UpdateTrailers`
+  for the trailers portion.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/115) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
+
 ## [1.16.2](https://github.com/Microsoft/StoreBroker/tree/1.16.2) - (2018/04/06)
 ### Fixes:
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.16.2'
+    ModuleVersion = '1.16.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1762,7 +1762,7 @@ function Patch-ApplicationSubmission
         $PatchedSubmission.gamingOptions = DeepCopy-Object -Object (, $NewSubmission.gamingOptions)
     }
 
-    if ($UpdateGamingOptions)
+    if ($UpdateTrailers)
     {
         # Making the assumption that hasAdvancedListingsPermission is false here since the
         # current submission object doesn't contain a trailers node.


### PR DESCRIPTION
There was an error in `Patch-ApplicationSubmission` (used internally
by `Update-ApplicationSubmission`) where it checked for
`-UpdateGamingOptions` for both updating gaming options as well
as for updating trailers, where it should have been checking
`-UpdateTrailers` for the trailers portion.