### PR TITLE
Migrate New-ApplicationFlightSubmission to use isMinimalResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [1.19.0](https://github.com/Microsoft/StoreBroker/tree/1.19.0) - (2018/08/30)
+### Fixes:
+
++ Updated `New-ApplicationFlightSubmission` to leverage the new `isMinimalResponse=true` when cloning
+  submissions in an attempt to reduce the likelihood of getting a `500` timeout response from
+  the service.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/131) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
 ## [1.18.1](https://github.com/Microsoft/StoreBroker/tree/1.18.1) - (2018/08/23)
 ### Fixes:
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.18.1'
+    ModuleVersion = '1.19.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
This is a follow-up to cdee54f6e3a23be29bf7f75df88af9fa4d4a648f (Pull Request #124).
The API team originally added `isMinimalResponse=true` as an optional parameter to the
clone/POST command for new submissions, which had it return a sparse/minimal response
in order to reduce the likelihood of getting a `500` error response while it tried to
gather the complete data for the full submission response.

They have now added support for the same scenario for Flights as well, and so the same
type of change is being made to `New-ApplicationFlightSubmission` so that it creates
the cloned submission with `IsMinimalResponse=true` and then immediately tries to
`GET` that submission to get the full content.

Resolves #131: Add isMinimalResponse support for new Flight Submissions