### PR TITLE
Make the transfer limit used for AzSDML configurable.

### DIFF
--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -124,6 +124,12 @@ values of these variables will be honored if they already exist, otherwise they 
    previous attempts result in an error code within the list of values in `$global:SBAutoRetryErrorCodes`.
    Defaults to `5`
 
+ **`$global:SBDefaultTransferConnectionLimit`** - [int] The default number of concurrent connections
+   that the Azure Storage Data Movement Library will use when transferring application packages
+   and listing media metadata (screenshots/trailers). _In general, you should never need to modify
+   this unless you're running multiple concurrent StoreBroker processes on the same machine._
+   Defaults to `[Environment]::ProcessorCount * 8`
+
 ### Common Switches
 
 All commands support the `-Verbose` switch in the event that you want fine-grained detail

--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.6'
+    ModuleVersion = '2.1.7'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'


### PR DESCRIPTION
AzSDML = Azure Storage Data Movement Library

For users that run multiple pararallel StoreBroker clients,
it's possible that they may run out of system resources when
those clients all start trying to tranfer packages and/or
media metadata (screenshots/videos) concurrently.

This change allows users to adjust the default connection limit that the Azure Storage Data Movement Library uses when
transferring content.