### PR TITLE
Improve success rate for New-ApplicationSubmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
-------
+## [1.18.0](https://github.com/Microsoft/StoreBroker/tree/1.18.0) - (2018/08/07)
+### Fixes:
 
++ Updated `New-ApplicationSubmission` to leverage the new `isMinimalResponse=true` when cloning
+  submissions in an attempt to reduce the likelihood of getting a `500` timeout response from
+  the service.
+- Fixed conflicting AccessToken caching logic between `Get-AccessToken` and `Start-SubmissionMonitor`.
+- Fixed issue in `Format-ApplicationSubmission` that incorrectly checked for valid trailers.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/124) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
 ## [1.17.0](https://github.com/Microsoft/StoreBroker/tree/1.17.0) - (2018/06/06)
 ### Fixes:
 
-- Sped up the module for users not using a Proxy.  `AccessToken` is now cached for the
++ Sped up the module for users not using a Proxy.  `AccessToken` is now cached for the
   duration of the console session, and only needs to be refreshed when it expires (which is about
   every 60 minutes).  Previously, the access token was only cached for the duration of the currently
   executing command, which meant that any succesive interactions at the commandline required a new

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.17.0'
+    ModuleVersion = '1.18.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1263,20 +1263,18 @@ function Start-SubmissionMonitor
 
     $shouldMonitor = $true
     $indentLength = 5
-    $lastTokenRefreshTime = Get-Date
-    $accessToken = Get-AccessToken -NoStatus:$NoStatus
 
     # Get the info so we have it's name when we give the user updates.
     $isIapSubmission = -not [String]::IsNullOrEmpty($IapId)
     if ($isIapSubmission)
     {
-        $iap = Get-InAppProduct -IapId $IapId -AccessToken $AccessToken -NoStatus:$NoStatus
+        $iap = Get-InAppProduct -IapId $IapId -NoStatus:$NoStatus
         $appName = $iap.productId
         $fullName = $appName
     }
     else
     {
-        $app = Get-Application -AppId $AppId -AccessToken $AccessToken -NoStatus:$NoStatus
+        $app = Get-Application -AppId $AppId -NoStatus:$NoStatus
         $appName = $app.primaryName
         $fullName = $appName
 
@@ -1285,7 +1283,7 @@ function Start-SubmissionMonitor
         $isFlightingSubmission = (-not [String]::IsNullOrEmpty($FlightId))
         if ($isFlightingSubmission)
         {
-            $flight = Get-ApplicationFlight -AppId $AppId -FlightId $FlightId -AccessToken $AccessToken -NoStatus:$NoStatus
+            $flight = Get-ApplicationFlight -AppId $AppId -FlightId $FlightId -NoStatus:$NoStatus
             $flightName = $flight.friendlyName
             $fullName = "$appName | $flightName"
         }
@@ -1300,28 +1298,19 @@ function Start-SubmissionMonitor
 
     while ($shouldMonitor)
     {
-        # We need to refresh our access token every hour...we'll go a little more often to give
-        # ourselves some wiggle room to avoid unnecessary failures.
-        $accessTokenTimeoutMinutes = 58
-        if ((New-TimeSpan $lastTokenRefreshTime $(Get-Date)).Minutes -gt $accessTokenTimeoutMinutes)
-        {
-            $lastTokenRefreshTime = Get-Date
-            $accessToken = Get-AccessToken -NoStatus:$NoStatus
-        }
-
         try
         {
             if ($isIapSubmission)
             {
-                $submission = Get-InAppProductSubmission -IapId $IapId -SubmissionId $SubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
+                $submission = Get-InAppProductSubmission -IapId $IapId -SubmissionId $SubmissionId -NoStatus:$NoStatus
             }
             elseif ($isFlightingSubmission)
             {
-                $submission = Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $SubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
+                $submission = Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $SubmissionId -NoStatus:$NoStatus
             }
             else
             {
-                $submission = Get-ApplicationSubmission -AppId $AppId -SubmissionId $SubmissionId -AccessToken $AccessToken -NoStatus:$NoStatus
+                $submission = Get-ApplicationSubmission -AppId $AppId -SubmissionId $SubmissionId -NoStatus:$NoStatus
             }
 
             if ($submission.status -ne $lastStatus)

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -542,7 +542,7 @@ function Format-ApplicationSubmission
             $output += ""
 
             # Only show the Trailers section if it exists
-            if ($null -ne $trailers)
+            if ($trailers.Count -gt 0)
             {
                 $langTrailers = $trailerByLang[$lang]
                 $output += "$(" " * $indentLength)Trailers            : {0}" -f $(if ($langTrailers.count -eq 0) { "<None>" } else { "" })


### PR DESCRIPTION
**Migrate `New-ApplicationSubmission` to use `isMinimalResponse`**
The Store API recently introduced a new option when cloning a new
Application submission (but not for IAP or Flight submissions):
    `isMinimalResponse=true`

When provided, the returned submission object will be shallow (missing
application packages and listings).  To get the full submission object,
you need to grab the `id` from that returned submission object and then
do a `GET` on that submission.

The benefit of doing this is reducing the likelihood that the API will
time out while trying to put together the newly cloned submission object
to return to us.  What has been happening is that when trying to clone
larger submissions, the service will return back a `500` error after it
has successfully cloned, but before it can return back the newly cloned
object.

**Fix conflicting access token caching mechanisms**
`Start-SubmissionMonitor` first added access-token caching logic to
limit the need for getting a new access token to just once per 58 minutes.

As of commit 35a9538, `Get-AccessToken` intelligently returns a cached
access token, only attempting to refresh it when it's about to expire.

Unfortunately, when paired together, an issue was introduced which meant that
`Start-SubmissionMonitor` might think that the _cached_ access token that it
got back had a `60 minute` expiration time (and assumed `58 minutes` in order
to have some additional buffer), but in reality, that access token might have
already been cached for 57 minutes.

Due to the double-caching logic, `Start-SubmissionMonitor` wouldn't attempt to
get a new access token until 58 minutes had passed, but by then the cached token
from `Get-AccessToken` may have already expired.

The fix here is to just let `Get-AccessToken` be the sole responsible entity for
caching tokens.  There's no reason to provide a "shared" access token to all
commands within `Start-SubmissionMonitor` for the same reason.   We'll just each
individual command try to acquire an AccessToken, letting `Get-AccessToken` do the
right thing in each instance.

**Fix `Format-ApplicationSubmission` check for trailers**
In the past, a submission object with no trailers had a `null` value
for the trailers node.  Now it appears that it returns back an empty
array instead.  Checkout `$trailers.Count -gt 0` handles both scenarios,
as `$null.Count -eq 0` is `$true` by default.

Resolves #122 Support isMinimalResponse when creating a new submission to reduce the load in the store backend