### PR TITLE
All apps support trailers and gaming options now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 
 ------
 
+## [1.16.4](https://github.com/Microsoft/StoreBroker/tree/1.16.4) - (2018/04/23)
+### Fixes:
+
+- Removed checks validation checks preventing some apps from updating
+  gaming options or trailers.  The API now enables all apps to use
+  trailers and gaming options, even if their submission object doesn't
+  provide those nodes.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/116) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
 ## [1.16.3](https://github.com/Microsoft/StoreBroker/tree/1.16.3) - (2018/04/10)
 ### Fixes:
 

--- a/Documentation/PDP.md
+++ b/Documentation/PDP.md
@@ -68,8 +68,6 @@ are as follows:
  * WebsiteURL
  * SupportContactInfo
  * PrivacyPolicyURL
-
-**Additional Sections if your app has Advanced Listing support**
  * Trailers
 
 **For In-App Product (IAP) ("add-on") Submissions**
@@ -195,9 +193,6 @@ image type, or you can add it to `AdditionalAssets` to affect them all (or to
 #### Trailers
 
 > Only relevant for Application submissions
-
-> Can only be set on applications that have
-> [`Advanced Listing Permission`](https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#advanced-listings).
 
 You can learn more about the specifics of trailers and how they're used by referring to the
 [dev portal's online documentation](https://docs.microsoft.com/en-us/windows/uwp/publish/app-screenshots-and-images#trailers).

--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -264,15 +264,11 @@ cloned submission:
    the cloned submission to that which is specified in your json.
 
  * **`-UpdateGamingOptions`** - This will update all values under the `gamingOptions`
-   node specified in your json.  Please note that your application must have
-   ["Advanced Listing Permission"](https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#advanced-listings)
-   enabled for this to work.
+   node specified in your json.
 
  * **`-UpdateTrailers`** - This will replace the cloned submission's trailers metadata with yours
    (the localized content from the PDP's), deleting any existing data along the way.
-   Please note that your application must have
-   ["Advanced Listing Permission"](https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#advanced-listings)
-   enabled for this to work.  For more info on trailers, review [PDP.md](./PDP.md#trailers).
+   For more info on trailers, review [PDP.md](./PDP.md#trailers).
 
  * **`-UpdateNotesForCertification`** - This will change the `notesForCertification` field of
    the cloned submission to that which is specified in your json.

--- a/StoreBroker/AppConfigTemplate.json
+++ b/StoreBroker/AppConfigTemplate.json
@@ -359,7 +359,6 @@
         //                 //
         /////////////////////
 
-        // This section is only applicable if your application has "Advanced Listings Support" enabled on it.
         // Up-to-date documentation for all possible option values can be found here:
         // https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#gaming-options-object
         "gamingOptions": [{

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -328,7 +328,7 @@ function Get-StoreBrokerConfigFileContentForAppId
         $updated = $updated -replace '"isGameDvrEnabled": .*,', "`"isGameDvrEnabled`": $($sub.isGameDvrEnabled | ConvertTo-Json),"
 
         # GAMING OPTIONS
-        if ($app.hasAdvancedListingPermission)
+        if ($null -ne $sub.gamingOptions)
         {
             $gamingOptionsGenres = $sub.gamingOptions.genres | ConvertTo-Json -Depth $script:jsonConversionDepth
             if ($null -eq $gamingOptionsGenres) { $gamingOptionsGenres = "[ ]" }

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.16.3'
+    ModuleVersion = '1.16.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -541,8 +541,7 @@ function Format-ApplicationSubmission
             $output += $baseListing.images | Format-SimpleTableString -IndentationLevel $($indentLength * 2)
             $output += ""
 
-            # Only show the Trailers section if the application has advanced listing support
-            # (the section will be null / won't exist if the app doesn't have that support)
+            # Only show the Trailers section if it exists
             if ($null -ne $trailers)
             {
                 $langTrailers = $trailerByLang[$lang]
@@ -556,8 +555,7 @@ function Format-ApplicationSubmission
             $output += ""
         }
 
-        # Only show the Gaming Options section if the application has advanced listing support
-        # (the section will be null / won't exist if the app doesn't have that support)
+        # Only show the Gaming Options section if ot exists
         if ($null -ne $ApplicationSubmissionData.gamingOptions)
         {
             $gamingOptions = $ApplicationSubmissionData.gamingOptions
@@ -1021,7 +1019,6 @@ function Update-ApplicationSubmission
 
     .PARAMETER UpdateGamingOptions
         Updates fields under the "Ganming Options" category in the PackageTool config file.
-        This option can only be used if your application has  "Advanced Listings Support" enabled on it.
         Updates the following fields using values from SubmissionDataPath under gamingOptions:
         genres, isLocalMultiplayer, isLocalCooperative, isOnlineMultiplayer, isOnlineCooperative,
         localMultiplayerMinPlayers, localMultiplayerMaxPlayers, localCooperativeMinPlayers,
@@ -1441,7 +1438,6 @@ function Patch-ApplicationSubmission
 
     .PARAMETER UpdateGamingOptions
         Updates fields under the "Ganming Options" category in the PackageTool config file.
-        This option can only be used if your application has  "Advanced Listings Support" enabled on it.
         Updates the following fields using values from SubmissionDataPath under gamingOptions:
         genres, isLocalMultiplayer, isLocalCooperative, isOnlineMultiplayer, isOnlineCooperative,
         localMultiplayerMinPlayers, localMultiplayerMaxPlayers, localCooperativeMinPlayers,
@@ -1732,16 +1728,11 @@ function Patch-ApplicationSubmission
 
     if ($UpdateGamingOptions)
     {
-        # Making the assumption that hasAdvancedListingsPermission is false here since the
-        # current submission object doesn't contain a gamingOptions node.
+        # It's possible that an existing submission object may not have this property at all.
+        # Make sure it's there before continuing.
         if ($null -eq $PatchedSubmission.gamingOptions)
         {
-            $output = @()
-            $output += "You selected to update the Gaming Options for this submission, but it appears that the app"
-            $output += "does not have `"Advanced Listings Support`" enabled. Unable to continue."
-            $output = $output -join [Environment]::NewLine
-            Write-Log -Message $output -Level Error
-            throw $output
+            $PatchedSubmission | Add-Member -Type NoteProperty -Name 'gamingOptions' -Value $null
         }
 
         if ($null -eq $NewSubmission.gamingOptions)
@@ -1764,16 +1755,11 @@ function Patch-ApplicationSubmission
 
     if ($UpdateTrailers)
     {
-        # Making the assumption that hasAdvancedListingsPermission is false here since the
-        # current submission object doesn't contain a trailers node.
+        # It's possible that an existing submission object may not have this property at all.
+        # Make sure it's there before continuing.
         if ($null -eq $PatchedSubmission.trailers)
         {
-            $output = @()
-            $output += "You selected to update the Trailers for this submission, but it appears that the app"
-            $output += "does not have `"Advanced Listings Support`" enabled. Unable to continue."
-            $output = $output -join [Environment]::NewLine
-            Write-Log -Message $output -Level Error
-            throw $output
+            $PatchedSubmission | Add-Member -Type NoteProperty -Name 'trailers' -Value $null
         }
 
         # Trailers has to be an array, so it's important that in the cases when we have 0 or 1


### PR DESCRIPTION
The Store has opened up gaming options and trailers to all apps, whether or not they explicitly have the "advanced listings" option added.

The API is making a change to always return back `true` for `hasAdvancedListingSupport`, but that doesn't completely unblock StoreBroker.  StoreBroker also followed the guidance in the [documentation](https://docs.microsoft.com/en-us/windows/uwp/monetize/update-an-app-submission#request-body) that indicated if `trailers` or `gamingOptions` was `null` in the cloned submission, it meant that they weren't supported.  That is no longer accurate and the MSDN documentation is being updated, but that also means that StoreBroker needs to make some minor changes to accomodate that change in behavior from the API.