### PR TITLE
Prevent `Get-NugetPackageDllPath` from throwing an error when calling…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [1.19.1](https://github.com/Microsoft/StoreBroker/tree/1.19.1) - (2018/11/13)
+### Fixes:
+
++ Updated `Get-NugetPackageDllPath` to not report errors when `Test-Path` is unable to access
+  a location.  All we care about is knowing if we can access the file or not...the error is just
+  noise.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/TODO) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
 ## [1.19.0](https://github.com/Microsoft/StoreBroker/tree/1.19.0) - (2018/08/30)
 ### Fixes:
 

--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -301,7 +301,7 @@ function Get-NugetPackageDllPath
 
     # First we'll check to see if the user has cached the assembly into the module's script directory
     $moduleAssembly = Join-Path $PSScriptRoot $AssemblyName
-    if (Test-Path -Path $moduleAssembly -PathType Leaf -ErrorAction SilentlyContinue)
+    if (Test-Path -Path $moduleAssembly -PathType Leaf -ErrorAction Ignore)
     {
         if (Test-AssemblyIsDesiredVersion -AssemblyPath $moduleAssembly -DesiredVersion $NugetPackageVersion)
         {
@@ -318,7 +318,7 @@ function Get-NugetPackageDllPath
     if (-not [System.String]::IsNullOrEmpty($SBAlternateAssemblyDir))
     {
         $alternateAssemblyPath = Join-Path $SBAlternateAssemblyDir $AssemblyName
-        if (Test-Path -Path $alternateAssemblyPath -PathType Leaf)
+        if (Test-Path -Path $alternateAssemblyPath -PathType Leaf -ErrorAction Ignore)
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $alternateAssemblyPath -DesiredVersion $NugetPackageVersion)
             {
@@ -340,7 +340,7 @@ function Get-NugetPackageDllPath
     else
     {
         $cachedAssemblyPath = Join-Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
-        if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction SilentlyContinue)
+        if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction Ignore)
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $cachedAssemblyPath -DesiredVersion $NugetPackageVersion)
             {
@@ -359,7 +359,7 @@ function Get-NugetPackageDllPath
     Get-NugetPackage -PackageName $NugetPackageName -Version $NugetPackageVersion -TargetPath $script:tempAssemblyCacheDir -NoStatus:$NoStatus
 
     $cachedAssemblyPath = Join-Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
-    if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction SilentlyContinue)
+    if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction Ignore)
     {
         Write-Log -Message @(
             "To avoid this download delay in the future, copy the following file:",

--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -294,7 +294,7 @@ function Get-NugetPackageDllPath
 
     # First we'll check to see if the user has cached the assembly into the module's script directory
     $moduleAssembly = Join-Path $PSScriptRoot $AssemblyName
-    if (Test-Path -Path $moduleAssembly -PathType Leaf)
+    if (Test-Path -Path $moduleAssembly -PathType Leaf -ErrorAction SilentlyContinue)
     {
         if (Test-AssemblyIsDesiredVersion -AssemblyPath $moduleAssembly -DesiredVersion $NugetPackageVersion)
         {
@@ -333,7 +333,7 @@ function Get-NugetPackageDllPath
     else
     {
         $cachedAssemblyPath = Join-Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
-        if (Test-Path -Path $cachedAssemblyPath -PathType Leaf)
+        if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction SilentlyContinue)
         {
             if (Test-AssemblyIsDesiredVersion -AssemblyPath $cachedAssemblyPath -DesiredVersion $NugetPackageVersion)
             {
@@ -352,7 +352,7 @@ function Get-NugetPackageDllPath
     Get-NugetPackage -PackageName $NugetPackageName -Version $NugetPackageVersion -TargetPath $script:tempAssemblyCacheDir -NoStatus:$NoStatus
 
     $cachedAssemblyPath = Join-Path $(Join-Path $script:tempAssemblyCacheDir $AssemblyPackageTailDirectory) $AssemblyName
-    if (Test-Path -Path $cachedAssemblyPath -PathType Leaf)
+    if (Test-Path -Path $cachedAssemblyPath -PathType Leaf -ErrorAction SilentlyContinue)
     {
         Write-Log -Message @(
             "To avoid this download delay in the future, copy the following file:",

--- a/StoreBroker/NugetTools.ps1
+++ b/StoreBroker/NugetTools.ps1
@@ -191,7 +191,14 @@ function Test-AssemblyIsDesiredVersion
 
     $splitTargetVer = $DesiredVersion.Split('.')
 
-    $versionInfo = (Get-Item -Path $AssemblyPath).VersionInfo
+    $file = Get-Item -Path $AssemblyPath -ErrorVariable ev
+    if (($null -ne $ev) -and ($ev.Count -gt 0))
+    {
+        Write-Log "Problem accessing [$Path]: $($ev[0].Exception.Message)" -Level Warning
+        return $false
+    }
+
+    $versionInfo = $file.VersionInfo
     $splitSourceVer = @(
         $versionInfo.ProductMajorPart,
         $versionInfo.ProductMinorPart,

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.19.0'
+    ModuleVersion = '1.19.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
… `Test-Path`

`Test-Path` will write an error to the error stream if the path being tested is
inaccessible.  This is just noise to us, as we simply care whether or not the
file is there and accessible -- we don't need the error message.