### PR TITLE
Update RESTProxy to use Microsoft.Data.OData v5.8.4

### DIFF
--- a/RESTProxy/packages.config
+++ b/RESTProxy/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net46" />
-  <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net46" />
+  <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />


### PR DESCRIPTION
Updating the version of Microsoft.Data.OData that the RESTProxy uses
due to an announced security vulnerability.

Resolves Issue #139: Update RestProxy to use Microsoft.Data.Odata 5.8.4