### PR TITLE
Support inspecting .msix packages for metadata when creating submission package

### DIFF
--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1633,7 +1633,7 @@ function Read-AppPackageMetadata
         if ($null -eq $appPackageManifest)
         {
             Report-UnsupportedFile -Path $AppPackagePath
-            throw "`"$AppPackagePath`" is not a proper .appx or .msix. Could not find an AppxManifest.xml."
+            throw "`"$AppPackagePath`" is not a proper .appx nor .msix. Could not find an AppxManifest.xml."
         }
 
         Write-Log -Message "Opening `"$appPackageManifest`"." -Level Verbose

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1522,14 +1522,14 @@ function Get-TargetPlatform
 
         Returns one of "Windows10", "Windows81", "Windows80", "WindowsPhone81", or $null
 
-    .PARAMETER AppxManifestPath
+    .PARAMETER AppPackageManifestPath
         A path to the AppxManifest.xml file to be processed.
 
     .OUTPUTS
         String    A string identifying the target platform, or $null if it could not be identified.
 
     .EXAMPLE
-        Get-TargetPlatform -AppxManifestPath "C:\package\AppxManifest.xml"
+        Get-TargetPlatform -AppPackageManifestPath "C:\package\AppxManifest.xml"
 
         Indentifies the target platform for the given AppxManifest.xml
 #>
@@ -1538,10 +1538,10 @@ function Get-TargetPlatform
         [ValidateScript({
             if (Test-Path -PathType Leaf -Include "AppxManifest.xml" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an AppxManifest.xml." } })]
-        [string] $AppxManifestPath
+        [string] $AppPackageManifestPath
     )
 
-    $manifest = [xml] (Get-Content -Path $AppxManifestPath -Encoding UTF8)
+    $manifest = [xml] (Get-Content -Path $AppPackageManifestPath -Encoding UTF8)
     $root = $manifest.DocumentElement
     if ($root.xmlns -match "^http://schemas.microsoft.com/appx/manifest/(.*/)?windows10(/.*)?$")
     {
@@ -1551,7 +1551,7 @@ function Get-TargetPlatform
     $minOSVersion = $root.Prerequisites.OSMinVersion
     if ([String]::IsNullOrEmpty($minOSVersion))
     {
-        Write-Log -Message "Could not find OSMinVersion in [$AppxManifestPath]" -Level Warning
+        Write-Log -Message "Could not find OSMinVersion in [$AppPackageManifestPath]" -Level Warning
         return $null
     }
 
@@ -2285,7 +2285,7 @@ function Get-SubmissionRequestBody
     .PARAMETER PackagePath
         A list of file paths to be included in the package.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
@@ -2343,7 +2343,7 @@ function Get-SubmissionRequestBody
 
         [string[]] $PackagePath,
 
-        [ref] $AppxInfo,
+        [ref] $AppPackageInfo,
 
         [switch] $DisableAutoPackageNameFormatting,
 
@@ -2355,7 +2355,7 @@ function Get-SubmissionRequestBody
 
     if ($PackagePath.Count -gt 0)
     {
-        $submissionRequestBody | Add-AppPackagesMetadata -PackagePath $PackagePath -AppxInfo $AppxInfo -EnableAutoPackageNameFormatting:(-not $DisableAutoPackageNameFormatting)
+        $submissionRequestBody | Add-AppPackagesMetadata -PackagePath $PackagePath -AppPackageInfo $AppPackageInfo -EnableAutoPackageNameFormatting:(-not $DisableAutoPackageNameFormatting)
     }
 
     if (-not [String]::IsNullOrWhiteSpace($PDPRootPath))
@@ -3227,8 +3227,8 @@ function New-SubmissionPackage
         $params = Get-Variable -Name $resourceParams -ErrorAction SilentlyContinue |
                   ForEach-Object { $m = @{} } { $m[$_.Name] = $_.Value } { $m } # foreach begin{} process{} end{}
 
-        $AppxInfo = @()
-        $submissionBody = Get-SubmissionRequestBody -ConfigObject $config -AppxInfo ([ref]$AppxInfo) @params
+        $AppPackageInfo = @()
+        $submissionBody = Get-SubmissionRequestBody -ConfigObject $config -AppPackageInfo ([ref]$AppPackageInfo) @params
 
         Write-SubmissionRequestBody -JsonObject $submissionBody -OutFilePath (Join-Path $OutPath ($OutName + '.json'))
 

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1613,7 +1613,7 @@ function Read-AppPackageMetadata
         [Parameter(Mandatory)]
         [ValidateScript({
             if (Test-Path -PathType Leaf -Include "*.appx" -Path $_ -ErrorAction Ignore) { $true }
-            else if (Test-Path -PathType Leaf -Include "*.msix" -Path $_ -ErrorAction Ignore) { $true }
+            elseif (Test-Path -PathType Leaf -Include "*.msix" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an .appx or .msix." } })]
         [string] $AppPackagePath,
 
@@ -1748,7 +1748,7 @@ function Read-AppPackageUploadMetadata
         [Parameter(Mandatory)]
         [ValidateScript({
             if (Test-Path -PathType Leaf -Include "*.appxupload" -Path $_ -ErrorAction Ignore) { $true }
-            else if (Test-Path -PathType Leaf -Include "*.msixupload" -Path $_ -ErrorAction Ignore) { $true }
+            elseif (Test-Path -PathType Leaf -Include "*.msixupload" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an .appxupload or .msixupload." } })]
         [string] $AppPackageUploadPath,
 
@@ -1844,7 +1844,7 @@ function Read-AppPackageBundleMetadata
         [Parameter(Mandatory)]
         [ValidateScript({
             if (Test-Path -PathType Leaf -Include "*.appxbundle" -Path $_ -ErrorAction Ignore) { $true }
-            else if (Test-Path -PathType Leaf -Include "*.msixbundle" -Path $_ -ErrorAction Ignore) { $true }
+            elseif (Test-Path -PathType Leaf -Include "*.msixbundle" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an .appxbundle or .msixbundle." } })]
         [string] $AppPackageBundlePath,
 


### PR DESCRIPTION
Currently, StoreBroker combines `.msix*` packages into `.json`/`.zip` pairs without inspecting the metadata within as it does for `.appx*` apps. This change will enable metadata inspection for `.msix`, `.msixbundle`, and `.msixupload` file extensions. This PR addresses issue #147 (for users using v2).

#### Tests
- Created `New-SubmissionPackage` for `.appxbundle` with and without this change to verify no different in generated `.json`
- Created `New-SubmissionPackage` for `.msixbundle` with this change and verified appropriate values were set
