### PR TITLE
Add "502 - Bad Gateway" to default codes to auto-retry on GET

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.3'
+    ModuleVersion = '2.0.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -138,7 +138,7 @@ function Initialize-StoreIngestionApiGlobalVariables
 
     if (!(Get-Variable -Name SBGetRequestAutoRetryErrorCodes -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBGetRequestAutoRetryErrorCodes = @(429, 500, 503)
+        $global:SBGetRequestAutoRetryErrorCodes = @(429, 500, 502, 503)
     }
 
     if (!(Get-Variable -Name SBMaxAutoRetries -Scope Global -ValueOnly -ErrorAction Ignore))


### PR DESCRIPTION
Add "502 - Bad Gateway" to default codes to auto-retry on GET. 502 is used by the Store as intermittent network issue code. As such, there is no harm to auto-retry it when there is a read operation.