### PR TITLE
Fix parameters in message printed post-Submission

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.4'
+    ModuleVersion = '2.0.5'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1442,9 +1442,9 @@ function Submit-Submission
             "You can view the progress of the submission validation on the Dev Portal here:",
             "    https://dev.windows.com/en-us/dashboard/apps/$appId/submissions/$submissionId/",
             "or by running this command:",
-            "    Get-Submission -ProductId $AppId -SubmissionId $submissionId",
+            "    Get-Submission -ProductId $ProductId -SubmissionId $submissionId",
             "You can automatically monitor this submission with this command:",
-            "    Start-SubmissionMonitor -Product $ProductId -SubmissionId $SubmissionId -EmailNotifyTo $env:username")
+            "    Start-SubmissionMonitor -ProductId $ProductId -SubmissionId $SubmissionId -EmailNotifyTo $env:username")
 
         return $result
     }


### PR DESCRIPTION
There was a typo in a parameter name as well as usage of the
wrong value when printing out the `Get-Submission` and
`Start-SubmissionMonitor` commands after a successful submission.