### PR TITLE
Protect against formatting invalid certification reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [1.19.1](https://github.com/Microsoft/StoreBroker/tree/1.19.1) - (2018/10/09)
+### Fixes:
+
+- Updates the formatting logic for certification reports to account for reports
+  that don't follow the documented object model and are missing dates.  At the
+  moment, formatting the report causes an exception when we attempt to format
+  the `date` property if it has a `$null` value.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/132) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+------
 ## [1.19.0](https://github.com/Microsoft/StoreBroker/tree/1.19.0) - (2018/08/30)
 ### Fixes:
 

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.19.0'
+    ModuleVersion = '1.19.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1344,7 +1344,13 @@ function Start-SubmissionMonitor
                 $body += "Status Details [Certification Reports] : {0}" -f $(if ($submission.statusDetails.certificationReports.count -eq 0) { "<None>" } else { "" })
                 foreach ($report in $submission.statusDetails.certificationReports)
                 {
-                    $body += $(" " * $indentLength) + $(Get-Date -Date $report.date -Format R) + ": $($report.reportUrl)"
+                    $date = ""
+                    if ($null -ne $report.date)
+                    {
+                        $date = $(Get-Date -Date $report.date -Format R)
+                    }
+
+                    $body += $(" " * $indentLength) + $date + ": $($report.reportUrl)"
                 }
 
                 $body += ""

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -587,7 +587,13 @@ function Format-ApplicationSubmission
         $output += "Status Details [Certification Reports] : {0}" -f $(if ($ApplicationSubmissionData.statusDetails.certificationReports.count -eq 0) { "<None>" } else { "" })
         foreach ($report in $ApplicationSubmissionData.statusDetails.certificationReports)
         {
-            $output += $(" " * $indentLength) + $(Get-Date -Date $report.date -Format R) + ": $($report.reportUrl)"
+            $date = ""
+            if ($null -ne $report.date)
+            {
+                $date = $(Get-Date -Date $report.date -Format R)
+            }
+
+            $output += $(" " * $indentLength) + $date + ": $($report.reportUrl)"
         }
     }
 

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -727,7 +727,13 @@ function Format-ApplicationFlightSubmission
         $output += "Status Details [Certification Reports] : {0}" -f $(if ($ApplicationFlightSubmissionData.statusDetails.certificationReports.count -eq 0) { "<None>" } else { "" })
         foreach ($report in $ApplicationFlightSubmissionData.statusDetails.certificationReports)
         {
-            $output += $(" " * $indentLength) + $(Get-Date -Date $report.date -Format R) + ": $($report.reportUrl)"
+            $date = ""
+            if ($null -ne $report.date)
+            {
+                $date = $(Get-Date -Date $report.date -Format R)
+            }
+
+            $output += $(" " * $indentLength) + $date + ": $($report.reportUrl)"
         }
     }
 

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -848,7 +848,13 @@ function Format-InAppProductSubmission
         $output += "Status Details [Certification Reports] : {0}" -f $(if ($IapSubmissionData.statusDetails.certificationReports.count -eq 0) { "<None>" } else { "" })
         foreach ($report in $IapSubmissionData.statusDetails.certificationReports)
         {
-            $output += $(" " * $indentLength) + $(Get-Date -Date $report.date -Format R) + ": $($report.reportUrl)"
+            $date = ""
+            if ($null -ne $report.date)
+            {
+                $date = $(Get-Date -Date $report.date -Format R)
+            }
+
+            $output += $(" " * $indentLength) + $date + ": $($report.reportUrl)"
         }
     }
 


### PR DESCRIPTION
Per the [documentation](https://docs.microsoft.com/en-us/windows/uwp/monetize/manage-app-submissions#certification-report-object),
a certification report is supposed to have both a `date` and `reportUrl` properties.

We've seen instances where the API returns back certification reports that don't have a `date` property, and where the `reportUrl`
contains the message `Obsolete: please visit https://developer.microsoft.com for report details.`.  When this happens, we end up
throwing an exception as we attempt to format a `$null` date value.

This update protects against that scenario by ensuring that we only attempt to format the date if one is provided.