### PR TITLE
Fix occasional error "ConvertFrom-Json : Invalid JSON primitive: Index"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [2.0.1](https://github.com/Microsoft/StoreBroker/tree/2.0.1) - (2019/03/15)
+### Fixes:
+
++ Fix occasional error "ConvertFrom-Json : Invalid JSON primitive: Index"
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/https://github.com/Microsoft/StoreBroker/pull/149) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/TODO)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
+## [2.0.0](https://github.com/Microsoft/StoreBroker/tree/2.0.0) - (2019/02/21)
+### Fixes:
+
++ Introducing StoreBroker v2.0.0
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/https://github.com/Microsoft/StoreBroker/pull/148) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/c3b54c54d93d7208859a4e87dd11074237c39273)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
 ## [1.19.1](https://github.com/Microsoft/StoreBroker/tree/1.19.1) - (2018/11/14)
 ### Fixes:
 

--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.0'
+    ModuleVersion = '2.0.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1981,13 +1981,33 @@ function Invoke-SBRestMethod
                                 Write-Log -Message "Unable to retrieve the raw HTTP Web Response:" -Exception $_ -Level Warning
                             }
 
-                            if ($_.Exception.Response.Headers.Count -gt 0)
+                            $responseHeaders = $_.Exception.Response.Headers
+                            if ($responseHeaders.Count -gt 0)
                             {
-                                $ex.RequestId = $_.Exception.Response.Headers[$script:headerMSRequestId]
-                                $ex.ClientRequestId = $_.Exception.Response.Headers[$script:headerMSClientRequestId]
-                                $ex.CorrelationId = $_.Exception.Response.Headers[$script:headerMSCorrelationId]
-                                $ex.RetryAfter = $_.Exception.Response.Headers[$script:headerRetryAfter]
-                                $ex.Location = $_.Exception.Response.Headers[$script:headerLocation]
+                                if ($responseHeaders.AllKeys.Contains($script:headerMSRequestId))
+                                {
+                                    $ex.RequestId = $responseHeaders[$script:headerMSRequestId]
+                                }
+
+                                if ($responseHeaders.AllKeys.Contains($script:headerMSClientRequestId))
+                                {
+                                    $ex.ClientRequestId = $responseHeaders[$script:headerMSClientRequestId]
+                                }
+
+                                if ($responseHeaders.AllKeys.Contains($script:headerMSCorrelationId))
+                                {
+                                    $ex.CorrelationId = $responseHeaders[$script:headerMSCorrelationId]
+                                }
+
+                                if ($responseHeaders.AllKeys.Contains($script:headerRetryAfter))
+                                {
+                                    $ex.RetryAfter = $responseHeaders[$script:headerRetryAfter]
+                                }
+
+                                if ($responseHeaders.AllKeys.Contains($script:headerLocation))
+                                {
+                                    $ex.Location = $responseHeaders[$script:headerLocation]
+                                }
                             }
 
                             throw ($ex | ConvertTo-Json -Depth 20)
@@ -2132,15 +2152,34 @@ function Invoke-SBRestMethod
                     Write-Log -Message "Unable to retrieve the raw HTTP Web Response:" -Exception $_ -Level Warning
                 }
 
-                if ($ex.Response.Headers.Count -gt 0)
+                $responseHeaders = $ex.Response.Headers
+                if ($responseHeaders.Count -gt 0)
                 {
-                    $requestId = $ex.Response.Headers[$script:headerMSRequestId]
-                    $returnedClientRequestId = $ex.Response.Headers[$script:headerMSClientRequestId]
-                    $returnedCorrelationId = $ex.Response.Headers[$script:headerMSCorrelationId]
-                    $retryAfterHeaderValue = $ex.Response.Headers[$script:headerRetryAfter]
-                    $locationHeaderValue = $ex.Response.Headers[$script:headerLocation]
-                }
+                    if ($responseHeaders.AllKeys.Contains($script:headerMSRequestId))
+                    {
+                        $requestId = $responseHeaders[$script:headerMSRequestId]
+                    }
 
+                    if ($responseHeaders.AllKeys.Contains($script:headerMSClientRequestId))
+                    {
+                        $returnedClientRequestId = $responseHeaders[$script:headerMSClientRequestId]
+                    }
+
+                    if ($responseHeaders.AllKeys.Contains($script:headerMSCorrelationId))
+                    {
+                        $returnedCorrelationId = $responseHeaders[$script:headerMSCorrelationId]
+                    }
+
+                    if ($responseHeaders.AllKeys.Contains($script:headerRetryAfter))
+                    {
+                        $retryAfterHeaderValue = $responseHeaders[$script:headerRetryAfter]
+                    }
+
+                    if ($responseHeaders.AllKeys.Contains($script:headerLocation))
+                    {
+                        $locationHeaderValue = $responseHeaders[$script:headerLocation]
+                    }
+                }
             }
             elseif (($_.Exception -is [System.Management.Automation.RemoteException]) -and
                 ($_.Exception.SerializedRemoteException.PSObject.TypeNames[0] -eq 'Deserialized.System.Management.Automation.RuntimeException'))


### PR DESCRIPTION
This was happening while trying to access a header that may not have
been there in a response.  Specifically, the RetryAfter header value
doesn't exist in some situations (like authentication failure), and
trying to access caused an error cascade.

The proper fix is to verify that the header value exists before
querying for it.