### PR TITLE
Flights do not support changes to ProductAvailability (Visibility)

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.3'
+    ModuleVersion = '2.1.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1638,7 +1638,8 @@ function Update-Submission
             'UpdatePricingAndAvailability',
             'UpdateAppProperties',
             'UpdateGamingOptions',
-            'UpdateVideos'
+            'UpdateVideos',
+            'Visibility'
         )
 
         foreach ($option in $unsupportedFlightingOptions)


### PR DESCRIPTION
Updating list of parameters that are restricted for flights.
Attempting to update the visibility (availability) of a flight submission
will result in a 400 error.