### PR TITLE
Move to v2 endpoint

### DIFF
--- a/RESTProxy/Controllers/RootController.cs
+++ b/RESTProxy/Controllers/RootController.cs
@@ -89,12 +89,6 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
             }
 
             // We must also extract out any relevant headers that a user may have set.
-            string correlationId = null;
-            if (Request.Headers.TryGetValues(ProxyManager.MSCorrelationIdHeader, out headerValues))
-            {
-                correlationId = headerValues.FirstOrDefault();
-            }
-
             string clientRequestId = null;
             if (Request.Headers.TryGetValues(ProxyManager.MSClientRequestIdHeader, out headerValues))
             {
@@ -116,7 +110,6 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Controllers
                 tenantId: tenantId,
                 tenantName: tenantName,
                 endpointType: endpointType,
-                correlationId: correlationId,
                 clientRequestId: clientRequestId,
                 clientName: clientName);
         }

--- a/RESTProxy/Models/Endpoint.cs
+++ b/RESTProxy/Models/Endpoint.cs
@@ -125,11 +125,11 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             {
                 if (this.Type == EndpointType.Prod)
                 {
-                    return "https://manage.devcenter.microsoft.com";
+                    return "https://api.partner.microsoft.com";
                 }
                 else
                 {
-                    return "https://manage.devcenter.microsoft-int.com";
+                    return "https://api.partner.microsoft-int.com";
                 }
             }
         }

--- a/RESTProxy/Models/Endpoint.cs
+++ b/RESTProxy/Models/Endpoint.cs
@@ -245,9 +245,6 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
         /// The <see cref="IPrincipal"/> of the user that we're performing the API request on behalf of.
         /// </param>
         /// <param name="body">The body content of the REST request (if needed).</param>
-        /// <param name="correlationId">
-        /// An ID that a client may have set in the header (which we must proxy) to track a string of related requests.
-        /// </param>
         /// <param name="clientRequestId">
         /// An ID that a client may have set in the header (which we must proxy) to track an individual request.
         /// </param>

--- a/RESTProxy/Models/Endpoint.cs
+++ b/RESTProxy/Models/Endpoint.cs
@@ -370,11 +370,13 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             // which is needed by the Windows Store Submission API team when they
             // are investigating bug reports with the API.
             const string MSHeaderPreface = "MS-";
+            const string RequestHeaderPreface = "Request-";
             const string RetryHeader = "retry";
             const string LocationHeader = "Location";
             foreach (string key in httpResponseFromApi.Headers.AllKeys)
             {
                 if (key.StartsWith(MSHeaderPreface, StringComparison.InvariantCultureIgnoreCase) ||
+                    key.StartsWith(RequestHeaderPreface, StringComparison.InvariantCultureIgnoreCase) ||
                     key.ToLowerInvariant().Contains(RetryHeader.ToLowerInvariant()) ||
                     (key.ToLowerInvariant() == LocationHeader.ToLowerInvariant()))
                 {

--- a/RESTProxy/Models/Endpoint.cs
+++ b/RESTProxy/Models/Endpoint.cs
@@ -357,17 +357,17 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             }
 
             // Proxy all of the special headers that the API returns
-            // (which all begin with "MS-").  One example is "MS-Client-RequestId"
+            // One example is "Client-Request-ID"
             // which is needed by the Windows Store Submission API team when they
             // are investigating bug reports with the API.
-            const string MSHeaderPreface = "MS-";
-            const string RequestHeaderPreface = "Request-";
+            const string ClientRequestIdHeader = "Client-Request-ID";
+            const string RequestHeader = "Request-ID";
             const string RetryHeader = "retry";
             const string LocationHeader = "Location";
             foreach (string key in httpResponseFromApi.Headers.AllKeys)
             {
-                if (key.StartsWith(MSHeaderPreface, StringComparison.InvariantCultureIgnoreCase) ||
-                    key.StartsWith(RequestHeaderPreface, StringComparison.InvariantCultureIgnoreCase) ||
+                if (key.ToLowerInvariant().Contains(RequestHeader.ToLowerInvariant()) ||
+                    key.ToLowerInvariant().Contains(ClientRequestIdHeader.ToLowerInvariant()) ||
                     key.ToLowerInvariant().Contains(RetryHeader.ToLowerInvariant()) ||
                     (key.ToLowerInvariant() == LocationHeader.ToLowerInvariant()))
                 {

--- a/RESTProxy/Models/Endpoint.cs
+++ b/RESTProxy/Models/Endpoint.cs
@@ -261,7 +261,6 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             HttpMethod method,
             IPrincipal onBehalfOf,
             string body = null,
-            string correlationId = null,
             string clientRequestId = null,
             string clientName = null)
         {
@@ -298,11 +297,6 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
                 }
 
                 // Add any additional headers that the client may have specified in their request
-                if (!string.IsNullOrWhiteSpace(correlationId))
-                {
-                    request.Headers[ProxyManager.MSCorrelationIdHeader] = correlationId;
-                }
-
                 if (!string.IsNullOrWhiteSpace(clientRequestId))
                 {
                     request.Headers[ProxyManager.MSClientRequestIdHeader] = clientRequestId;
@@ -366,7 +360,7 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             }
 
             // Proxy all of the special headers that the API returns
-            // (which all begin with "MS-").  One example is "MS-CorrelationId"
+            // (which all begin with "MS-").  One example is "MS-Client-RequestId"
             // which is needed by the Windows Store Submission API team when they
             // are investigating bug reports with the API.
             const string MSHeaderPreface = "MS-";

--- a/RESTProxy/Models/ProxyManager.cs
+++ b/RESTProxy/Models/ProxyManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
         ///  The header name for the RequestId that clients can set for tracking an individual request
         ///  during post-mortem diagnostics.
         /// </summary>
-        public const string MSClientRequestIdHeader = "MS-Client-RequestId";
+        public const string MSClientRequestIdHeader = "Client-Request-ID";
 
         /// <summary>
         /// The header name for a special header that the API uses for telemetry/tracking of API clients.

--- a/RESTProxy/Models/ProxyManager.cs
+++ b/RESTProxy/Models/ProxyManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
         /// <summary>
         ///  The header name for the RequestId that the API adds for post-mortem diagnostics.
         /// </summary>
-        public const string MSRequestIdHeader = "MS-RequestId";
+        public const string RequestIdHeader = "Request-ID";
 
         /// <summary>
         ///  The header name for the RequestId that clients can set for tracking an individual request
@@ -208,7 +208,7 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
                     correlationId = headerValues.FirstOrDefault();
                 }
 
-                if (response.Headers.TryGetValues(ProxyManager.MSRequestIdHeader, out headerValues))
+                if (response.Headers.TryGetValues(ProxyManager.RequestIdHeader, out headerValues))
                 {
                     requestId = headerValues.FirstOrDefault();
                 }

--- a/RESTProxy/Models/ProxyManager.cs
+++ b/RESTProxy/Models/ProxyManager.cs
@@ -123,6 +123,8 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             {
                 ProxyManager.defaultTenantId = defaultTenantId.ToLowerInvariant();
             }
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
         /// <summary>

--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.9'
+    ModuleVersion = '2.1.10'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/ConvertFrom-ExistingSubmission.ps1
+++ b/StoreBroker/ConvertFrom-ExistingSubmission.ps1
@@ -142,7 +142,7 @@ function ConvertFrom-ExistingSubmission
 
         [switch] $DownloadMedia,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -154,10 +154,10 @@ function ConvertFrom-ExistingSubmission
 
     try
     {
-        $CorrelationId = Get-CorrelationId -CorrelationId $CorrelationId -Identifier 'ConvertFrom-ExistingSubmission'
+        $ClientRequestId = Get-ClientRequestId -ClientRequestId $ClientRequestId -Identifier 'ConvertFrom-ExistingSubmission'
 
         $commonParams = @{
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -239,7 +239,7 @@ function ConvertFrom-ExistingSubmission
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::AppId = $AppId
             [StoreBrokerTelemetryProperty]::SubmissionId = $submissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName ConvertFrom-ExistingSubmission -Properties $telemetryProperties -Metrics $telemetryMetrics
@@ -1552,7 +1552,7 @@ function ConvertFrom-Listing
 
         [switch] $DownloadMedia,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1565,7 +1565,7 @@ function ConvertFrom-Listing
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
             'LanguageCode' = $Listing.languageCode
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }

--- a/StoreBroker/ConvertFrom-ExistingSubmission.ps1
+++ b/StoreBroker/ConvertFrom-ExistingSubmission.ps1
@@ -142,8 +142,6 @@ function ConvertFrom-ExistingSubmission
 
         [switch] $DownloadMedia,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -159,7 +157,6 @@ function ConvertFrom-ExistingSubmission
         $CorrelationId = Get-CorrelationId -CorrelationId $CorrelationId -Identifier 'ConvertFrom-ExistingSubmission'
 
         $commonParams = @{
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -242,7 +239,6 @@ function ConvertFrom-ExistingSubmission
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::AppId = $AppId
             [StoreBrokerTelemetryProperty]::SubmissionId = $submissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1556,8 +1552,6 @@ function ConvertFrom-Listing
 
         [switch] $DownloadMedia,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1571,7 +1565,6 @@ function ConvertFrom-Listing
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
             'LanguageCode' = $Listing.languageCode
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -51,7 +51,7 @@ $script:headerClientName = 'X-ClientName'
 
 # Special header added to Submission API responses that provides a unique ID
 # that the Submission API team can use to trace back problems with a specific request.
-$script:headerMSRequestId = 'MS-RequestId'
+$script:headerRequestId = 'Request-ID'
 
 # Special headers that clients can add to their requests to make it easier to track the
 # responses
@@ -1953,7 +1953,7 @@ function Invoke-SBRestMethod
 
                         # Because this is running in a different PowerShell process, we need to
                         # redefine this script variable (for use within the exception)
-                        $script:headerMSRequestId = $RequestIdHeaderName
+                        $script:headerRequestId = $RequestIdHeaderName
                         $script:headerMSClientRequestId = $ClientRequestIdHeaderName
                         $script:headerMSCorrelationId = $CorrelationIdHeaderName
 
@@ -2002,9 +2002,9 @@ function Invoke-SBRestMethod
                             $responseHeaders = $_.Exception.Response.Headers
                             if ($responseHeaders.Count -gt 0)
                             {
-                                if ($responseHeaders.AllKeys.Contains($script:headerMSRequestId))
+                                if ($responseHeaders.AllKeys.Contains($script:headerRequestId))
                                 {
-                                    $ex.RequestId = $responseHeaders[$script:headerMSRequestId]
+                                    $ex.RequestId = $responseHeaders[$script:headerRequestId]
                                 }
 
                                 if ($responseHeaders.AllKeys.Contains($script:headerMSClientRequestId))
@@ -2032,7 +2032,7 @@ function Invoke-SBRestMethod
                         }
                     }
 
-                    $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $script:headerMSRequestId, $script:headerMSClientRequestId, $script:headerMSCorrelationId, $global:SBWebRequestTimeoutSec, $PSScriptRoot)
+                    $null = Start-Job -Name $jobName -ScriptBlock $scriptBlock -Arg @($url, $Method, $headers, $Body, $script:headerRequestId, $script:headerMSClientRequestId, $script:headerMSCorrelationId, $global:SBWebRequestTimeoutSec, $PSScriptRoot)
 
                     if ($PSCmdlet.ShouldProcess($jobName, "Wait-JobWithAnimation"))
                     {
@@ -2056,11 +2056,11 @@ function Invoke-SBRestMethod
                 }
             }
 
-            $requestId = $result.Headers[$script:headerMSRequestId]
+            $requestId = $result.Headers[$script:headerRequestId]
             if (-not [String]::IsNullOrEmpty($requestId))
             {
-                $localTelemetryProperties[$script:headerMSRequestId] = $requestId
-                Write-Log -Message "$($script:headerMSRequestId) : $requestId" -Level Verbose
+                $localTelemetryProperties[$script:headerRequestId] = $requestId
+                Write-Log -Message "$($script:headerRequestId) : $requestId" -Level Verbose
             }
 
             $returnedClientRequestId = $result.Headers[$script:headerMSClientRequestId]
@@ -2174,9 +2174,9 @@ function Invoke-SBRestMethod
                 $responseHeaders = $ex.Response.Headers
                 if ($responseHeaders.Count -gt 0)
                 {
-                    if ($responseHeaders.AllKeys.Contains($script:headerMSRequestId))
+                    if ($responseHeaders.AllKeys.Contains($script:headerRequestId))
                     {
-                        $requestId = $responseHeaders[$script:headerMSRequestId]
+                        $requestId = $responseHeaders[$script:headerRequestId]
                     }
 
                     if ($responseHeaders.AllKeys.Contains($script:headerMSClientRequestId))
@@ -2305,8 +2305,8 @@ function Invoke-SBRestMethod
 
             if (-not [String]::IsNullOrEmpty($requestId))
             {
-                $localTelemetryProperties[$script:headerMSRequestId] = $requestId
-                $message = $script:headerMSRequestId + ': ' + $requestId
+                $localTelemetryProperties[$script:headerRequestId] = $requestId
+                $message = $script:headerRequestId + ': ' + $requestId
                 $output += $message
                 Write-Log -Message $message -Level Verbose
             }

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -53,9 +53,9 @@ $script:headerClientName = 'X-ClientName'
 # that the Submission API team can use to trace back problems with a specific request.
 $script:headerRequestId = 'Request-ID'
 
-# Special headers that clients can add to their requests to make it easier to track the
+# Special header that clients can add to their requests to make it easier to track the
 # responses
-$script:headerMSClientRequestId = 'MS-Client-RequestId'
+$script:headerMSClientRequestId = 'Client-Request-ID'
 
 # Other headers that we may need for processing a response
 $script:headerRetryAfter = 'Retry-After'
@@ -948,7 +948,7 @@ function Set-StoreFile
 
             if ($remoteErrors.Count -gt 0)
             {
-               throw $remoteErrors[0].Exception
+                throw $remoteErrors[0].Exception
             }
         }
 
@@ -1888,6 +1888,7 @@ function Invoke-SBRestMethod
             }
         }
 
+        # Add header that the clients can add to track groups of requests
         if (-not [String]::IsNullOrWhiteSpace($ClientRequestId))
         {
             $headers.Add($script:headerMSClientRequestId, $ClientRequestId)

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -643,8 +643,8 @@ function Get-ServiceEndpoint
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "", Justification="We use global variables sparingly and intentionally for module configuration, and employ a consistent naming convention.")]
     param()
 
-    $serviceEndpointInt = "https://manage.devcenter.microsoft-int.com"
-    $serviceEndpointProd = "https://manage.devcenter.microsoft.com"
+    $serviceEndpointInt = "https://api.partner.microsoft-int.com"
+    $serviceEndpointProd = "https://api.partner.microsoft.com"
 
     if (-not [String]::IsNullOrEmpty($script:proxyEndpoint))
     {
@@ -1809,7 +1809,7 @@ function Invoke-SBRestMethod
         [switch] $NoStatus
     )
 
-    $serviceEndpointVersion = "2.0"
+    $serviceEndpointVersion = "1.0"
 
     # Normalize our Uri fragment.  It might be coming from a method implemented here, or it might
     # be coming from the Location header in a previous response.  Either way, we don't want there
@@ -1857,7 +1857,7 @@ function Invoke-SBRestMethod
         $stopwatch.Start()
 
         $serviceEndpoint = Get-ServiceEndpoint
-        $uriPreface = "v$serviceEndpointVersion/my"
+        $uriPreface = "v$serviceEndpointVersion/ingestion"
         $url = "$serviceEndpoint/$uriPreface/$UriFragment"
 
         # This scenario might happen if a client calls into here setting the UriFragment

--- a/StoreBroker/StoreIngestionFeatureAvailabilityApi.ps1
+++ b/StoreBroker/StoreIngestionFeatureAvailabilityApi.ps1
@@ -33,7 +33,7 @@ function Get-FeatureAvailability
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -54,7 +54,7 @@ function Get-FeatureAvailability
             [StoreBrokerTelemetryProperty]::IncludeMarketStates = ($IncludeMarketStates -eq $true)
             [StoreBrokerTelemetryProperty]::IncludeTrial = ($IncludeTrial -eq $true)
             [StoreBrokerTelemetryProperty]::IncludePricing = ($IncludePricing -eq $true)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -73,7 +73,7 @@ function Get-FeatureAvailability
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-FeatureAvailability"
             "TelemetryProperties" = $telemetryProperties
@@ -130,7 +130,7 @@ function New-FeatureAvailability
             ParameterSetName="Object")]
         [PSCustomObject] $Object,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -149,7 +149,7 @@ function New-FeatureAvailability
             [StoreBrokerTelemetryProperty]::IncludeTrial = ($IncludeTrial -eq $true)
             [StoreBrokerTelemetryProperty]::IncludePricing = ($IncludePricing -eq $true)
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::FeatureAvailability)
@@ -161,7 +161,7 @@ function New-FeatureAvailability
             "Method" = 'Post'
             "Description" = "Creating new feature availability for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-FeatureAvailability"
             "TelemetryProperties" = $telemetryProperties
@@ -208,7 +208,7 @@ function Set-FeatureAvailability
             ParameterSetName="Object")]
         [PSCustomObject] $Object,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -233,7 +233,7 @@ function Set-FeatureAvailability
             [StoreBrokerTelemetryProperty]::IncludeTrial = ($IncludeTrial -eq $true)
             [StoreBrokerTelemetryProperty]::IncludePricing = ($IncludePricing -eq $true)
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::FeatureAvailability)
@@ -245,7 +245,7 @@ function Set-FeatureAvailability
             "Method" = 'Put'
             "Description" = "Updating feature availability $FeatureAvailabilityId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-FeatureAvailability"
             "TelemetryProperties" = $telemetryProperties

--- a/StoreBroker/StoreIngestionFeatureAvailabilityApi.ps1
+++ b/StoreBroker/StoreIngestionFeatureAvailabilityApi.ps1
@@ -33,8 +33,6 @@ function Get-FeatureAvailability
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -56,7 +54,6 @@ function Get-FeatureAvailability
             [StoreBrokerTelemetryProperty]::IncludeMarketStates = ($IncludeMarketStates -eq $true)
             [StoreBrokerTelemetryProperty]::IncludeTrial = ($IncludeTrial -eq $true)
             [StoreBrokerTelemetryProperty]::IncludePricing = ($IncludePricing -eq $true)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -76,7 +73,6 @@ function Get-FeatureAvailability
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-FeatureAvailability"
@@ -134,8 +130,6 @@ function New-FeatureAvailability
             ParameterSetName="Object")]
         [PSCustomObject] $Object,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -155,7 +149,6 @@ function New-FeatureAvailability
             [StoreBrokerTelemetryProperty]::IncludeTrial = ($IncludeTrial -eq $true)
             [StoreBrokerTelemetryProperty]::IncludePricing = ($IncludePricing -eq $true)
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -168,7 +161,6 @@ function New-FeatureAvailability
             "Method" = 'Post'
             "Description" = "Creating new feature availability for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-FeatureAvailability"
@@ -216,8 +208,6 @@ function Set-FeatureAvailability
             ParameterSetName="Object")]
         [PSCustomObject] $Object,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -243,7 +233,6 @@ function Set-FeatureAvailability
             [StoreBrokerTelemetryProperty]::IncludeTrial = ($IncludeTrial -eq $true)
             [StoreBrokerTelemetryProperty]::IncludePricing = ($IncludePricing -eq $true)
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -256,7 +245,6 @@ function Set-FeatureAvailability
             "Method" = 'Put'
             "Description" = "Updating feature availability $FeatureAvailabilityId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-FeatureAvailability"

--- a/StoreBroker/StoreIngestionFeatureGroupApi.ps1
+++ b/StoreBroker/StoreIngestionFeatureGroupApi.ps1
@@ -25,8 +25,6 @@ function Get-FeatureGroup
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -44,12 +42,10 @@ function Get-FeatureGroup
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-FeatureGroup"
@@ -99,8 +95,6 @@ function New-FeatureGroup
             ParameterSetName="Object")]
         [PSCustomObject[]] $Object,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -116,7 +110,6 @@ function New-FeatureGroup
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -154,7 +147,6 @@ function New-FeatureGroup
             "Method" = 'Post'
             "Description" = $description
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-FeatureGroup"
@@ -173,7 +165,6 @@ function New-FeatureGroup
                 $params = @{
                     "UriFragment" = $result.nextLink
                     "Description" = "Getting remaining results"
-                    "ClientRequestId" = $ClientRequestId
                     "CorrelationId" = $CorrelationId
                     "AccessToken" = $AccessToken
                     "TelemetryEventName" = "New-FeatureGroup"
@@ -213,8 +204,6 @@ function Remove-FeatureGroup
         [Parameter(Mandatory)]
         [string] $FeatureGroupId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -230,7 +219,6 @@ function Remove-FeatureGroup
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -244,7 +232,6 @@ function Remove-FeatureGroup
             "UriFragment" = "products/$ProductId/featureGroups/$FeatureGroupId`?" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting feature group $FeaureGroupId for $ProductId (SubmissionId: $SubmissionId)"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-FeatureGroup"
@@ -289,8 +276,6 @@ function Set-FeatureGroup
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -313,7 +298,6 @@ function Set-FeatureGroup
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $GroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -343,7 +327,6 @@ function Set-FeatureGroup
             "Method" = 'Put'
             "Description" = "Updating feature group $FeatureGroupId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-FeatureGroup"

--- a/StoreBroker/StoreIngestionFeatureGroupApi.ps1
+++ b/StoreBroker/StoreIngestionFeatureGroupApi.ps1
@@ -25,7 +25,7 @@ function Get-FeatureGroup
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -42,11 +42,11 @@ function Get-FeatureGroup
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-FeatureGroup"
             "TelemetryProperties" = $telemetryProperties
@@ -95,7 +95,7 @@ function New-FeatureGroup
             ParameterSetName="Object")]
         [PSCustomObject[]] $Object,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -110,7 +110,7 @@ function New-FeatureGroup
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -147,7 +147,7 @@ function New-FeatureGroup
             "Method" = 'Post'
             "Description" = $description
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-FeatureGroup"
             "TelemetryProperties" = $telemetryProperties
@@ -165,7 +165,7 @@ function New-FeatureGroup
                 $params = @{
                     "UriFragment" = $result.nextLink
                     "Description" = "Getting remaining results"
-                    "CorrelationId" = $CorrelationId
+                    "ClientRequestId" = $ClientRequestId
                     "AccessToken" = $AccessToken
                     "TelemetryEventName" = "New-FeatureGroup"
                     "TelemetryProperties" = $telemetryProperties
@@ -204,7 +204,7 @@ function Remove-FeatureGroup
         [Parameter(Mandatory)]
         [string] $FeatureGroupId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -219,7 +219,7 @@ function Remove-FeatureGroup
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -232,7 +232,7 @@ function Remove-FeatureGroup
             "UriFragment" = "products/$ProductId/featureGroups/$FeatureGroupId`?" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting feature group $FeaureGroupId for $ProductId (SubmissionId: $SubmissionId)"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-FeatureGroup"
             "TelemetryProperties" = $telemetryProperties
@@ -276,7 +276,7 @@ function Set-FeatureGroup
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -298,7 +298,7 @@ function Set-FeatureGroup
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $GroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -327,7 +327,7 @@ function Set-FeatureGroup
             "Method" = 'Put'
             "Description" = "Updating feature group $FeatureGroupId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-FeatureGroup"
             "TelemetryProperties" = $telemetryProperties

--- a/StoreBroker/StoreIngestionFlightApi.ps1
+++ b/StoreBroker/StoreIngestionFlightApi.ps1
@@ -33,8 +33,6 @@ function Get-Flight
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -51,12 +49,10 @@ function Get-Flight
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::FlightId = $FlightId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Flight"
@@ -116,8 +112,6 @@ function New-Flight
         [Parameter(ParameterSetName="Individual")]
         [int] $RelativeRank,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -133,7 +127,6 @@ function New-Flight
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RelativeRank = $RelativeRank
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -163,7 +156,6 @@ function New-Flight
             "Method" = 'Post'
             "Description" = "Creating new flight for $ProductId"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Flight"
@@ -192,8 +184,6 @@ function Remove-Flight
         [Parameter(Mandatory)]
         [string] $FlightId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -208,7 +198,6 @@ function Remove-Flight
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::FlightId = $FlightId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -216,7 +205,6 @@ function Remove-Flight
             "UriFragment" = "products/$ProductId/flights/$FlightId"
             "Method" = "Delete"
             "Description" = "Deleting flight $FlightId for $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Flight"
@@ -272,8 +260,6 @@ function Set-Flight
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -296,7 +282,6 @@ function Set-Flight
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RelativeRank = $RelativeRank
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -327,7 +312,6 @@ function Set-Flight
             "Method" = 'Put'
             "Description" = "Updating flight $FlightId for $ProductId"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-Flight"
@@ -360,8 +344,6 @@ function Update-Flight
 
         [int] $RelativeRank,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -380,7 +362,6 @@ function Update-Flight
         $params = @{
             'ProductId' = $ProductId
             'FlightId' = $FlightId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -411,7 +392,6 @@ function Update-Flight
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::FlightId = $FlightId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionFlightApi.ps1
+++ b/StoreBroker/StoreIngestionFlightApi.ps1
@@ -33,7 +33,7 @@ function Get-Flight
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -49,11 +49,11 @@ function Get-Flight
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::FlightId = $FlightId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Flight"
             "TelemetryProperties" = $telemetryProperties
@@ -112,7 +112,7 @@ function New-Flight
         [Parameter(ParameterSetName="Individual")]
         [int] $RelativeRank,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -127,7 +127,7 @@ function New-Flight
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RelativeRank = $RelativeRank
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::Flight)
@@ -156,7 +156,7 @@ function New-Flight
             "Method" = 'Post'
             "Description" = "Creating new flight for $ProductId"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Flight"
             "TelemetryProperties" = $telemetryProperties
@@ -184,7 +184,7 @@ function Remove-Flight
         [Parameter(Mandatory)]
         [string] $FlightId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -198,14 +198,14 @@ function Remove-Flight
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::FlightId = $FlightId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/flights/$FlightId"
             "Method" = "Delete"
             "Description" = "Deleting flight $FlightId for $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Flight"
             "TelemetryProperties" = $telemetryProperties
@@ -260,7 +260,7 @@ function Set-Flight
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -282,7 +282,7 @@ function Set-Flight
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RelativeRank = $RelativeRank
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::Flight)
@@ -312,7 +312,7 @@ function Set-Flight
             "Method" = 'Put'
             "Description" = "Updating flight $FlightId for $ProductId"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-Flight"
             "TelemetryProperties" = $telemetryProperties
@@ -344,7 +344,7 @@ function Update-Flight
 
         [int] $RelativeRank,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -357,12 +357,12 @@ function Update-Flight
     {
         $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-        $CorrelationId = Get-CorrelationId -CorrelationId $CorrelationId -Identifier 'Update-Flight'
+        $ClientRequestId = Get-ClientRequestId -ClientRequestId $ClientRequestId -Identifier 'Update-Flight'
 
         $params = @{
             'ProductId' = $ProductId
             'FlightId' = $FlightId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -392,7 +392,7 @@ function Update-Flight
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::FlightId = $FlightId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-Flight -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionGroupApi.ps1
+++ b/StoreBroker/StoreIngestionGroupApi.ps1
@@ -20,8 +20,6 @@ function Get-Group
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -36,12 +34,10 @@ function Get-Group
         $singleQuery = (-not [String]::IsNullOrWhiteSpace($GroupId))
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Group"
@@ -95,8 +91,6 @@ function New-Group
             ParameterSetName="Individual")]
         [string] $Type,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -111,7 +105,6 @@ function New-Group
         $telemetryProperties = @{
                 [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
                 [StoreBrokerTelemetryProperty]::Type = $Type
-                [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
                 [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -135,7 +128,6 @@ function New-Group
             "Method" = 'Post'
             "Description" = "Creating new group"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Group"
@@ -184,8 +176,6 @@ function Set-Group
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -206,7 +196,6 @@ function Set-Group
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::Type = $Type
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -231,7 +220,6 @@ function Set-Group
             "Method" = 'Put'
             "Description" = "Updating group $GroupId"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-Group"

--- a/StoreBroker/StoreIngestionGroupApi.ps1
+++ b/StoreBroker/StoreIngestionGroupApi.ps1
@@ -20,7 +20,7 @@ function Get-Group
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -34,11 +34,11 @@ function Get-Group
         $singleQuery = (-not [String]::IsNullOrWhiteSpace($GroupId))
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Group"
             "TelemetryProperties" = $telemetryProperties
@@ -91,7 +91,7 @@ function New-Group
             ParameterSetName="Individual")]
         [string] $Type,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -105,7 +105,7 @@ function New-Group
         $telemetryProperties = @{
                 [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
                 [StoreBrokerTelemetryProperty]::Type = $Type
-                [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+                [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::Group)
@@ -128,7 +128,7 @@ function New-Group
             "Method" = 'Post'
             "Description" = "Creating new group"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Group"
             "TelemetryProperties" = $telemetryProperties
@@ -176,7 +176,7 @@ function Set-Group
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -196,7 +196,7 @@ function Set-Group
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::Type = $Type
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::Group)
@@ -220,7 +220,7 @@ function Set-Group
             "Method" = 'Put'
             "Description" = "Updating group $GroupId"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-Group"
             "TelemetryProperties" = $telemetryProperties

--- a/StoreBroker/StoreIngestionListingApi.ps1
+++ b/StoreBroker/StoreIngestionListingApi.ps1
@@ -42,7 +42,7 @@ function Get-Listing
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -60,7 +60,7 @@ function Get-Listing
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -75,7 +75,7 @@ function Get-Listing
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Listing"
             "TelemetryProperties" = $telemetryProperties
@@ -172,7 +172,7 @@ function New-Listing
         [Parameter(ParameterSetName="Individual")]
         [string] $ShortDescription,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -189,7 +189,7 @@ function New-Listing
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -297,7 +297,7 @@ function New-Listing
             "Method" = 'Post'
             "Description" = "Creating new $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Listing"
             "TelemetryProperties" = $telemetryProperties
@@ -331,7 +331,7 @@ function Remove-Listing
 
         [string] $FeatureGroupId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -347,7 +347,7 @@ function Remove-Listing
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -365,7 +365,7 @@ function Remove-Listing
             "UriFragment" = "products/$ProductId/listings/$LanguageCode" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting the $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Listing"
             "TelemetryProperties" = $telemetryProperties
@@ -454,7 +454,7 @@ function Set-Listing
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -477,7 +477,7 @@ function Set-Listing
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -583,7 +583,7 @@ function Set-Listing
             "Method" = 'Put'
             "Description" = "Updating $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-Listing"
             "TelemetryProperties" = $telemetryProperties
@@ -624,7 +624,7 @@ function Update-Listing
 
         [switch] $IsMinimalObject,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -652,7 +652,7 @@ function Update-Listing
         $commonParams = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -852,7 +852,7 @@ function Update-Listing
             [StoreBrokerTelemetryProperty]::UpdateListingText = $UpdateListingText
             [StoreBrokerTelemetryProperty]::UpdateImagesAndCaptions = $UpdateImagesAndCaptions
             [StoreBrokerTelemetryProperty]::UpdateVideos = $UpdateVideos
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-Listing -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionListingApi.ps1
+++ b/StoreBroker/StoreIngestionListingApi.ps1
@@ -42,8 +42,6 @@ function Get-Listing
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -62,7 +60,6 @@ function Get-Listing
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -78,7 +75,6 @@ function Get-Listing
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Listing"
@@ -176,8 +172,6 @@ function New-Listing
         [Parameter(ParameterSetName="Individual")]
         [string] $ShortDescription,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -195,7 +189,6 @@ function New-Listing
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -304,7 +297,6 @@ function New-Listing
             "Method" = 'Post'
             "Description" = "Creating new $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Listing"
@@ -339,8 +331,6 @@ function Remove-Listing
 
         [string] $FeatureGroupId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -357,7 +347,6 @@ function Remove-Listing
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -376,7 +365,6 @@ function Remove-Listing
             "UriFragment" = "products/$ProductId/listings/$LanguageCode" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting the $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Listing"
@@ -466,8 +454,6 @@ function Set-Listing
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -491,7 +477,6 @@ function Set-Listing
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -598,7 +583,6 @@ function Set-Listing
             "Method" = 'Put'
             "Description" = "Updating $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-Listing"
@@ -640,8 +624,6 @@ function Update-Listing
 
         [switch] $IsMinimalObject,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -670,7 +652,6 @@ function Update-Listing
         $commonParams = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -871,7 +852,6 @@ function Update-Listing
             [StoreBrokerTelemetryProperty]::UpdateListingText = $UpdateListingText
             [StoreBrokerTelemetryProperty]::UpdateImagesAndCaptions = $UpdateImagesAndCaptions
             [StoreBrokerTelemetryProperty]::UpdateVideos = $UpdateVideos
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionListingImageApi.ps1
+++ b/StoreBroker/StoreIngestionListingImageApi.ps1
@@ -37,8 +37,6 @@ function Get-ListingImage
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -58,7 +56,6 @@ function Get-ListingImage
             [StoreBrokerTelemetryProperty]::ImageId = $ImageId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
             [StoreBrokerTelemetryProperty]::WithSasUri = $WithSasUri.ToBool()
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -74,7 +71,6 @@ function Get-ListingImage
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ListingImage"
@@ -148,8 +144,6 @@ function New-ListingImage
         [Parameter(ParameterSetName="Individual")]
         [int] $Orientation = 0,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -167,7 +161,6 @@ function New-ListingImage
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::Type = $Type
             [StoreBrokerTelemetryProperty]::Orientation = $Orientation
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -207,7 +200,6 @@ function New-ListingImage
             "Method" = 'Post'
             "Description" = $description
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ListingImage"
@@ -226,7 +218,6 @@ function New-ListingImage
                 $params = @{
                     "UriFragment" = $result.nextLink
                     "Description" = "Getting remaining results"
-                    "ClientRequestId" = $ClientRequestId
                     "CorrelationId" = $CorrelationId
                     "AccessToken" = $AccessToken
                     "TelemetryEventName" = "New-ListingImage"
@@ -270,8 +261,6 @@ function Remove-ListingImage
         [Parameter(Mandatory)]
         [string] $ImageId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -288,7 +277,6 @@ function Remove-ListingImage
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::ImageId = $ImageId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -302,7 +290,6 @@ function Remove-ListingImage
             "UriFragment" = "products/$ProductId/listings/$LanguageCode/images/$ImageId`?" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting image $ImageId from the $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-ListingImage"
@@ -362,8 +349,6 @@ function Set-ListingImage
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -388,7 +373,6 @@ function Set-ListingImage
             [StoreBrokerTelemetryProperty]::State = $State
             [StoreBrokerTelemetryProperty]::Orientation = $Orientation
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -419,7 +403,6 @@ function Set-ListingImage
             "Method" = 'Put'
             "Description" = "Updating listing image $ImageId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ListingImage"
@@ -466,8 +449,6 @@ function Update-ListingImage
         [Parameter(ParameterSetName="RemoveOnly")]
         [switch] $RemoveOnly,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -487,7 +468,6 @@ function Update-ListingImage
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
             'LanguageCode' = $LanguageCode
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -529,7 +509,6 @@ function Update-ListingImage
             [StoreBrokerTelemetryProperty]::MediaRootPath = (Get-PiiSafeString -PlainText $MediaRootPath)
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::RemoveOnly = $RemoveOnly
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionListingImageApi.ps1
+++ b/StoreBroker/StoreIngestionListingImageApi.ps1
@@ -37,7 +37,7 @@ function Get-ListingImage
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -56,7 +56,7 @@ function Get-ListingImage
             [StoreBrokerTelemetryProperty]::ImageId = $ImageId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
             [StoreBrokerTelemetryProperty]::WithSasUri = $WithSasUri.ToBool()
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -71,7 +71,7 @@ function Get-ListingImage
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ListingImage"
             "TelemetryProperties" = $telemetryProperties
@@ -144,7 +144,7 @@ function New-ListingImage
         [Parameter(ParameterSetName="Individual")]
         [int] $Orientation = 0,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -161,7 +161,7 @@ function New-ListingImage
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::Type = $Type
             [StoreBrokerTelemetryProperty]::Orientation = $Orientation
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -200,7 +200,7 @@ function New-ListingImage
             "Method" = 'Post'
             "Description" = $description
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ListingImage"
             "TelemetryProperties" = $telemetryProperties
@@ -218,7 +218,7 @@ function New-ListingImage
                 $params = @{
                     "UriFragment" = $result.nextLink
                     "Description" = "Getting remaining results"
-                    "CorrelationId" = $CorrelationId
+                    "ClientRequestId" = $ClientRequestId
                     "AccessToken" = $AccessToken
                     "TelemetryEventName" = "New-ListingImage"
                     "TelemetryProperties" = $telemetryProperties
@@ -261,7 +261,7 @@ function Remove-ListingImage
         [Parameter(Mandatory)]
         [string] $ImageId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -277,7 +277,7 @@ function Remove-ListingImage
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::ImageId = $ImageId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -290,7 +290,7 @@ function Remove-ListingImage
             "UriFragment" = "products/$ProductId/listings/$LanguageCode/images/$ImageId`?" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting image $ImageId from the $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-ListingImage"
             "TelemetryProperties" = $telemetryProperties
@@ -349,7 +349,7 @@ function Set-ListingImage
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -373,7 +373,7 @@ function Set-ListingImage
             [StoreBrokerTelemetryProperty]::State = $State
             [StoreBrokerTelemetryProperty]::Orientation = $Orientation
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -403,7 +403,7 @@ function Set-ListingImage
             "Method" = 'Put'
             "Description" = "Updating listing image $ImageId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ListingImage"
             "TelemetryProperties" = $telemetryProperties
@@ -449,7 +449,7 @@ function Update-ListingImage
         [Parameter(ParameterSetName="RemoveOnly")]
         [switch] $RemoveOnly,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -468,7 +468,7 @@ function Update-ListingImage
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
             'LanguageCode' = $LanguageCode
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -509,7 +509,7 @@ function Update-ListingImage
             [StoreBrokerTelemetryProperty]::MediaRootPath = (Get-PiiSafeString -PlainText $MediaRootPath)
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::RemoveOnly = $RemoveOnly
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-ListingImage -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionListingVideoApi.ps1
+++ b/StoreBroker/StoreIngestionListingVideoApi.ps1
@@ -43,8 +43,6 @@ function Get-ListingVideo
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -63,7 +61,6 @@ function Get-ListingVideo
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::VideoId = $VideoId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -74,7 +71,6 @@ function Get-ListingVideo
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ListingVideo"
@@ -149,8 +145,6 @@ function New-ListingVideo
         [Parameter(ParameterSetName="Individual")]
         [int] $ThumbnailOrientation = 0,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -167,7 +161,6 @@ function New-ListingVideo
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::Orientation = $ThumbnailOrientation
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -211,7 +204,6 @@ function New-ListingVideo
             "Method" = 'Post'
             "Description" = $description
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ListingVideo"
@@ -230,7 +222,6 @@ function New-ListingVideo
                 $params = @{
                     "UriFragment" = $result.nextLink
                     "Description" = "Getting remaining results"
-                    "ClientRequestId" = $ClientRequestId
                     "CorrelationId" = $CorrelationId
                     "AccessToken" = $AccessToken
                     "TelemetryEventName" = "New-ListingVideo"
@@ -274,8 +265,6 @@ function Remove-ListingVideo
         [Parameter(Mandatory)]
         [string] $VideoId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -292,7 +281,6 @@ function Remove-ListingVideo
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::VideoId = $VideoId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -306,7 +294,6 @@ function Remove-ListingVideo
             "UriFragment" = "products/$ProductId/listings/$LanguageCode/videos/$VideoId`?" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting video $VideoId from the $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-ListingVideo"
@@ -378,8 +365,6 @@ function Set-ListingVideo
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -405,7 +390,6 @@ function Set-ListingVideo
             [StoreBrokerTelemetryProperty]::State = $State
             [StoreBrokerTelemetryProperty]::Orientation = $ThumbnailOrientation
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -440,7 +424,6 @@ function Set-ListingVideo
             "Method" = 'Put'
             "Description" = "Updating listing video $VideoId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ListingVideo"
@@ -486,8 +469,6 @@ function Update-ListingVideo
         [Parameter(ParameterSetName="RemoveOnly")]
         [switch] $RemoveOnly,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -507,7 +488,6 @@ function Update-ListingVideo
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
             'LanguageCode' = $LanguageCode
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -564,7 +544,6 @@ function Update-ListingVideo
             [StoreBrokerTelemetryProperty]::MediaRootPath = (Get-PiiSafeString -PlainText $MediaRootPath)
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::RemoveOnly = $RemoveOnly
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionListingVideoApi.ps1
+++ b/StoreBroker/StoreIngestionListingVideoApi.ps1
@@ -43,7 +43,7 @@ function Get-ListingVideo
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -61,7 +61,7 @@ function Get-ListingVideo
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::VideoId = $VideoId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -71,7 +71,7 @@ function Get-ListingVideo
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ListingVideo"
             "TelemetryProperties" = $telemetryProperties
@@ -145,7 +145,7 @@ function New-ListingVideo
         [Parameter(ParameterSetName="Individual")]
         [int] $ThumbnailOrientation = 0,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -161,7 +161,7 @@ function New-ListingVideo
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::Orientation = $ThumbnailOrientation
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -204,7 +204,7 @@ function New-ListingVideo
             "Method" = 'Post'
             "Description" = $description
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ListingVideo"
             "TelemetryProperties" = $telemetryProperties
@@ -222,7 +222,7 @@ function New-ListingVideo
                 $params = @{
                     "UriFragment" = $result.nextLink
                     "Description" = "Getting remaining results"
-                    "CorrelationId" = $CorrelationId
+                    "ClientRequestId" = $ClientRequestId
                     "AccessToken" = $AccessToken
                     "TelemetryEventName" = "New-ListingVideo"
                     "TelemetryProperties" = $telemetryProperties
@@ -265,7 +265,7 @@ function Remove-ListingVideo
         [Parameter(Mandatory)]
         [string] $VideoId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -281,7 +281,7 @@ function Remove-ListingVideo
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::VideoId = $VideoId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -294,7 +294,7 @@ function Remove-ListingVideo
             "UriFragment" = "products/$ProductId/listings/$LanguageCode/videos/$VideoId`?" + ($getParams -join '&')
             "Method" = "Delete"
             "Description" = "Deleting video $VideoId from the $LanguageCode listing for $ProductId (SubmissionId: $SubmissionId)"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-ListingVideo"
             "TelemetryProperties" = $telemetryProperties
@@ -365,7 +365,7 @@ function Set-ListingVideo
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -390,7 +390,7 @@ function Set-ListingVideo
             [StoreBrokerTelemetryProperty]::State = $State
             [StoreBrokerTelemetryProperty]::Orientation = $ThumbnailOrientation
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -424,7 +424,7 @@ function Set-ListingVideo
             "Method" = 'Put'
             "Description" = "Updating listing video $VideoId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ListingVideo"
             "TelemetryProperties" = $telemetryProperties
@@ -469,7 +469,7 @@ function Update-ListingVideo
         [Parameter(ParameterSetName="RemoveOnly")]
         [switch] $RemoveOnly,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -488,7 +488,7 @@ function Update-ListingVideo
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
             'LanguageCode' = $LanguageCode
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -544,7 +544,7 @@ function Update-ListingVideo
             [StoreBrokerTelemetryProperty]::MediaRootPath = (Get-PiiSafeString -PlainText $MediaRootPath)
             [StoreBrokerTelemetryProperty]::LanguageCode = $LanguageCode
             [StoreBrokerTelemetryProperty]::RemoveOnly = $RemoveOnly
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-ListingVideo -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionPackageApi.ps1
+++ b/StoreBroker/StoreIngestionPackageApi.ps1
@@ -38,8 +38,6 @@ function Get-ProductPackage
         [Parameter(ParameterSetName="Known")]
         [switch] $WithSasUri,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -56,7 +54,6 @@ function Get-ProductPackage
         [StoreBrokerTelemetryProperty]::PackageId = $PackageId
         [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
         [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-        [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
         [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
     }
 
@@ -77,7 +74,6 @@ function Get-ProductPackage
     }
 
     $params = @{
-        "ClientRequestId" = $ClientRequestId
         "CorrelationId" = $CorrelationId
         "AccessToken" = $AccessToken
         "TelemetryEventName" = "Get-ProductPackage"
@@ -144,10 +140,6 @@ function Wait-ProductPackageProcessed
         as it has been detected that a package has entered the "ProcessFailed" state, the
         function will immediately fail.
 
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
-
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
@@ -202,8 +194,6 @@ function Wait-ProductPackageProcessed
 
         [switch] $FailOnFirstError,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -219,7 +209,6 @@ function Wait-ProductPackageProcessed
         [StoreBrokerTelemetryProperty]::ProductId = $ProductId
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
         [StoreBrokerTelemetryProperty]::PackageId = $PackageId -join ', '
-        [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
         [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
     }
 
@@ -229,7 +218,6 @@ function Wait-ProductPackageProcessed
         'ProductId' = $ProductId
         'SubmissionId' = $SubmissionId
         'FeatureGroupId' = $FeatureGroupId
-        'ClientRequestId' = $ClientRequestId
         'CorrelationId' = $CorrelationId
         'AccessToken' = $AccessToken
         'NoStatus' = $NoStatus
@@ -312,8 +300,6 @@ function New-ProductPackage
             ParameterSetName="Individual")]
         [string] $FileName,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -328,7 +314,6 @@ function New-ProductPackage
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
         [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
         [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-        [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
         [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
     }
 
@@ -362,7 +347,6 @@ function New-ProductPackage
         "Method" = 'Post'
         "Description" = "Creating new package for $ProductId (SubmissionId: $SubmissionId)"
         "Body" = $body
-        "ClientRequestId" = $ClientRequestId
         "CorrelationId" = $CorrelationId
         "AccessToken" = $AccessToken
         "TelemetryEventName" = "New-ProductPackage"
@@ -410,8 +394,6 @@ function Set-ProductPackage
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -436,7 +418,6 @@ function Set-ProductPackage
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::State = $State
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -471,7 +452,6 @@ function Set-ProductPackage
             "Method" = 'Put'
             "Description" = "Updating package $PackageId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductPackage"
@@ -505,8 +485,6 @@ function Remove-ProductPackage
 
         [string] $FeatureGroupId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -523,7 +501,6 @@ function Remove-ProductPackage
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::PackageId = $PackageId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -542,7 +519,6 @@ function Remove-ProductPackage
             "UriFragment" = "products/$ProductId/packages/$PackageId`?" + ($getParams -join '&')
             "Method" = 'Delete'
             "Description" = "Removing package $PackageId for $ProductId (SubmissionId: $SubmissionId)"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-ProductPackage"
@@ -725,8 +701,6 @@ function Update-ProductPackage
         [Parameter(ParameterSetName="UpdatePackages")]
         [int] $RedundantPackagesToKeep = 1,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -761,7 +735,6 @@ function Update-ProductPackage
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -822,7 +795,6 @@ function Update-ProductPackage
             [StoreBrokerTelemetryProperty]::ReplacePackages = ($ReplacePackages -eq $true)
             [StoreBrokerTelemetryProperty]::UpdatePackages = ($UpdatePackages -eq $true)
             [StoreBrokerTelemetryProperty]::RedundantPackagesToKeep = $RedundantPackagesToKeep
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionPackageApi.ps1
+++ b/StoreBroker/StoreIngestionPackageApi.ps1
@@ -38,7 +38,7 @@ function Get-ProductPackage
         [Parameter(ParameterSetName="Known")]
         [switch] $WithSasUri,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -54,7 +54,7 @@ function Get-ProductPackage
         [StoreBrokerTelemetryProperty]::PackageId = $PackageId
         [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
         [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-        [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+        [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
     }
 
     $getParams = @()
@@ -74,7 +74,7 @@ function Get-ProductPackage
     }
 
     $params = @{
-        "CorrelationId" = $CorrelationId
+        "ClientRequestId" = $ClientRequestId
         "AccessToken" = $AccessToken
         "TelemetryEventName" = "Get-ProductPackage"
         "TelemetryProperties" = $telemetryProperties
@@ -140,7 +140,7 @@ function Wait-ProductPackageProcessed
         as it has been detected that a package has entered the "ProcessFailed" state, the
         function will immediately fail.
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -194,7 +194,7 @@ function Wait-ProductPackageProcessed
 
         [switch] $FailOnFirstError,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -203,13 +203,13 @@ function Wait-ProductPackageProcessed
 
     Write-InvocationLog
 
-    $CorrelationId = Get-CorrelationId -CorrelationId $CorrelationId -Identifier 'Wait-ProductPackageProcessed'
+    $ClientRequestId = Get-ClientRequestId -ClientRequestId $ClientRequestId -Identifier 'Wait-ProductPackageProcessed'
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::ProductId = $ProductId
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
         [StoreBrokerTelemetryProperty]::PackageId = $PackageId -join ', '
-        [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+        [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
     }
 
     Set-TelemetryEvent -EventName Wait-ProductPackageProcessed -Properties $telemetryProperties
@@ -218,7 +218,7 @@ function Wait-ProductPackageProcessed
         'ProductId' = $ProductId
         'SubmissionId' = $SubmissionId
         'FeatureGroupId' = $FeatureGroupId
-        'CorrelationId' = $CorrelationId
+        'ClientRequestId' = $ClientRequestId
         'AccessToken' = $AccessToken
         'NoStatus' = $NoStatus
     }
@@ -300,7 +300,7 @@ function New-ProductPackage
             ParameterSetName="Individual")]
         [string] $FileName,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -314,7 +314,7 @@ function New-ProductPackage
         [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
         [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
         [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-        [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+        [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
     }
 
     $getParams = @()
@@ -347,7 +347,7 @@ function New-ProductPackage
         "Method" = 'Post'
         "Description" = "Creating new package for $ProductId (SubmissionId: $SubmissionId)"
         "Body" = $body
-        "CorrelationId" = $CorrelationId
+        "ClientRequestId" = $ClientRequestId
         "AccessToken" = $AccessToken
         "TelemetryEventName" = "New-ProductPackage"
         "TelemetryProperties" = $telemetryProperties
@@ -394,7 +394,7 @@ function Set-ProductPackage
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -418,7 +418,7 @@ function Set-ProductPackage
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::State = $State
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -452,7 +452,7 @@ function Set-ProductPackage
             "Method" = 'Put'
             "Description" = "Updating package $PackageId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductPackage"
             "TelemetryProperties" = $telemetryProperties
@@ -485,7 +485,7 @@ function Remove-ProductPackage
 
         [string] $FeatureGroupId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -501,7 +501,7 @@ function Remove-ProductPackage
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::PackageId = $PackageId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -519,7 +519,7 @@ function Remove-ProductPackage
             "UriFragment" = "products/$ProductId/packages/$PackageId`?" + ($getParams -join '&')
             "Method" = 'Delete'
             "Description" = "Removing package $PackageId for $ProductId (SubmissionId: $SubmissionId)"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-ProductPackage"
             "TelemetryProperties" = $telemetryProperties
@@ -701,7 +701,7 @@ function Update-ProductPackage
         [Parameter(ParameterSetName="UpdatePackages")]
         [int] $RedundantPackagesToKeep = 1,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -735,7 +735,7 @@ function Update-ProductPackage
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -795,7 +795,7 @@ function Update-ProductPackage
             [StoreBrokerTelemetryProperty]::ReplacePackages = ($ReplacePackages -eq $true)
             [StoreBrokerTelemetryProperty]::UpdatePackages = ($UpdatePackages -eq $true)
             [StoreBrokerTelemetryProperty]::RedundantPackagesToKeep = $RedundantPackagesToKeep
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-ProductPackage -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionPackageConfigurationApi.ps1
+++ b/StoreBroker/StoreIngestionPackageConfigurationApi.ps1
@@ -36,7 +36,7 @@ function Get-ProductPackageConfiguration
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -54,7 +54,7 @@ function Get-ProductPackageConfiguration
             [StoreBrokerTelemetryProperty]::PackageConfigurationId = $PackageConfigurationId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -69,7 +69,7 @@ function Get-ProductPackageConfiguration
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductPackageConfiguration"
             "TelemetryProperties" = $telemetryProperties
@@ -126,7 +126,7 @@ function New-ProductPackageConfiguration
         [Parameter(ParameterSetName="Individual")]
         [DateTime] $MandatoryUpdateEffectiveDate,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -142,7 +142,7 @@ function New-ProductPackageConfiguration
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -201,7 +201,7 @@ function New-ProductPackageConfiguration
             "Method" = 'Post'
             "Description" = "Creating new package configuration for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ProductPackageConfiguration"
             "TelemetryProperties" = $telemetryProperties
@@ -253,7 +253,7 @@ function Set-ProductPackageConfiguration
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -276,7 +276,7 @@ function Set-ProductPackageConfiguration
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -334,7 +334,7 @@ function Set-ProductPackageConfiguration
             "Method" = 'Put'
             "Description" = "Updating package configuration $PackageConfigurationId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductPackageConfiguration"
             "TelemetryProperties" = $telemetryProperties
@@ -364,7 +364,7 @@ function Update-ProductPackageConfiguration
 
         [DateTime] $MandatoryUpdateEffectiveDate,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -380,7 +380,7 @@ function Update-ProductPackageConfiguration
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -408,7 +408,7 @@ function Update-ProductPackageConfiguration
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-ProductPackageConfiguration -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionPackageConfigurationApi.ps1
+++ b/StoreBroker/StoreIngestionPackageConfigurationApi.ps1
@@ -36,8 +36,6 @@ function Get-ProductPackageConfiguration
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -56,7 +54,6 @@ function Get-ProductPackageConfiguration
             [StoreBrokerTelemetryProperty]::PackageConfigurationId = $PackageConfigurationId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -72,7 +69,6 @@ function Get-ProductPackageConfiguration
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductPackageConfiguration"
@@ -130,8 +126,6 @@ function New-ProductPackageConfiguration
         [Parameter(ParameterSetName="Individual")]
         [DateTime] $MandatoryUpdateEffectiveDate,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -148,7 +142,6 @@ function New-ProductPackageConfiguration
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -208,7 +201,6 @@ function New-ProductPackageConfiguration
             "Method" = 'Post'
             "Description" = "Creating new package configuration for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ProductPackageConfiguration"
@@ -261,8 +253,6 @@ function Set-ProductPackageConfiguration
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -286,7 +276,6 @@ function Set-ProductPackageConfiguration
             [StoreBrokerTelemetryProperty]::FeatureGroupId = $FeatureGroupId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -345,7 +334,6 @@ function Set-ProductPackageConfiguration
             "Method" = 'Put'
             "Description" = "Updating package configuration $PackageConfigurationId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductPackageConfiguration"
@@ -376,8 +364,6 @@ function Update-ProductPackageConfiguration
 
         [DateTime] $MandatoryUpdateEffectiveDate,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -394,7 +380,6 @@ function Update-ProductPackageConfiguration
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -423,7 +408,6 @@ function Update-ProductPackageConfiguration
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionProductApi.ps1
+++ b/StoreBroker/StoreIngestionProductApi.ps1
@@ -35,7 +35,7 @@ function Get-Product
         [Parameter(ParameterSetName="Search")]
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -53,7 +53,7 @@ function Get-Product
             [StoreBrokerTelemetryProperty]::AppId = $AppId
             [StoreBrokerTelemetryProperty]::SpecifiedType = ($Type.Count -gt 0)
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $searchDescription = "Getting information for all products"
@@ -71,7 +71,7 @@ function Get-Product
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Product"
             "TelemetryProperties" = $telemetryProperties
@@ -130,7 +130,7 @@ function New-Product
         [ValidateSet('AvatarItem', 'Bundle', 'Consumable', 'ManagedConsumable', 'Durable', 'DurableWithBits', 'Subscription', 'SeasonPass', 'InternetOfThings')]
         [string] $Type,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -146,7 +146,7 @@ function New-Product
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::Name = $Name
             [StoreBrokerTelemetryProperty]::ResourceType = $Type
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $hashBody = $Object
@@ -165,7 +165,7 @@ function New-Product
             "Method" = "Post"
             "Description" = "Creating a new product called: $Name"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Product"
             "TelemetryProperties" = $telemetryProperties
@@ -190,7 +190,7 @@ function Remove-Product
         [ValidateScript({if ($_.Length -le 12) { throw "It looks like you supplied an AppId instead of a ProductId.  Use Get-Product with -AppId to find the ProductId for this AppId." } else { $true }})]
         [string] $ProductId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -203,14 +203,14 @@ function Remove-Product
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId"
             "Method" = "Delete"
             "Description" = "Deleting product: $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Product"
             "TelemetryProperties" = $telemetryProperties
@@ -234,7 +234,7 @@ function Get-ProductPackageIdentity
         [ValidateScript({if ($_.Length -le 12) { throw "It looks like you supplied an AppId instead of a ProductId.  Use Get-Product with -AppId to find the ProductId for this AppId." } else { $true }})]
         [string] $ProductId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -247,14 +247,14 @@ function Get-ProductPackageIdentity
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::AppId = $AppId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/packageIdentity"
             "Method" = "Get"
             "Description" = "Getting package identity for product: $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductPackageIdentity"
             "TelemetryProperties" = $telemetryProperties
@@ -278,7 +278,7 @@ function Get-ProductStoreLink
         [ValidateScript({if ($_.Length -le 12) { throw "It looks like you supplied an AppId instead of a ProductId.  Use Get-Product with -AppId to find the ProductId for this AppId." } else { $true }})]
         [string] $ProductId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -291,14 +291,14 @@ function Get-ProductStoreLink
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::AppId = $AppId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/storelink"
             "Method" = "Get"
             "Description" = "Getting store link for product: $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductStoreLink"
             "TelemetryProperties" = $telemetryProperties
@@ -328,7 +328,7 @@ function Get-ProductRelated
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -341,7 +341,7 @@ function Get-ProductRelated
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::AppId = $AppId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -350,7 +350,7 @@ function Get-ProductRelated
         $params = @{
             "UriFragment" = "products/$ProductId/related`?" + ($getParams -join '&')
             "Description" = "Getting related products for product: $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductRelated"
             "TelemetryProperties" = $telemetryProperties

--- a/StoreBroker/StoreIngestionProductApi.ps1
+++ b/StoreBroker/StoreIngestionProductApi.ps1
@@ -35,8 +35,6 @@ function Get-Product
         [Parameter(ParameterSetName="Search")]
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -55,7 +53,6 @@ function Get-Product
             [StoreBrokerTelemetryProperty]::AppId = $AppId
             [StoreBrokerTelemetryProperty]::SpecifiedType = ($Type.Count -gt 0)
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -74,7 +71,6 @@ function Get-Product
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-Product"
@@ -134,8 +130,6 @@ function New-Product
         [ValidateSet('AvatarItem', 'Bundle', 'Consumable', 'ManagedConsumable', 'Durable', 'DurableWithBits', 'Subscription', 'SeasonPass', 'InternetOfThings')]
         [string] $Type,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -152,7 +146,6 @@ function New-Product
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::Name = $Name
             [StoreBrokerTelemetryProperty]::ResourceType = $Type
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -172,7 +165,6 @@ function New-Product
             "Method" = "Post"
             "Description" = "Creating a new product called: $Name"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Product"
@@ -198,8 +190,6 @@ function Remove-Product
         [ValidateScript({if ($_.Length -le 12) { throw "It looks like you supplied an AppId instead of a ProductId.  Use Get-Product with -AppId to find the ProductId for this AppId." } else { $true }})]
         [string] $ProductId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -213,7 +203,6 @@ function Remove-Product
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -221,7 +210,6 @@ function Remove-Product
             "UriFragment" = "products/$ProductId"
             "Method" = "Delete"
             "Description" = "Deleting product: $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Product"
@@ -246,8 +234,6 @@ function Get-ProductPackageIdentity
         [ValidateScript({if ($_.Length -le 12) { throw "It looks like you supplied an AppId instead of a ProductId.  Use Get-Product with -AppId to find the ProductId for this AppId." } else { $true }})]
         [string] $ProductId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -261,7 +247,6 @@ function Get-ProductPackageIdentity
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::AppId = $AppId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -269,7 +254,6 @@ function Get-ProductPackageIdentity
             "UriFragment" = "products/$ProductId/packageIdentity"
             "Method" = "Get"
             "Description" = "Getting package identity for product: $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductPackageIdentity"
@@ -294,8 +278,6 @@ function Get-ProductStoreLink
         [ValidateScript({if ($_.Length -le 12) { throw "It looks like you supplied an AppId instead of a ProductId.  Use Get-Product with -AppId to find the ProductId for this AppId." } else { $true }})]
         [string] $ProductId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -309,7 +291,6 @@ function Get-ProductStoreLink
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::AppId = $AppId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -317,7 +298,6 @@ function Get-ProductStoreLink
             "UriFragment" = "products/$ProductId/storelink"
             "Method" = "Get"
             "Description" = "Getting store link for product: $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductStoreLink"
@@ -348,8 +328,6 @@ function Get-ProductRelated
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -363,7 +341,6 @@ function Get-ProductRelated
     {
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::AppId = $AppId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -373,7 +350,6 @@ function Get-ProductRelated
         $params = @{
             "UriFragment" = "products/$ProductId/related`?" + ($getParams -join '&')
             "Description" = "Getting related products for product: $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductRelated"

--- a/StoreBroker/StoreIngestionProductAvailabilityApi.ps1
+++ b/StoreBroker/StoreIngestionProductAvailabilityApi.ps1
@@ -27,7 +27,7 @@ function Get-ProductAvailability
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -44,7 +44,7 @@ function Get-ProductAvailability
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::ProductAvailabilityId = $ProductAvailabilityId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -54,7 +54,7 @@ function Get-ProductAvailability
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductAvailability"
             "TelemetryProperties" = $telemetryProperties
@@ -114,7 +114,7 @@ function New-ProductAvailability
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -131,7 +131,7 @@ function New-ProductAvailability
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::HasAudience = ($null -ne $Audience)
             [StoreBrokerTelemetryProperty]::Visibility = $Visibility
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -165,7 +165,7 @@ function New-ProductAvailability
             "Method" = 'Post'
             "Description" = "Creating new product availability for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ProductAvailability"
             "TelemetryProperties" = $telemetryProperties
@@ -218,7 +218,7 @@ function Set-ProductAvailability
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -242,7 +242,7 @@ function Set-ProductAvailability
             [StoreBrokerTelemetryProperty]::HasAudience = ($null -ne $Audience)
             [StoreBrokerTelemetryProperty]::Visibility = $Visibility
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -277,7 +277,7 @@ function Set-ProductAvailability
             "Method" = 'Put'
             "Description" = "Updating product availability $ProductAvailabilityId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductAvailability"
             "TelemetryProperties" = $telemetryProperties
@@ -312,7 +312,7 @@ function Update-ProductAvailability
 
         [switch] $IsMinimalObject,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -343,7 +343,7 @@ function Update-ProductAvailability
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -378,7 +378,7 @@ function Update-ProductAvailability
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::ProvidedSubmissionData = ($null -ne $SubmissionData)
             [StoreBrokerTelemetryProperty]::Visibility = $Visibility
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Patch-ProductAvailability -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionProductAvailabilityApi.ps1
+++ b/StoreBroker/StoreIngestionProductAvailabilityApi.ps1
@@ -27,8 +27,6 @@ function Get-ProductAvailability
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -46,7 +44,6 @@ function Get-ProductAvailability
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::ProductAvailabilityId = $ProductAvailabilityId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -57,7 +54,6 @@ function Get-ProductAvailability
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductAvailability"
@@ -118,8 +114,6 @@ function New-ProductAvailability
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -137,7 +131,6 @@ function New-ProductAvailability
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::HasAudience = ($null -ne $Audience)
             [StoreBrokerTelemetryProperty]::Visibility = $Visibility
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -172,7 +165,6 @@ function New-ProductAvailability
             "Method" = 'Post'
             "Description" = "Creating new product availability for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ProductAvailability"
@@ -226,8 +218,6 @@ function Set-ProductAvailability
             ParameterSetName="Individual")]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -252,7 +242,6 @@ function Set-ProductAvailability
             [StoreBrokerTelemetryProperty]::HasAudience = ($null -ne $Audience)
             [StoreBrokerTelemetryProperty]::Visibility = $Visibility
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -288,7 +277,6 @@ function Set-ProductAvailability
             "Method" = 'Put'
             "Description" = "Updating product availability $ProductAvailabilityId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductAvailability"
@@ -324,8 +312,6 @@ function Update-ProductAvailability
 
         [switch] $IsMinimalObject,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -357,7 +343,6 @@ function Update-ProductAvailability
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -393,7 +378,6 @@ function Update-ProductAvailability
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::ProvidedSubmissionData = ($null -ne $SubmissionData)
             [StoreBrokerTelemetryProperty]::Visibility = $Visibility
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionPropertyApi.ps1
+++ b/StoreBroker/StoreIngestionPropertyApi.ps1
@@ -45,7 +45,7 @@ function Get-ProductProperty
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -62,7 +62,7 @@ function Get-ProductProperty
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::PropertyId = $PropertyId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -72,7 +72,7 @@ function Get-ProductProperty
         }
 
         $params = @{
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductProperty"
             "TelemetryProperties" = $telemetryProperties
@@ -124,7 +124,7 @@ function New-ProductProperty
         [ValidateSet('ApplicationProperty', 'AddonProperty', 'BundleProperty', 'AvatarProperty', 'IoTProperty', 'AzureProperty')]
         [string] $Type,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -140,7 +140,7 @@ function New-ProductProperty
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::ResourceType = $Type
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -170,7 +170,7 @@ function New-ProductProperty
             "Method" = 'Post'
             "Description" = "Creating new property for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ProductProperty"
             "TelemetryProperties" = $telemetryProperties
@@ -216,7 +216,7 @@ function Set-ProductProperty
         [Parameter(Mandatory)]
         [string] $RevisionToken,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -239,7 +239,7 @@ function Set-ProductProperty
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::ResourceType = $Type
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -270,7 +270,7 @@ function Set-ProductProperty
             "Method" = 'Put'
             "Description" = "Updating property $PropertyId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductProperty"
             "TelemetryProperties" = $telemetryProperties
@@ -309,7 +309,7 @@ function Update-ProductProperty
 
         [switch] $IsMinimalObject,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -339,7 +339,7 @@ function Update-ProductProperty
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -499,7 +499,7 @@ function Update-ProductProperty
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::ProvidedSubmissionData = ($null -ne $SubmissionData)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-ProductProperty -Properties $telemetryProperties -Metrics $telemetryMetrics

--- a/StoreBroker/StoreIngestionPropertyApi.ps1
+++ b/StoreBroker/StoreIngestionPropertyApi.ps1
@@ -45,8 +45,6 @@ function Get-ProductProperty
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -64,7 +62,6 @@ function Get-ProductProperty
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::PropertyId = $PropertyId
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -75,7 +72,6 @@ function Get-ProductProperty
         }
 
         $params = @{
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-ProductProperty"
@@ -128,8 +124,6 @@ function New-ProductProperty
         [ValidateSet('ApplicationProperty', 'AddonProperty', 'BundleProperty', 'AvatarProperty', 'IoTProperty', 'AzureProperty')]
         [string] $Type,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -146,7 +140,6 @@ function New-ProductProperty
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::ResourceType = $Type
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -177,7 +170,6 @@ function New-ProductProperty
             "Method" = 'Post'
             "Description" = "Creating new property for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-ProductProperty"
@@ -224,8 +216,6 @@ function Set-ProductProperty
         [Parameter(Mandatory)]
         [string] $RevisionToken,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -249,7 +239,6 @@ function Set-ProductProperty
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::ResourceType = $Type
             [StoreBrokerTelemetryProperty]::RevisionToken = $RevisionToken
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -281,7 +270,6 @@ function Set-ProductProperty
             "Method" = 'Put'
             "Description" = "Updating property $PropertyId for $ProductId (SubmissionId: $SubmissionId)"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-ProductProperty"
@@ -321,8 +309,6 @@ function Update-ProductProperty
 
         [switch] $IsMinimalObject,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -353,7 +339,6 @@ function Update-ProductProperty
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -514,7 +499,6 @@ function Update-ProductProperty
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::ProvidedSubmissionData = ($null -ne $SubmissionData)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionRolloutApi.ps1
+++ b/StoreBroker/StoreIngestionRolloutApi.ps1
@@ -34,8 +34,6 @@ function Get-SubmissionRollout
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -50,7 +48,6 @@ function Get-SubmissionRollout
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -58,7 +55,6 @@ function Get-SubmissionRollout
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/rollout"
             "Method" = 'Get'
             "Description" = "Getting rollout info for product: $ProductId submissionId: $SubmissionId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionRollout"
@@ -107,8 +103,6 @@ function Set-SubmissionRollout
         [Parameter(ParameterSetName="Individual")]
         [switch] $SeekEnabled,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -125,7 +119,6 @@ function Set-SubmissionRollout
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::State = $State
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -174,7 +167,6 @@ function Set-SubmissionRollout
             "Method" = 'Post'
             "Description" = "Updating rollout details for submission: $SubmissionId"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-SubmissionRollout"
@@ -233,8 +225,6 @@ function Update-SubmissionRollout
 
         [switch] $SeekEnabled,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -251,7 +241,6 @@ function Update-SubmissionRollout
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -293,7 +282,6 @@ function Update-SubmissionRollout
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::Percentage = $Percentage
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 

--- a/StoreBroker/StoreIngestionRolloutApi.ps1
+++ b/StoreBroker/StoreIngestionRolloutApi.ps1
@@ -34,7 +34,7 @@ function Get-SubmissionRollout
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -48,14 +48,14 @@ function Get-SubmissionRollout
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/rollout"
             "Method" = 'Get'
             "Description" = "Getting rollout info for product: $ProductId submissionId: $SubmissionId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionRollout"
             "TelemetryProperties" = $telemetryProperties
@@ -103,7 +103,7 @@ function Set-SubmissionRollout
         [Parameter(ParameterSetName="Individual")]
         [switch] $SeekEnabled,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -119,7 +119,7 @@ function Set-SubmissionRollout
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::State = $State
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::Rollout)
@@ -167,7 +167,7 @@ function Set-SubmissionRollout
             "Method" = 'Post'
             "Description" = "Updating rollout details for submission: $SubmissionId"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-SubmissionRollout"
             "TelemetryProperties" = $telemetryProperties
@@ -225,7 +225,7 @@ function Update-SubmissionRollout
 
         [switch] $SeekEnabled,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -241,7 +241,7 @@ function Update-SubmissionRollout
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -282,7 +282,7 @@ function Update-SubmissionRollout
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::Percentage = $Percentage
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         if (-not [String]::IsNullOrWhiteSpace($global:SBStoreBrokerClientName)) { $telemetryProperties[[StoreBrokerTelemetryProperty]::ClientName] = $global:SBStoreBrokerClientName }

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -109,7 +109,7 @@ function Get-Submission
         If not specified, then the API continuously be queried until all results have been
         retrieved, and then the final combined result set will be returned.
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -191,7 +191,7 @@ function Get-Submission
         [Parameter(ParameterSetName="Search")]
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -214,11 +214,11 @@ function Get-Submission
             [StoreBrokerTelemetryProperty]::GetValidation = $Validation
             [StoreBrokerTelemetryProperty]::WaitUntilReady = ($WaitUntilReady -eq $true)
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $commonParams = @{
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -332,7 +332,7 @@ function New-Submission
         objects asynchronously, and thus the information in the Submission cannot be "trusted"
         until all of its resources are "ready".
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -414,7 +414,7 @@ function New-Submission
 
         [switch] $WaitUntilReady,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -434,12 +434,12 @@ function New-Submission
             [StoreBrokerTelemetryProperty]::Scope = $Scope
             [StoreBrokerTelemetryProperty]::Force = ($Force -eq $true)
             [StoreBrokerTelemetryProperty]::WaitUntilReady = ($WaitUntilReady -eq $true)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $commonParams = @{
             'ProductId' = $ProductId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -530,7 +530,7 @@ function New-Submission
             "Method" = 'Post'
             "Description" = "Creating a new submission for product: $ProductId"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Submission"
             "TelemetryProperties" = $telemetryProperties
@@ -572,7 +572,7 @@ function Remove-Submission
     .PARAMETER SubmissionId
         The ID of the Submission for the Product that is to be deleted.
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -602,7 +602,7 @@ function Remove-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -616,14 +616,14 @@ function Remove-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId"
             "Method" = "Delete"
             "Description" = "Deleting submission $SubmissionId for product: $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Submission"
             "TelemetryProperties" = $telemetryProperties
@@ -658,7 +658,7 @@ function Stop-Submission
     .PARAMETER SubmissionId
         The ID of the Submission for the Product that is to be stopped/cancelled.
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -691,7 +691,7 @@ function Stop-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -705,14 +705,14 @@ function Stop-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/cancel"
             "Method" = 'Post'
             "Description" = "Cancelling submission $SubmissionId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Stop-Submission"
             "TelemetryProperties" = $telemetryProperties
@@ -744,7 +744,7 @@ function Get-SubmissionDetail
     .PARAMETER SubmissionId
         The ID of the Submission for the Product whose details are to be retrieved.
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -776,7 +776,7 @@ function Get-SubmissionDetail
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -790,14 +790,14 @@ function Get-SubmissionDetail
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/detail"
             "Method" = 'Get'
             "Description" = "Getting details of submission $SubmissionId for $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionDetail"
             "TelemetryProperties" = $telemetryProperties
@@ -857,7 +857,7 @@ function Set-SubmissionDetail
         To change the corresponding value, you must explicitly specify either $true or $false
         with this switch.
 
-    .PARAMETER CorrelationId
+    .PARAMETER ClientRequestId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
         associate a group of API requests with a single end-goal.
@@ -918,7 +918,7 @@ function Set-SubmissionDetail
         [Parameter(ParameterSetName="Individual")]
         [switch] $AutoPromote,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -934,7 +934,7 @@ function Set-SubmissionDetail
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::UpdateCertificationNotes = ($null -ne $CertificationNotes)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Test-ResourceType -Object $Object -ResourceType ([StoreBrokerResourceType]::SubmissionDetail)
@@ -985,7 +985,7 @@ function Set-SubmissionDetail
             "Method" = 'Post'
             "Description" = "Updating detail for submission: $SubmissionId"
             "Body" = $body
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-SubmissionDetail"
             "TelemetryProperties" = $telemetryProperties
@@ -1025,7 +1025,7 @@ function Update-SubmissionDetail
 
         [switch] $IsMinimalObject,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1064,7 +1064,7 @@ function Update-SubmissionDetail
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'CorrelationId' = $CorrelationId
+            'ClientRequestId' = $ClientRequestId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
         }
@@ -1151,7 +1151,7 @@ function Update-SubmissionDetail
             [StoreBrokerTelemetryProperty]::UpdateCertificationNotes = $UpdateCertificationNotes
             [StoreBrokerTelemetryProperty]::ProvidedCertificationNotes = $providedCertificationNotes
             [StoreBrokerTelemetryProperty]::ProvidedSubmissionData = $providedSubmissionData
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         Set-TelemetryEvent -EventName Update-SubmissionDetail -Properties $telemetryProperties -Metrics $telemetryMetrics
@@ -1177,7 +1177,7 @@ function Push-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1191,14 +1191,14 @@ function Push-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/promote"
             "Method" = 'Post'
             "Description" = "Promoting submission $SubmissionId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Push-Submission"
             "TelemetryProperties" = $telemetryProperties
@@ -1225,7 +1225,7 @@ function Publish-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1239,14 +1239,14 @@ function Publish-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/publish"
             "Method" = 'Post'
             "Description" = "Publishing submission $SubmissionId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Publish-Submission"
             "TelemetryProperties" = $telemetryProperties
@@ -1275,7 +1275,7 @@ function Get-SubmissionReport
 
         [switch] $SinglePage,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1289,13 +1289,13 @@ function Get-SubmissionReport
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/reports"
             "Description" = "Getting reports of submission $SubmissionId for $ProductId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionReport"
             "TelemetryProperties" = $telemetryProperties
@@ -1327,7 +1327,7 @@ function Submit-Submission
 
         [switch] $Auto,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1342,7 +1342,7 @@ function Submit-Submission
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::Auto = $Auto
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $getParams = @()
@@ -1355,7 +1355,7 @@ function Submit-Submission
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/submit`?" + ($getParams -join '&')
             "Method" = 'Post'
             "Description" = "Submitting submission $SubmissionId"
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Submit-Submission"
             "TelemetryProperties" = $telemetryProperties
@@ -1364,7 +1364,7 @@ function Submit-Submission
 
         $result = Invoke-SBRestMethod @params
 
-        $product = Get-Product -ProductId $ProductId -CorrelationId $CorrelationId -AccessToken $AccessToken -NoStatus:$NoStatus
+        $product = Get-Product -ProductId $ProductId -ClientRequestId $ClientRequestId -AccessToken $AccessToken -NoStatus:$NoStatus
         $appId = ($product.externalIds | Where-Object { $_.type -eq 'StoreId' }).value
         Write-Log -Message @(
             "The submission has been successfully submitted.",
@@ -1400,7 +1400,7 @@ function Get-SubmissionValidation
 
         [switch] $WaitForCompletion,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1415,7 +1415,7 @@ function Get-SubmissionValidation
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::WaitForCompletion = ($WaitForCompletion -eq $true)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
         }
 
         $params = @{
@@ -1423,7 +1423,7 @@ function Get-SubmissionValidation
             "Method" = 'Get'
             "Description" = "Getting validation of submission $SubmissionId for $ProductId"
             "WaitForCompletion" = $WaitForCompletion
-            "CorrelationId" = $CorrelationId
+            "ClientRequestId" = $ClientRequestId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionValidation"
             "TelemetryProperties" = $telemetryProperties
@@ -1532,7 +1532,7 @@ function Update-Submission
         # be updated.
         [switch] $IsMinimalObject,
 
-        [string] $CorrelationId,
+        [string] $ClientRequestId,
 
         [string] $AccessToken,
 
@@ -1614,10 +1614,10 @@ function Update-Submission
         throw $message
     }
 
-    $CorrelationId = Get-CorrelationId -CorrelationId $CorrelationId -Identifier $ProductId
+    $ClientRequestId = Get-ClientRequestId -ClientRequestId $ClientRequestId -Identifier $ProductId
 
     $commonParams = @{
-        'CorrelationId' = $CorrelationId
+        'ClientRequestId' = $ClientRequestId
         'AccessToken' = $AccessToken
         'NoStatus' = $NoStatus
     }
@@ -1980,7 +1980,7 @@ function Update-Submission
             [StoreBrokerTelemetryProperty]::UpdateCertificationNotes = ($UpdateCertificationNotes -eq $true)
             [StoreBrokerTelemetryProperty]::ProvidedCertificationNotes = (-not [String]::IsNullOrWhiteSpace($CertificationNotes))
             [StoreBrokerTelemetryProperty]::IsMinimalObject = ($IsMinimalObject -eq $true)
-            [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
+            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequestId
             [StoreBrokerTelemetryProperty]::SeekEnabled = $SeekEnabled
         }
 

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -109,10 +109,6 @@ function Get-Submission
         If not specified, then the API continuously be queried until all results have been
         retrieved, and then the final combined result set will be returned.
 
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
-
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
@@ -195,8 +191,6 @@ function Get-Submission
         [Parameter(ParameterSetName="Search")]
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -220,12 +214,10 @@ function Get-Submission
             [StoreBrokerTelemetryProperty]::GetValidation = $Validation
             [StoreBrokerTelemetryProperty]::WaitUntilReady = ($WaitUntilReady -eq $true)
             [StoreBrokerTelemetryProperty]::SingleQuery = $singleQuery
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
         $commonParams = @{
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -340,10 +332,6 @@ function New-Submission
         objects asynchronously, and thus the information in the Submission cannot be "trusted"
         until all of its resources are "ready".
 
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
-
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
@@ -426,8 +414,6 @@ function New-Submission
 
         [switch] $WaitUntilReady,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -448,13 +434,11 @@ function New-Submission
             [StoreBrokerTelemetryProperty]::Scope = $Scope
             [StoreBrokerTelemetryProperty]::Force = ($Force -eq $true)
             [StoreBrokerTelemetryProperty]::WaitUntilReady = ($WaitUntilReady -eq $true)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
         $commonParams = @{
             'ProductId' = $ProductId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -546,7 +530,6 @@ function New-Submission
             "Method" = 'Post'
             "Description" = "Creating a new submission for product: $ProductId"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "New-Submission"
@@ -589,10 +572,6 @@ function Remove-Submission
     .PARAMETER SubmissionId
         The ID of the Submission for the Product that is to be deleted.
 
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
-
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
@@ -623,8 +602,6 @@ function Remove-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -639,7 +616,6 @@ function Remove-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -647,7 +623,6 @@ function Remove-Submission
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId"
             "Method" = "Delete"
             "Description" = "Deleting submission $SubmissionId for product: $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Remove-Submission"
@@ -683,10 +658,6 @@ function Stop-Submission
     .PARAMETER SubmissionId
         The ID of the Submission for the Product that is to be stopped/cancelled.
 
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
-
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
         this request during post-mortem debugging.  This is typically supplied when trying to
@@ -720,8 +691,6 @@ function Stop-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -736,7 +705,6 @@ function Stop-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -744,7 +712,6 @@ function Stop-Submission
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/cancel"
             "Method" = 'Post'
             "Description" = "Cancelling submission $SubmissionId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Stop-Submission"
@@ -776,10 +743,6 @@ function Get-SubmissionDetail
 
     .PARAMETER SubmissionId
         The ID of the Submission for the Product whose details are to be retrieved.
-
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
 
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
@@ -813,8 +776,6 @@ function Get-SubmissionDetail
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -829,7 +790,6 @@ function Get-SubmissionDetail
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -837,7 +797,6 @@ function Get-SubmissionDetail
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/detail"
             "Method" = 'Get'
             "Description" = "Getting details of submission $SubmissionId for $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionDetail"
@@ -897,10 +856,6 @@ function Set-SubmissionDetail
         If this switch is not specified, no change will be made to the existing object.
         To change the corresponding value, you must explicitly specify either $true or $false
         with this switch.
-
-    .PARAMETER ClientRequestId
-        An optional identifier that should be sent along to the Store to help with identifying
-        this request during post-mortem debugging.
 
     .PARAMETER CorrelationId
         An optional identifier that should be sent along to the Store to help with identifying
@@ -963,8 +918,6 @@ function Set-SubmissionDetail
         [Parameter(ParameterSetName="Individual")]
         [switch] $AutoPromote,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -981,7 +934,6 @@ function Set-SubmissionDetail
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::UsingObject = ($null -ne $Object)
             [StoreBrokerTelemetryProperty]::UpdateCertificationNotes = ($null -ne $CertificationNotes)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1033,7 +985,6 @@ function Set-SubmissionDetail
             "Method" = 'Post'
             "Description" = "Updating detail for submission: $SubmissionId"
             "Body" = $body
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Set-SubmissionDetail"
@@ -1074,8 +1025,6 @@ function Update-SubmissionDetail
 
         [switch] $IsMinimalObject,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1115,7 +1064,6 @@ function Update-SubmissionDetail
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
-            'ClientRequestId' = $ClientRequestId
             'CorrelationId' = $CorrelationId
             'AccessToken' = $AccessToken
             'NoStatus' = $NoStatus
@@ -1203,7 +1151,6 @@ function Update-SubmissionDetail
             [StoreBrokerTelemetryProperty]::UpdateCertificationNotes = $UpdateCertificationNotes
             [StoreBrokerTelemetryProperty]::ProvidedCertificationNotes = $providedCertificationNotes
             [StoreBrokerTelemetryProperty]::ProvidedSubmissionData = $providedSubmissionData
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1230,8 +1177,6 @@ function Push-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1246,7 +1191,6 @@ function Push-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1254,7 +1198,6 @@ function Push-Submission
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/promote"
             "Method" = 'Post'
             "Description" = "Promoting submission $SubmissionId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Push-Submission"
@@ -1282,8 +1225,6 @@ function Publish-Submission
         [Parameter(Mandatory)]
         [string] $SubmissionId,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1298,7 +1239,6 @@ function Publish-Submission
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1306,7 +1246,6 @@ function Publish-Submission
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/publish"
             "Method" = 'Post'
             "Description" = "Publishing submission $SubmissionId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Publish-Submission"
@@ -1336,8 +1275,6 @@ function Get-SubmissionReport
 
         [switch] $SinglePage,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1352,14 +1289,12 @@ function Get-SubmissionReport
         $telemetryProperties = @{
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
         $params = @{
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/reports"
             "Description" = "Getting reports of submission $SubmissionId for $ProductId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionReport"
@@ -1392,8 +1327,6 @@ function Submit-Submission
 
         [switch] $Auto,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1409,7 +1342,6 @@ function Submit-Submission
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::Auto = $Auto
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1423,7 +1355,6 @@ function Submit-Submission
             "UriFragment" = "products/$ProductId/submissions/$SubmissionId/submit`?" + ($getParams -join '&')
             "Method" = 'Post'
             "Description" = "Submitting submission $SubmissionId"
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Submit-Submission"
@@ -1433,7 +1364,7 @@ function Submit-Submission
 
         $result = Invoke-SBRestMethod @params
 
-        $product = Get-Product -ProductId $ProductId -ClientRequestId $ClientRequestId -CorrelationId $CorrelationId -AccessToken $AccessToken -NoStatus:$NoStatus
+        $product = Get-Product -ProductId $ProductId -CorrelationId $CorrelationId -AccessToken $AccessToken -NoStatus:$NoStatus
         $appId = ($product.externalIds | Where-Object { $_.type -eq 'StoreId' }).value
         Write-Log -Message @(
             "The submission has been successfully submitted.",
@@ -1469,8 +1400,6 @@ function Get-SubmissionValidation
 
         [switch] $WaitForCompletion,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1486,7 +1415,6 @@ function Get-SubmissionValidation
             [StoreBrokerTelemetryProperty]::ProductId = $ProductId
             [StoreBrokerTelemetryProperty]::SubmissionId = $SubmissionId
             [StoreBrokerTelemetryProperty]::WaitForCompletion = ($WaitForCompletion -eq $true)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
         }
 
@@ -1495,7 +1423,6 @@ function Get-SubmissionValidation
             "Method" = 'Get'
             "Description" = "Getting validation of submission $SubmissionId for $ProductId"
             "WaitForCompletion" = $WaitForCompletion
-            "ClientRequestId" = $ClientRequestId
             "CorrelationId" = $CorrelationId
             "AccessToken" = $AccessToken
             "TelemetryEventName" = "Get-SubmissionValidation"
@@ -1605,8 +1532,6 @@ function Update-Submission
         # be updated.
         [switch] $IsMinimalObject,
 
-        [string] $ClientRequestId,
-
         [string] $CorrelationId,
 
         [string] $AccessToken,
@@ -1692,7 +1617,6 @@ function Update-Submission
     $CorrelationId = Get-CorrelationId -CorrelationId $CorrelationId -Identifier $ProductId
 
     $commonParams = @{
-        'ClientRequestId' = $ClientRequestId
         'CorrelationId' = $CorrelationId
         'AccessToken' = $AccessToken
         'NoStatus' = $NoStatus
@@ -2056,7 +1980,6 @@ function Update-Submission
             [StoreBrokerTelemetryProperty]::UpdateCertificationNotes = ($UpdateCertificationNotes -eq $true)
             [StoreBrokerTelemetryProperty]::ProvidedCertificationNotes = (-not [String]::IsNullOrWhiteSpace($CertificationNotes))
             [StoreBrokerTelemetryProperty]::IsMinimalObject = ($IsMinimalObject -eq $true)
-            [StoreBrokerTelemetryProperty]::ClientRequestId = $ClientRequesId
             [StoreBrokerTelemetryProperty]::CorrelationId = $CorrelationId
             [StoreBrokerTelemetryProperty]::SeekEnabled = $SeekEnabled
         }

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -15,7 +15,7 @@ Add-Type -TypeDefinition @"
       Auto,
       AutoSubmit,
       ClientName,
-      CorrelationId,
+      ClientRequestId,
       DayOfWeek,
       EndingConfigVersion,
       ErrorBucket,

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -15,7 +15,6 @@ Add-Type -TypeDefinition @"
       Auto,
       AutoSubmit,
       ClientName,
-      ClientRequestId,
       CorrelationId,
       DayOfWeek,
       EndingConfigVersion,


### PR DESCRIPTION
This PR swaps out the Store API endpoint from the v1 version to the v2 version.

- Changes the endpoint from https://manage.devcenter.microsoft.com to https://api.partner.microsoft.com for both the StoreBroker client and RestProxy service.
- Updated the proxy to pass down the new Request-ID header and updated the client to log the Request-ID header.
- Removed the MS-CorrelationId header, the API now uses the MS-ClientRequestId header to track multiple API calls. The logic for automatically generating a CorrelationId if one was not passed was re-purposed to generate a ClientRequestId instead.
- Updates the RestProxy Security Protocol to be TLS 1.2 as that is what the new endpoint expects.
