### PR TITLE
Update Resolve-ProductId to be able to resolve ProductId from the config

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.7'
+    ModuleVersion = '2.0.8'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/PackageConfig.ps1
+++ b/StoreBroker/PackageConfig.ps1
@@ -774,7 +774,8 @@ function Resolve-ProductId
         "values for AppId/IapId."
         ) | Out-String
 
-    if ([String]::IsNullOrWhiteSpace($ProductId))
+    if ([String]::IsNullOrWhiteSpace($ProductId) -and
+        [String]::IsNullOrWhiteSpace($Config.appSubmission.productId))
     {
         # Use AppId or IapId and do a reverse lookup of ProductId.
         # If we don't have either, check the config for the value.
@@ -829,6 +830,12 @@ function Resolve-ProductId
     }
     else
     {
+        if ([String]::IsNullOrWhiteSpace($ProductId))
+        {
+            $ProductId = $Config.appSubmission.productId
+            Write-Log -Message "Using ProductId from config: [$ProductId]." -Level Verbose
+        }
+
         Write-Log -Message "Validating ProductId: [$ProductId]" -Level Verbose
         $product = Get-Product -ProductId $ProductId
         if ($null -eq $product)


### PR DESCRIPTION
Previously, this was only ever tested against config files that had been
migrated from v1 over to v2 (meaning that they had appId's present).

As of 2.0.7, StoreBroker can create v2 config files, but that means that
it won't have the AppId, which means that Resolve-ProductId needs to also
support getting the ProductId from the config file as well.