### PR TITLE
Increase the potential spread for the retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [1.18.1](https://github.com/Microsoft/StoreBroker/tree/1.18.1) - (2018/08/23)
+### Fixes:
+
+- Changed how the initial sleep time is determined for retry attempts in order to achieve a better spread amongst clients.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/127) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
 ## [1.18.0](https://github.com/Microsoft/StoreBroker/tree/1.18.0) - (2018/08/07)
 ### Fixes:
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.18.0'
+    ModuleVersion = '1.18.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1751,7 +1751,7 @@ function Invoke-SBRestMethod
     # The initial number of minutes we'll wait before retrying this command when we've hit an
     # error with a status code that is configured to auto-retry.  To reduce repeated contention, we
     # stagger the initial wait time (and thus, the resulting spread when it exponentially backs off).
-    $retryDelayMin = (1, 1.25, 1.5, 1.75, 2) | Get-Random
+    $retryDelayMin = [Math]::Round((Get-Random -Minimum 0.4 -Maximum 2.0), 2)
     $numRetries = 0
 
     # Telemetry-related


### PR DESCRIPTION
We knew already that we wanted to use a random value for the
intial sleep time on the retry in order to ensure a nice time
spread for all clients (to reduce the likelihood of continued
contentions).  However, to achieve this, we had PowerShell
randomly select one of five potential initial sleep times
(1, 1.25, 1.5, 1.75, 2).

To achieve a better spread, we'll instead let it truly select a random value between a larger initial spread of values between
0.4 and 2.0 with a larger range of granularity.

This change is attempting to solve a real problem we're
experiencing lately with an increased number of 429 errors
(too many requests in a given minute).