### PR TITLE
Add support for `X-ClientName` header to StoreBroker Proxy

### DIFF
--- a/RESTProxy/Controllers/RootController.cs
+++ b/RESTProxy/Controllers/RootController.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
         /// (this is defined in WebApiConfig.cs).
         /// <para />
         /// We don't care at all about the parameters because all we end up doing is grabbing the
-        /// full AbsoluteUri and $proxying$ that request to the real API.  This is very abnormal 
+        /// full AbsoluteUri and $proxying$ that request to the real API.  This is very abnormal
         /// usage of ASP.NET WebApi, but doing things this way makes the code SUPER-concise.
         /// <para />
         /// The only event where this method will ever need to be updated is if additional
@@ -100,6 +100,12 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
                 clientRequestId = headerValues.FirstOrDefault();
             }
 
+            string clientName = null;
+            if (Request.Headers.TryGetValues(ProxyManager.ClientNameHeader, out headerValues))
+            {
+                clientName = headerValues.FirstOrDefault();
+            }
+
             // Now, just proxy the request over to the real API.
             return await ProxyManager.PerformRequestAsync(
                 pathAndQuery: Request.RequestUri.PathAndQuery,
@@ -110,7 +116,8 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
                 tenantName: tenantName,
                 endpointType: endpointType,
                 correlationId: correlationId,
-                clientRequestId: clientRequestId);
+                clientRequestId: clientRequestId,
+                clientName: clientName);
         }
    }
 }

--- a/RESTProxy/Models/ProxyManager.cs
+++ b/RESTProxy/Models/ProxyManager.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
         public const string MSClientRequestIdHeader = "MS-Client-RequestId";
 
         /// <summary>
+        /// The header name for a special header that the API uses for telemetry/tracking of API clients.
+        /// </summary>
+        public const string ClientNameHeader = "X-ClientName";
+
+        /// <summary>
         /// The Application Insights client that will be used for "logging" all of the user requests
         /// </summary>
         private static TelemetryClient telemetryClient = new TelemetryClient();
@@ -152,6 +157,10 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
         /// <param name="clientRequestId">
         /// An ID that a client may have set in the header (which we must proxy) to track an individual request.
         /// </param>
+        /// <param name="clientName">
+        /// The name of the requesting client that we can pass on to the API via a special header
+        /// for tracking purposes.
+        /// </param>
         /// <returns>The <see cref="HttpResponseMessage"/> to be sent to the user.</returns>
         public static async Task<HttpResponseMessage> PerformRequestAsync(
             string pathAndQuery,
@@ -162,7 +171,8 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             string tenantName = null,
             EndpointType endpointType = EndpointType.Prod,
             string correlationId = null,
-            string clientRequestId = null)
+            string clientRequestId = null,
+            string clientName = null)
         {
             // We'll track how long this takes, for telemetry purposes.
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -183,7 +193,7 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
                 if (ProxyManager.TryGetEndpoint(tenantId, tenantName, endpointType, out endpoint, out response))
                 {
                     clientId = endpoint.ClientId;
-                    response = await endpoint.PerformRequestAsync(pathAndQuery, method, onBehalfOf, body, correlationId, clientRequestId);
+                    response = await endpoint.PerformRequestAsync(pathAndQuery, method, onBehalfOf, body, correlationId, clientRequestId, clientName);
                 }
 
                 // We'll capture the status code for use in the finally block.

--- a/RESTProxy/Properties/AssemblyInfo.cs
+++ b/RESTProxy/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]


### PR DESCRIPTION
For API v2, the API team has added an optional header that API clients
can specify to indicate the name/version of the client being used, so
that they can gain insight into the varied API clients that are leveraging
the API.

This updates the Proxy so that it properly recognizes and proxies that property
on to the API if it has been specified.