### PR TITLE
Check for null values when calling Convert-EnumToString on PSCustomObject

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.11'
+    ModuleVersion = '2.1.12'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -1246,13 +1246,16 @@ function Convert-EnumToString
     {
         $modified = $InputObject.PSObject.Copy() # Get a new instance, not a reference
         $modified | Get-Member -type NoteProperty | Select-Object -ExpandProperty Name | ForEach-Object {
-            $converted = (Convert-EnumToString -InputObject $modified.$_)
-            if ($modified.$_ -is [array])
+            if ($null -ne $modified.$_)
             {
-                $converted = @($converted)
+                $converted = (Convert-EnumToString -InputObject $modified.$_)
+                if ($modified.$_ -is [array])
+                {
+                    $converted = @($converted)
+                }
+    
+                $modified.$_ = $converted
             }
-
-            $modified.$_ = $converted
         }
 
         return $modified

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -1254,7 +1254,7 @@ function Convert-EnumToString
             }
 
             $modified.$_ = $converted
-            }
+        }
 
         return $modified
     }

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -1211,6 +1211,7 @@ function Convert-EnumToString
         [Parameter(
             ValueFromPipeline,
             Mandatory)]
+        [AllowNull()]
         $InputObject
     )
 
@@ -1246,16 +1247,13 @@ function Convert-EnumToString
     {
         $modified = $InputObject.PSObject.Copy() # Get a new instance, not a reference
         $modified | Get-Member -type NoteProperty | Select-Object -ExpandProperty Name | ForEach-Object {
-            if ($null -ne $modified.$_)
-            {
-                $converted = (Convert-EnumToString -InputObject $modified.$_)
-                if ($modified.$_ -is [array])
-                {
-                    $converted = @($converted)
-                }
-    
-                $modified.$_ = $converted
-            }
+        $converted = (Convert-EnumToString -InputObject $modified.$_)
+        if ($modified.$_ -is [array])
+        {
+            $converted = @($converted)
+        }
+
+        $modified.$_ = $converted
         }
 
         return $modified

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -1247,14 +1247,14 @@ function Convert-EnumToString
     {
         $modified = $InputObject.PSObject.Copy() # Get a new instance, not a reference
         $modified | Get-Member -type NoteProperty | Select-Object -ExpandProperty Name | ForEach-Object {
-        $converted = (Convert-EnumToString -InputObject $modified.$_)
-        if ($modified.$_ -is [array])
-        {
-            $converted = @($converted)
-        }
+            $converted = (Convert-EnumToString -InputObject $modified.$_)
+            if ($modified.$_ -is [array])
+            {
+                $converted = @($converted)
+            }
 
-        $modified.$_ = $converted
-        }
+            $modified.$_ = $converted
+            }
 
         return $modified
     }


### PR DESCRIPTION
Convert-EnumToString iterates over each property and calls itself recursively in order to convert all properties that are enums into strings. In the case of converting PSCustomObjects if the value in the property is $null we would try to pass that $null value recursively to Convert-EnumToString which would throw this exception:

Cannot bind argument to parameter 'InputObject' because it is null.

Now we check for null before doing the recursive call.