### PR TITLE
Get New-StoreBrokerConfig working

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.6'
+    ModuleVersion = '2.0.7'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/AppConfigTemplate.ps1
+++ b/StoreBroker/AppConfigTemplate.ps1
@@ -1,5 +1,5 @@
 ﻿[ordered]@{
-    "helpUri" = "https:\\\\aka.ms\\StoreBroker_Config";
+    "helpUri" = "https:\\aka.ms\StoreBroker_Config";
     "schemaVersion" = 2;
     "packageParameters" = [ordered]@{
                               "PDPRootPath" = "";


### PR DESCRIPTION
New-StoreBrokerConfig can now generate a valid config file.
It works with or without a ProductId being specified.

If a ProductId is specified, it will fill that value into the
appSubmission.ProductId field, but it does not yet look up the recent
submission and populate the remainder of the appSubmission config values.