### PR TITLE
Enable proper handling of bundles with subfolders

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.4'
+    ModuleVersion = '2.1.5'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1894,8 +1894,13 @@ function Read-AppPackageBundleMetadata
         $applications = ($manifest.Bundle.Packages.ChildNodes | Where-Object Type -like "application").FileName
         foreach ($application in $applications)
         {
-            $appPackageFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include $application).FullName
-            Write-Log -Message "Opening `"$appPackageFilePath`"." -Indent 2 -Level Verbose
+            # Usually, the "application" attribute will just be a file that is in the root of the
+            # bundle, however sometimes it might be directly referencing a file in a sub-folder.
+            # Therefore, we need to split that path apart so that Get-ChildItem can search correctly.
+            $searchPath = Join-Path -Path $expandedContainerPath -ChildPath (Split-Path -Path $application -Parent)
+            $searchFilename = Split-Path -Path $application -Leaf
+            $appPackageFilePath = (Get-ChildItem -Recurse -Path $searchPath -Include $searchFilename).FullName
+            Write-Log -Message "Looked for [`"$application`"].  Opening it from [`"$appPackageFilePath`"]." -Indent 2 -Level Verbose
             $appPackageMetadata = Read-AppPackageMetadata -AppPackagePath $appPackageFilePath -AppPackageInfo $AppPackageInfo
 
             # targetPlatform will always be the values of the last .appx processed.


### PR DESCRIPTION
The existing logic incorrectly assumed that individual packages within
a bundle (appxbundle/msixbundle) would always be in the root.

This minor update corrects how we search for the application specified in
the manifest when we are processing the package metadata.