### PR TITLE
Avoid timing issue when adding Listings while packages are being processed

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.2'
+    ModuleVersion = '2.1.3'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'


### PR DESCRIPTION
In Submission API v2, if a package adds support for new languages,
the API will automatically create listings for those languages once the
package has been fully processed.

It turns out that this can lead to a timing issue if, during `Update-Submission`,
we upload a new package, and then proceed to add/update/delete the Listings.

The API will return back a 400 error if you try to POST (create) a listing
for a language that already exists (as opposed to trying to modify it).
Since we call `Get-Listing` to get all of the existing listings right after
uploading the packages, this introduces a potental timing issue that we might
be attempting to create a Listing for a language that didn't previously exist,
but that the API automatically created as soon as it finished processing the
package.

There are two potential solutions to this problem:
  1. Call `Wait-ProductPackageProcessed` after modifying the packages to ensure
     that we don't proceed further until all of the packages have been processed
  2. Update the listings _first_, and then update the packages.

With this change, I've decided to take the second approach, primarily because
I don't want to unnecessarily wait for packages to be processed if the user
isn't intending to automatically commit the submission once all of the processing
is done (we already call `Wait-ProductPackageProcessed` if `-AutoCommit` was provided).