### PR TITLE
Add support for `withSasUri` parameter for ListingImage

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.5'
+    ModuleVersion = '2.0.6'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionListingImageApi.ps1
+++ b/StoreBroker/StoreIngestionListingImageApi.ps1
@@ -33,6 +33,8 @@ function Get-ListingImage
 
         [string] $ImageId,
 
+        [switch] $WithSasUri,
+
         [switch] $SinglePage,
 
         [string] $ClientRequestId,
@@ -55,6 +57,7 @@ function Get-ListingImage
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::ImageId = $ImageId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
+            [StoreBrokerTelemetryProperty]::WithSasUri = $WithSasUri.ToBool()
             [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
@@ -63,6 +66,11 @@ function Get-ListingImage
         if (-not [String]::IsNullOrWhiteSpace($SubmissionId))
         {
             $getParams += "submissionId=$SubmissionId"
+        }
+
+        if ($WithSasUri)
+        {
+            $getParams += "withSasUri=true"
         }
 
         $params = @{

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -104,6 +104,7 @@ Add-Type -TypeDefinition @"
       WaitForCompletion,
       WaitUntilReady,
       Web,
+      WithSasUri,
       ZipPath
    }
 "@


### PR DESCRIPTION
This will force it to return back the SasUri for existing images
which is necessary when trying to download them via ConvertFrom-ExistingSubmission.

This also updates `ConvertFrom-ExistingSubmission` to use this new parameter and fixes the logic
so that it correctly references the `fileSasUri` to download the media during conversion.