### PR TITLE
Fix logic for adding new localized language listings

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.8'
+    ModuleVersion = '2.0.9'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionListingApi.ps1
+++ b/StoreBroker/StoreIngestionListingApi.ps1
@@ -651,7 +651,8 @@ function Update-Listing
 
     Write-InvocationLog
 
-    if ($SubmissionData.listings.Count -eq 0)
+    $submissionDataLangCodes = ($SubmissionData.listings |Get-Member -Type NoteProperty | Select-Object -ExpandProperty Name)
+    if ($submissionDataLangCodes.Count -eq 0)
     {
         if ((-not $UpdateVideos) -or ($SubmissionData.trailers.Count -eq 0))
         {
@@ -769,17 +770,12 @@ function Update-Listing
 
         # Now we have to see what languages exist in the user's supplied content that we didn't already
         # have cloned submissions for
-        if ($SubmissionData.listings.Count -gt 0)
+        foreach ($langCode in $submissionDataLangCodes)
         {
-            $SubmissionData.listings |
-                Get-Member -Type NoteProperty |
-                    ForEach-Object {
-                        $langCode = $_.Name
-                        if (-not $existingLangCodes.Contains($langCode))
-                        {
-                            $null = $missingLangCodes.Add($langCode)
-                        }
-                    }
+            if (-not $existingLangCodes.Contains($langCode))
+            {
+                $null = $missingLangCodes.Add($langCode)
+            }
         }
 
         Write-Log -Message 'Now adding listings for languages that don''t already exist.' -Level Verbose


### PR DESCRIPTION
The logic in `Update-Listing` incorrectly treated the `listings`
property on `SubmissionData` like an array (checking for the `Count` of
elements it contains).  The languages are actually treated as _properties_
on the object, and thus asking for the `$SubmissionData.listings.Count` always
returned back `$null` (and iterating on it did nothing).

Instead, we need to be looking specifically at its `NoteProperty` members,
and iterating on, or checking the count of, _those_.