### PR TITLE
Change server-requested retry logic from recursion to looping

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.1'
+    ModuleVersion = '2.1.2'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -2103,8 +2103,9 @@ function Invoke-SBRestMethod
             {
                 Write-Log -Message "The server has indicated that the result is not yet ready (received status code of [$statusCode]).  Will retry in [$retryAfterHeaderValue] seconds."
                 Start-Sleep -Seconds ($retryAfterHeaderValue)
-                $PSBoundParameters['UriFragment'] = $locationHeaderValue
-                return (Invoke-SBRestMethod @PSBoundParameters)
+                $UriFragment = $locationHeaderValue
+                $stopwatch.Reset() # since we'll be re-using this same stopwatch on the next iteration, make sure it starts fresh.
+                continue # start the loop over using the new location, and see if we waited enough time for the API to be ready for us this time around.
             }
             else
             {


### PR DESCRIPTION
Previously, if a request returned a `202` response (result not yet ready),
`Invoke-SBRestMethod` would sleep the requested amount of time, and then
recursively call itself to try again.

This implementation was perfectly reasonable, except that some API commands
have been increasing in how long they take to complete, and the result has been
large recursive call stacks that are too much for the system to handle:
`The script failed due to call depth overflow.`

To fix this, I have migrated the handling of `202` results from using recursion
to taking advantage of the loop that already exists to handle the other retry
logic that `Invoke-SBRestMethod` supports for other response codes; instead of
using recursion, it simply updates `$UrlFragment` with the new location from the
header, and then uses `continue` to start the loop all over again.  Since the
same stopwatch will be used for the next telemetry event in the loop, we also
reset the stopwatch before continuing so that each retry has an accurate duration.