### PR TITLE
Fix Open-Store support for AppId

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.0'
+    ModuleVersion = '2.1.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1668,7 +1668,7 @@ param(
 
     Set-TelemetryEvent -EventName Open-Store -Properties $telemetryProperties
 
-    if ($null -eq $ProductId)
+    if ([String]::IsNullOrWhiteSpace($ProductId))
     {
         $product = Get-Product -AppId $AppId
         $ProductId = $product.id


### PR DESCRIPTION
`Open-Store` uses the `Get-ProductStoreLink` to determine the
web and Store App URI's which requires a `ProductId`.  `Open-Store`
supports being called directly with a `ProductId`, or instead
with an `Appid` (it will simply use that to look up the `ProductId`
via `Get-Product`).  There was, however, an incorrect check was
determining if there was a valid `ProductId` by comparing it to `$null`
instead of checking if it was also empty.

Because of that incorrect check, we ended up calling `Get-ProductStoreLink`
with an empty `ProductId` which caused the validation logic in
`Get-ProductStoreLink` to return the error message that a user likely
passed-in an AppId and should therefore call it with the `-AppId` parameter.

That message was confusing, as it's the same validation error that `Open-Store`
would report back to users if they passed in an `AppId` as a `ProductId`, and yet
in this case the user _had_ actually passed in `-AppId`.

The fix here was to simply replace the `$null` check with a `[String]::IsNullOrWhiteSpace`
check.