### PR TITLE
Always cast to array and remove default retry

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.2'
+    ModuleVersion = '2.0.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -133,12 +133,12 @@ function Initialize-StoreIngestionApiGlobalVariables
 
     if (!(Get-Variable -Name SBAutoRetryErrorCodes -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBAutoRetryErrorCodes = @(429, 503)
+        $global:SBAutoRetryErrorCodes = @()
     }
 
     if (!(Get-Variable -Name SBGetRequestAutoRetryErrorCodes -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBGetRequestAutoRetryErrorCodes = @(500)
+        $global:SBGetRequestAutoRetryErrorCodes = @(429, 500, 503)
     }
 
     if (!(Get-Variable -Name SBMaxAutoRetries -Scope Global -ValueOnly -ErrorAction Ignore))

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1993,7 +1993,7 @@ function Update-Submission
                     (Format-SimpleTableString -Object $validation))
             }
 
-            $hasValidationErrors = ($validation | Where-Object { $_.severity -eq 'Error' }).Length -gt 0
+            $hasValidationErrors = @($validation | Where-Object { $_.severity -eq 'Error' }).Length -gt 0
             if ($hasValidationErrors)
             {
                 $message = 'Unable to continue with submission because of validation errors.'


### PR DESCRIPTION
Fixes:
 * When querying for validation errors, we are not casting to array. PowerShell will return a single object when the `Where-Object` filter returns only one object. To ensure consistency, we can cast to array so we can access the `Length` property.
 * The retry logic for the API now relies on the retry-after header, so no need to have a default list of codes to automatically retry. The functionality is still available to users if they decide to override it.