### PR TITLE
Don't overwrite inner package metadata with data from packages in subfolders

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.5'
+    ModuleVersion = '2.1.6'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -1891,16 +1891,16 @@ function Read-AppPackageBundleMetadata
         $targetDeviceFamilies            = @()
         $targetDeviceFamiliesEx          = @()
 
-        $applications = ($manifest.Bundle.Packages.ChildNodes | Where-Object Type -like "application").FileName
+        $applications = ($manifest.Bundle.Packages.ChildNodes | Where-Object Type -like "application")
         foreach ($application in $applications)
         {
             # Usually, the "application" attribute will just be a file that is in the root of the
             # bundle, however sometimes it might be directly referencing a file in a sub-folder.
             # Therefore, we need to split that path apart so that Get-ChildItem can search correctly.
-            $searchPath = Join-Path -Path $expandedContainerPath -ChildPath (Split-Path -Path $application -Parent)
-            $searchFilename = Split-Path -Path $application -Leaf
+            $searchPath = Join-Path -Path $expandedContainerPath -ChildPath (Split-Path -Path $application.FileName -Parent)
+            $searchFilename = Split-Path -Path $application.FileName -Leaf
             $appPackageFilePath = (Get-ChildItem -Recurse -Path $searchPath -Include $searchFilename).FullName
-            Write-Log -Message "Looked for [`"$application`"].  Opening it from [`"$appPackageFilePath`"]." -Indent 2 -Level Verbose
+            Write-Log -Message "Looked for [`"$($application.FileName)`"].  Opening it from [`"$appPackageFilePath`"]." -Indent 2 -Level Verbose
             $appPackageMetadata = Read-AppPackageMetadata -AppPackagePath $appPackageFilePath -AppPackageInfo $AppPackageInfo
 
             # targetPlatform will always be the values of the last .appx processed.
@@ -1909,6 +1909,12 @@ function Read-AppPackageBundleMetadata
             $capabilities            += $appPackageMetadata.capabilities
             $targetDeviceFamilies    += $appPackageMetadata.targetDeviceFamilies
             $targetDeviceFamiliesEx  += $appPackageMetadata.targetDeviceFamiliesEx
+            
+            # Don't overwrite full app data with data from a stub
+            if ($application.IsStub -and $null -ne $metadata.innerPackages.$($appPackageMetadata.architecture))
+            {
+                continue
+            }
 
             $metadata.innerPackages.$($appPackageMetadata.architecture) = @{
                 version                = $appPackageMetadata.version;


### PR DESCRIPTION
Packages in subfolders should have a subset of capabilities of the main app. It should also have the same target device family and platform. Furthermore we shouldn't use the version number from the subfolder package when naming the package later on.