### PR TITLE
Fix character escaping issues during config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [1.19.4](https://github.com/Microsoft/StoreBroker/tree/1.19.4) - (2020/08/14)
+### Fixes:
+
+- Fixes the logic for config generation when `tag` or `notesForCertification` from Partner Center
+  had an encoded character or a URL value.  The encoded character wasn't getting re-encoded properly
+  in the generated config, and everything after the `//` in the URL was being treated as a comment.
+
+More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/https://github.com/Microsoft/StoreBroker/pull/198) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/...)
+
+Author: [**@HowardWolosky**](https://github.com/HowardWolosky)
+
 ## [1.19.3](https://github.com/Microsoft/StoreBroker/tree/1.19.3) - (2020/04/10)
 ### Fixes:
 
-+ Updated all of the Partner Center URL's to follow the new location format.
+- Updated all of the Partner Center URL's to follow the new location format.
 
 More Info: [[pr]](https://github.com/Microsoft/StoreBroker/pull/https://github.com/Microsoft/StoreBroker/pull/185) | [[cl]](https://github.com/Microsoft/StoreBroker/commit/0fbb6b9a702cf0edf52e8f5ef6d920fb859fc954)
 
@@ -13,7 +24,7 @@ Author: [**@cartwrightluke**](https://github.com/cartwrightluke)
 ## [1.19.2](https://github.com/Microsoft/StoreBroker/tree/1.19.2) - (2018/12/14)
 ### Fixes:
 
-+ Updated the logic for finding the appxbundle/appx manifests to use direct instead of relative
+- Updated the logic for finding the appxbundle/appx manifests to use direct instead of relative
   paths
 
 More Info: [[cl]](https://github.com/Microsoft/StoreBroker/commit/9f884ff367bca72c604e57f5ce9daad6b0f4b277)

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -321,57 +321,6 @@ function Get-SHA512Hash
     return [System.BitConverter]::ToString($sha512.ComputeHash($utf8.GetBytes($PlainText))) -replace '-', ''
 }
 
-function Get-EscapedJsonValue
-{
-<#
-    .SYNOPSIS
-        Escapes special characters within a string for use within a JSON value.
-
-    .DESCRIPTION
-        Escapes special characters within a string for use within a JSON value.
-
-        The Git repo for this module can be found here: http://aka.ms/StoreBroker
-
-    .PARAMETER Value
-        The string that needs to be escaped
-
-    .EXAMPLE
-        Get-EscapedJsonValue -Value 'This is my "quote". Look here: c:\windows\'
-
-        Returns back the string 'This is my \"quote\". Look here: c:\\windows\\'
-
-    .OUTPUTS
-        System.String - A string with special characters escaped for use within JSON.
-
-    .NOTES
-        Normalizes newlines and carriage returns to always be \r\n.
-#>
-    [CmdletBinding()]
-    param(
-        [Parameter(
-            Mandatory,
-            ValueFromPipeline)]
-        [AllowNull()]
-        [AllowEmptyString()]
-        [string] $Value
-    )
-
-    # The syntax of -replace is a bit confusing, so it's worth a note here.
-    # The first parameter is a regular expression match pattern.  The second parameter is a replacement string.
-    # So, when we try to do "-replace '\\', '\\", that's matching a single backslash (which has to be
-    # escaped within the match regular expression as a double-backslash), and replacing it with a
-    # string containing literally two backslashes.
-    # (And as a reminder, PowerShell's escape character is actually the backtick (`) and not backslash (\).)
-
-    # \, ", <tab>
-    $escaped = $Value -replace '\\', '\\' -replace '"', '\"' -replace '\t', '\t'
-
-    # Now normalize actual CR's and LF's with their control codes.  We'll ensure all variations are uniformly formatted as \r\n
-    $escaped = $escaped -replace '\r\n', '\r\n' -replace '\r', '\r\n' -replace '\n', '\r\n'
-
-    return $escaped
-}
-
 function ConvertTo-Array
 {
 <#

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -125,16 +125,16 @@ function Get-StoreBrokerConfigFileContentForIapId
         $updated = $updated -replace '"lifetime": ".*",', "`"lifetime`": `"$($sub.lifetime)`","
         $updated = $updated -replace '"contentType": ".*",', "`"contentType`": `"$($sub.contentType)`","
 
-        $tag = Get-EscapedJsonValue -Value $sub.tag
-        $updated = $updated -replace '"tag": ""', "`"tag`": `"$tag`""
+        $tag = ConvertTo-Json -InputObject ($sub.tag -replace '//', '\\') # Ensure // doesn't get stripped out as a comment later on.
+        $updated = $updated -replace '"tag": ""', "`"tag`": $tag"
 
         $keywords = $sub.keywords | ConvertTo-Json -Depth $script:jsonConversionDepth
         if ($null -eq $keywords) { $keywords = "[ ]" }
         $updated = $updated -replace '(\s+)"keywords": \[.*(\r|\n)+\s*\]', "`$1`"keywords`": $keywords"
 
         # NOTES FOR CERTIFICATION
-        $notesForCertification = Get-EscapedJsonValue -Value $sub.notesForCertification
-        $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": `"$notesForCertification`""
+        $notesForCertification = ConvertTo-Json -InputObject ($sub.notesForCertification -replace '//', '\\') # Ensure // doesn't get stripped out as a comment later on.
+        $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": $notesForCertification"
 
         return $updated
     }
@@ -361,8 +361,8 @@ function Get-StoreBrokerConfigFileContentForAppId
         }
 
         # NOTES FOR CERTIFICATION
-        $notesForCertification = Get-EscapedJsonValue -Value $sub.notesForCertification
-        $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": `"$notesForCertification`""
+        $notesForCertification = ConvertTo-Json -InputObject ($sub.notesForCertification -replace '//', '\\') # Ensure // doesn't get stripped out as a comment later on.
+        $updated = $updated -replace '"notesForCertification": ""', "`"notesForCertification`": $notesForCertification"
 
         return $updated
     }

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.19.3'
+    ModuleVersion = '1.19.4'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Many years ago, #24 attempted to properly escape special characters in a string by creating its own `Get-EscapedJsonValue` function, but that only escaped `\`, `\t`, `\r`, `\n`.  That doesn't cover all the possible characters needing to be encoded though.

A user had a `<` character (which was properly JSON-escaped as `\u003c`), but that didn't get escaped by this logic, and thus caused an issue when trying to get decoded by `ConvertFrom-Json` later on.

Back then, `Get-EscapedJsonValue` must have seemed like a _good_ idea, but looking back at this code with more experience, it's not clear to me why I didn't just use `ConvertTo-Json` directly. Doing that now.

One additional update that needed to be done however was to replace `//` with `\\`  in `tag` and `notesForCertification`.  This isn't _completely_ correct, but not doing so meant that anything after that would be improperly flagged as a comment by `Remove-Comment` and then removed.  This was found because the same user had a URL in their `notesForCertification` and the closing JSON was getting stripped out incorrectly as soon as it found the `//` in `https://....`.

Fixes #197