### PR TITLE
Fix enum reference for StoreBrokerSubmissionProperty::isManualPublish

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.0.10'
+    ModuleVersion = '2.0.11'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1134,7 +1134,7 @@ function Update-SubmissionDetail
             if ((-not $IsMinimalObject) -or
                 (Test-PropertyExists -InputObject $SubmissionData -Name 'targetPublishMode'))
             {
-                Set-ObjectProperty @setObjectPropertyParams -Name ([StoreBrokerProductPropertyProperty]::isManualPublish) -Value ($SubmissionData.targetPublishMode -eq $script:keywordManual)
+                Set-ObjectProperty @setObjectPropertyParams -Name ([StoreBrokerSubmissionProperty]::isManualPublish) -Value ($SubmissionData.targetPublishMode -eq $script:keywordManual)
             }
 
             # There is no equivalent of changing to "Immediate" from a specific date/time,


### PR DESCRIPTION
There was an instance where the wrong enum class was being access for
the `isManualPublish` value.