### PR TITLE
Add support for msixupload for packaging

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.10'
+    ModuleVersion = '2.0.11'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -6,7 +6,7 @@ $script:packageImageFolderName = "Assets"
 
 # New-SubmissionPackage supports these extensions, but won't inspect their content due to encryption
 $script:extensionsSupportingInspection = @(".appx", ".appxbundle", ".appxupload")
-$script:extensionsNotSupportingInspection = @('.xvc', '.msix', '.msixbundle')
+$script:extensionsNotSupportingInspection = @('.xvc', '.msix', '.msixbundle', '.msixupload')
 $script:supportedExtensions =  $script:extensionsSupportingInspection + $script:extensionsNotSupportingInspection
 
 # String constants for New-SubmissionPackage parameters


### PR DESCRIPTION
Adds '.msixupload' to the list of extensions for files
that should be able to be packaged but not inspected (for
version numbers).  This means that .msixupload files will
not support the `-UpdatePackages` switch.