### PR TITLE
Add Load Balancing / Round Robin Support to StoreBroker Proxy 

### DIFF
--- a/Documentation/RESTPROXY.md
+++ b/Documentation/RESTPROXY.md
@@ -277,7 +277,7 @@ but without affecting live customers.
 
 > You must have the [Azure SDK](https://azure.microsoft.com/en-us/downloads/) installed before
 > you can deploy.  As of the time of this writing, the appropriate one to download
-> is the one for [VS 2015](https://go.microsoft.com/fwlink/?LinkId=518003&clcid=0x409).
+> is the one for [VS 2017](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&utm_source=azuremscom&utm_medium=clickbutton&utm_campaign=tailored_azuredownloadpage&rid=34348).
 
 Deployment is very straightforward.  With the solution open, just right-click on `AzureService`
 and choose **Publish**.  Choose either "Production" or "Staging" from the profile dropdown
@@ -674,13 +674,13 @@ There are a couple things to note when doing local development:
 
  * You must have the [Azure SDK](https://azure.microsoft.com/en-us/downloads/) installed before
    you can do any development.  As of the time of this writing, the appropriate one to download
-   is the one for [VS 2015](https://go.microsoft.com/fwlink/?LinkId=518003&clcid=0x409).
+   is the one for [VS 2017](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15&utm_source=azuremscom&utm_medium=clickbutton&utm_campaign=tailored_azuredownloadpage&rid=34348).
 
  * The code is [StyleCop](http://stylecop.codeplex.com/) clean.  Please keep it that way.
    Install StyleCop (if you don't have it installed already) and run 
    `Tools->Run StyleCop (Rescan All)` before you submit to enure that it stays clean.
  
- * When developing/debugging the service locally, you'll want to set the `RESTProxy' as the
+ * When developing/debugging the service locally, you'll want to set the `RESTProxy` as the
    default project, and _not_ `AzureService`.
 
  * If you are deploying on your local box, it will deploy to `localhost`.  This will work fine
@@ -696,8 +696,8 @@ There are a couple things to note when doing local development:
    (**but do not check them in**):
 
    * Click on the `RESTProxy` solution in `Solution Explorer` and _temporarily_ enable
-    `Anonymous Authentication`
-   * Modify `ProxyManager.TryHasPermission` to always return `true`
+    `Anonymous Authentication` in the `Properties Pane`.
+   * Modify `Endpoint.TryHasPermission` to always return `true`
    * Statically add in the values for `ClientSecretProd` and `ClientSecretInt` in
     `ProxyManager.GetClientSecret`.   
 

--- a/RESTProxy/Controllers/RootController.cs
+++ b/RESTProxy/Controllers/RootController.cs
@@ -87,6 +87,19 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
                 tenantName = headerValues.FirstOrDefault();
             }
 
+            // We must also extract out any relevant headers that a user may have set.
+            string correlationId = null;
+            if (Request.Headers.TryGetValues(ProxyManager.MSCorrelationIdHeader, out headerValues))
+            {
+                correlationId = headerValues.FirstOrDefault();
+            }
+
+            string clientRequestId = null;
+            if (Request.Headers.TryGetValues(ProxyManager.MSClientRequestIdHeader, out headerValues))
+            {
+                clientRequestId = headerValues.FirstOrDefault();
+            }
+
             // Now, just proxy the request over to the real API.
             return await ProxyManager.PerformRequestAsync(
                 pathAndQuery: Request.RequestUri.PathAndQuery,
@@ -95,7 +108,9 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
                 body: body,
                 tenantId: tenantId,
                 tenantName: tenantName,
-                endpointType: endpointType);
+                endpointType: endpointType,
+                correlationId: correlationId,
+                clientRequestId: clientRequestId);
         }
    }
 }

--- a/RESTProxy/Models/TenantEndpointCollection.cs
+++ b/RESTProxy/Models/TenantEndpointCollection.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
+{
+    using System.Collections.Generic;
+    using System.Threading;
+
+    /// <summary>
+    /// Collects all of the endpoints that can be used for the same Tenant, and provides
+    /// a mechanism to load-balance between them, round-robin style.
+    /// </summary>
+    public class TenantEndpointCollection
+    {
+        /// <summary>
+        /// Gets the semaphore which provides locking functionality to ensure that this collection
+        /// can safely and reliably alternate, round-robin style, between different Endpoints.
+        /// </summary>
+        private readonly SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TenantEndpointCollection"/> class.
+        /// </summary>
+        /// <param name="tenantId">
+        /// The tenantId that should be used for requests by this endpoint.
+        /// </param>
+        /// <param name="tenantFriendlyName">The friendly name for this endpoint.</param>
+        public TenantEndpointCollection(string tenantId, string tenantFriendlyName)
+        {
+            this.TenantId = tenantId;
+            this.TenantFriendlyName = tenantFriendlyName;
+            this.EndpointsByType = new Dictionary<EndpointType, List<Endpoint>>();
+            this.NextEndpointIndex = new Dictionary<EndpointType, int>();
+        }
+
+        /// <summary>
+        /// Gets the TenantId associated with this developer account.
+        /// </summary>
+        public string TenantId { get; private set; }
+
+        /// <summary>
+        /// Gets the friendly name that can be used in lieu of specifying the <see cref="TenantId"/>.
+        /// </summary>
+        public string TenantFriendlyName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the actual collection of endpoints for this TenantId/TenantFriendlyName.
+        /// </summary>
+        private Dictionary<EndpointType, List<Endpoint>> EndpointsByType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index of the next Endpoint to use for a given EndpointType.
+        /// </summary>
+        private Dictionary<EndpointType, int> NextEndpointIndex { get; set; }
+
+        /// <summary>
+        /// Adds a new endpoint to this endpoint collection.
+        /// </summary>
+        /// <param name="endpoint">
+        /// The endpoint that should be part of this collection.
+        /// </param>
+        /// <remarks>
+        /// This endpoint should have the same TenantId as any other Endpoint in this collection.
+        /// </remarks>
+        public void Add(Endpoint endpoint)
+        {
+            // To maintain operational integrity, we don't want external entities to have
+            // access to the endpoints being used when ProxyManager is running.  Therefore,
+            // we will duplicate the endpoint being passed-in during configuration, and that
+            // duplicate is what will be shared between our private dictionaries.
+            Endpoint duplicatedEndpoint = endpoint.Duplicate();
+
+            this.semaphore.Wait();
+            try
+            {
+                List<Endpoint> typeEndpoints;
+                if (this.EndpointsByType.TryGetValue(duplicatedEndpoint.Type, out typeEndpoints))
+                {
+                    typeEndpoints.Add(duplicatedEndpoint);
+                    this.EndpointsByType[duplicatedEndpoint.Type] = typeEndpoints;
+                }
+                else
+                {
+                    typeEndpoints = new List<Endpoint>();
+                    typeEndpoints.Add(duplicatedEndpoint);
+                    this.EndpointsByType.Add(duplicatedEndpoint.Type, typeEndpoints);
+                    this.NextEndpointIndex.Add(duplicatedEndpoint.Type, 0);
+                }
+            }
+            finally
+            {
+                this.semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Rotates through all the <see cref="Endpoint"/>s in this collection, round-robin style,
+        /// and retrieves the next available one for the specified <paramref name="endpointType"/>.
+        /// </summary>
+        /// <param name="endpointType">The type of endpoint that should be used for the request.</param>
+        /// <returns>
+        /// The next <see cref="Endpoint"/> in the collection that matches the specified type.
+        /// </returns>
+        /// <exception cref="KeyNotFoundException">
+        /// No <see cref="Endpoint"/> is defined for the specified <paramref name="endpointType"/>.
+        /// </exception>
+        public Endpoint GetNextEndpoint(EndpointType endpointType)
+        {
+            try
+            {
+                this.semaphore.Wait();
+
+                List<Endpoint> endpoints;
+                if (this.EndpointsByType.TryGetValue(endpointType, out endpoints))
+                {
+                    int nextIndex = this.NextEndpointIndex[endpointType];
+                    Endpoint endpoint = endpoints[nextIndex];
+
+                    // Careful not to do a post-increment here, as the increment would happen _after_ the assignment.
+                    // A pre-increment would work, but I'd argue that expliclty adding 1 here is more clear.
+                    this.NextEndpointIndex[endpointType] = nextIndex + 1;
+                    if (this.NextEndpointIndex[endpointType] >= endpoints.Count)
+                    {
+                        this.NextEndpointIndex[endpointType] = 0;
+                    }
+
+                    return endpoint;
+                }
+                else
+                {
+                    throw new KeyNotFoundException(string.Format(
+                        "This Proxy is not configured to handle requests for Tenant [{0} ({1})] with the endpoint type of [{2}].",
+                        this.TenantId,
+                        this.TenantFriendlyName,
+                        endpointType.ToString()));
+                }
+            }
+            finally
+            {
+                this.semaphore.Release();
+            }
+        }
+    }
+}

--- a/RESTProxy/Properties/AssemblyInfo.cs
+++ b/RESTProxy/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/RESTProxy/RESTProxy.csproj
+++ b/RESTProxy/RESTProxy.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Models\TenantEndpointCollection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add Load Balancing / Round Robin Support to StoreBroker Proxy

The Store API has two different rate limiters in place with corresponding error codes:

`429` - _API rate limiter_ - a ClientId can't make more than 60 queries per minute
`403` - _API quota limiter_ - a ClientId can't make more than  60,000 queries per day

For organizations that have many StoreBroker clients, it is quite possible that 429 errors may happen fairly frequently (along with the occasional 403's on really bad days).

To avoid this, the Proxy is gaining the concept of load balancing (from the API/Client Id perspective) by
enabling administrators to configure a TenantId to have as many ClientId's as they'd like -- the Proxy will use a "round robin" approach and simply cycle through all configured ClientId's for a given 
TenantId/EndpointType combination upon each request.

As more StoreBroker clients are added within an organization, the Proxy administrator can simply add in additional ClientId's as needed.  This change will be completely transparent to all clients, and help ensure reliable API execution that doesn't hit any rate or quota limiters.

Also, some additional headers need to be proxied to the API.
Clients are able to provide the `MS-CorrelationId` and `MS-Client-RequestId` headers in their requests, and when specified, these should be proxied directly to the API.

We also want to return back any header that includes the word `retry`  in it, as the API may start to use those to indicate how long we should wait before retrying the same request.

Finally, we want to provide a default value for the return message's `ContentType` in the event that the API is incorrectly returning back a message without one specified (in this scenario, we'll default to
`text/plain`) (an issue that has occurred in the past).

Resolves Issue #114 - Add ClientID round-robin support to StoreBroker Proxy