### PR TITLE
No Status switch doesn't cache the access token

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.1'
+    ModuleVersion = '2.0.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -522,8 +522,6 @@ function Get-AccessToken
             {
                 $response = Invoke-RestMethod $url -Method Post -Body $body
             }
-
-            return $response.access_token
         }
         else
         {
@@ -553,14 +551,20 @@ function Get-AccessToken
             {
                throw $remoteErrors[0].Exception
             }
+        }
 
+        # Account for the case where ShouldProcess is false
+        if (Test-Path variable:response)
+        {
             # Keep track of how long this token will be valid for, to enable logic that re-uses
             # the same token across multiple commands to know when a new one is necessary.
             $script:accessTokenTimeoutSeconds = $response.expires_in - $script:accessTokenRefreshBufferSeconds
             $script:lastAccessTokenExpirationDate = (Get-Date).AddSeconds($script:accessTokenTimeoutSeconds)
             $script:lastAccessToken = $response.access_token
-            return $response.access_token
+            Write-Log -Message "Access Token has been cached for future use. Will expire in $($script:accessTokenTimeoutSeconds) seconds."
         }
+
+        return $response.access_token
     }
     catch [System.InvalidOperationException]
     {

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -515,6 +515,7 @@ function Get-AccessToken
     {
         Write-Log -Message "Getting access token..." -Level Verbose
         Write-Log -Message "Accessing [POST] $url" -Level Verbose
+        $response = $null
 
         if ($NoStatus)
         {
@@ -553,15 +554,14 @@ function Get-AccessToken
             }
         }
 
-        # Account for the case where ShouldProcess is false
-        if (Test-Path variable:response)
+        if ($null -ne $response)
         {
             # Keep track of how long this token will be valid for, to enable logic that re-uses
             # the same token across multiple commands to know when a new one is necessary.
             $script:accessTokenTimeoutSeconds = $response.expires_in - $script:accessTokenRefreshBufferSeconds
             $script:lastAccessTokenExpirationDate = (Get-Date).AddSeconds($script:accessTokenTimeoutSeconds)
             $script:lastAccessToken = $response.access_token
-            Write-Log -Message "Access Token has been cached for future use. Will expire in $($script:accessTokenTimeoutSeconds) seconds."
+            Write-Log -Message "Access Token has been cached for future use. Will expire in $($script:accessTokenTimeoutSeconds) seconds." -Level Verbose
         }
 
         return $response.access_token


### PR DESCRIPTION
Currently, the method `Get-AccessToken` only caches the access token when the `NoStatus` switch is not provided. The caching mechanism should be used regardless of the `NoStatus` flag to avoid multiple calls to the OAuth API.