### PR TITLE
Fixing switch parameter name for Patch-ApplicationFlightSubmission

### DIFF
--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1583,7 +1583,7 @@ function Patch-ApplicationFlightSubmission
 
         [switch] $UpdateListings,
 
-        [switch] $UpdatePublishModeAndVisibility,
+        [switch] $UpdatePublishMode,
 
         [switch] $UpdatePricingAndAvailability,
 


### PR DESCRIPTION
All of the "flight" methods expected a switch called `-UpdatePublishMode`,
but in `Patch-ApplicationFlightSubmission`, it was actually called
`UpdatePublishModeAndVisibility`.  Due to PowerShell's logic of doing
best-effort parameter matching when there's no ambiguity, the existing logic
worked fine since it was always called as `-UpdatePublishMode` (which is a strict
substring of `-UpdatePublishModeAndVisibility).

To remove any potential confusion for code inspectors however, fixing this
accidental typo.

Resolves #143