### PR TITLE
Port Write-InvocationLog from v2 branch

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -752,6 +752,89 @@ function Send-SBMailMessage
     }
 }
 
+$script:alwaysRedactParametersForLogging = @(
+    'AccessToken' # Would be a security issue
+)
+
+$script:alwaysExcludeParametersForLogging = @(
+    'NoStatus'
+)
+
+function Write-InvocationLog
+{
+    <#
+    .SYNOPSIS
+        Writes a log entry for the invoke command.
+
+    .DESCRIPTION
+        Writes a log entry for the invoke command.
+
+        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
+
+    .PARAMETER InvocationInfo
+        The '$MyInvocation' object from the calling function.
+        No need to explicitly provide this if you're trying to log the immediate function this is
+        being called from.
+
+    .PARAMETER RedactParameter
+        An optional array of parameter names that should be logged, but their values redacted.
+
+    .PARAMETER ExcludeParameter
+        An optional array of parameter names that should simply not be logged.
+
+    .EXAMPLE
+        Write-InvocationLog -Invocation $MyInvocation
+
+    .EXAMPLE
+        Write-InvocationLog -Invocation $MyInvocation -ExcludeParameter @('Properties', 'Metrics')
+
+    .NOTES
+        The actual invocation line will not be _completely_ accurate as converted parameters will
+        be in JSON format as opposed to PowerShell format.  However, it should be sufficient enough
+        for debugging purposes.
+
+        ExcludeParamater will always take precedence over RedactParameter.
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Management.Automation.InvocationInfo] $Invocation = (Get-Variable -Name MyInvocation -Scope 1 -ValueOnly),
+
+        [string[]] $RedactParameter,
+
+        [string[]] $ExcludeParameter
+    )
+
+    $jsonConversionDepth = 20 # Seems like it should be more than sufficient
+
+    # Build up the invoked line, being sure to exclude and/or redact any values necessary
+    $params = @()
+    foreach ($param in $Invocation.BoundParameters.GetEnumerator())
+    {
+        if ($param.Key -in ($script:alwaysExcludeParametersForLogging + $ExcludeParameter))
+        {
+            continue
+        }
+
+        if ($param.Key -in ($script:alwaysRedactParametersForLogging + $RedactParameter))
+        {
+            $params += "-$($param.Key) <redacted>"
+        }
+        else
+        {
+            if ($param.Value -is [switch])
+            {
+                $params += "-$($param.Key):`$$($param.Value.ToBool().ToString().ToLower())"
+            }
+            else
+            {
+                $params += "-$($param.Key) $($param.Value | ConvertTo-Json -Depth $jsonConversionDepth -Compress)"
+            }
+        }
+    }
+
+    Write-Log -Message "[$($Invocation.MyCommand.Module.Version)] Executing: $($Invocation.MyCommand) $($params -join ' ')" -Level Verbose
+}
+
 function Write-InteractiveHost
 {
 <#

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -230,7 +230,7 @@ function Set-StoreBrokerAuthentication
         [string] $TenantName = $null
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     if ($UseProxy)
     {
@@ -336,7 +336,7 @@ function Clear-StoreBrokerAuthentication
 
     Set-TelemetryEvent -EventName Clear-StoreBrokerAuthentication
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     if ($PSCmdlet.ShouldProcess("", "Clear tenantId"))
     {
@@ -809,7 +809,7 @@ function Set-SubmissionPackage
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::PackagePath = (Get-PiiSafeString -PlainText $PackagePath) }
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     Write-Log -Message "Attempting to upload the package ($PackagePath) for the submission to $UploadUrl..." -Level Verbose
 
@@ -1005,7 +1005,7 @@ function Get-SubmissionPackage
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::PackagePath = (Get-PiiSafeString -PlainText $PackagePath) }
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     Write-Log -Message "Attempting to download the contents of $UploadUrl to $PackagePath..." -Level Verbose
 
@@ -1248,7 +1248,7 @@ function Start-SubmissionMonitor
         [switch] $PassThru
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     # Telemetry-related
     $telemetryProperties = @{

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -89,7 +89,7 @@ function Get-Applications
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $params = @{
         "UriFragment" = "applications"
@@ -227,7 +227,7 @@ function Get-Application
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
 
@@ -367,7 +367,7 @@ function Get-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -657,7 +657,7 @@ function Get-ApplicationSubmissionStatus
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -731,7 +731,7 @@ function Remove-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -830,7 +830,7 @@ function New-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
     {
@@ -1159,7 +1159,7 @@ function Update-ApplicationSubmission
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     Write-Log -Message "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
     if ($PSCmdlet.ShouldProcess($SubmissionDataPath, "Get-Content"))
@@ -1864,7 +1864,7 @@ function Set-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $submissionId = $UpdatedSubmission.id
     $body = [string]($UpdatedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth)
@@ -1945,7 +1945,7 @@ function Complete-ApplicationSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2042,7 +2042,7 @@ function Get-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2133,7 +2133,7 @@ function Update-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2231,7 +2231,7 @@ function Stop-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2327,7 +2327,7 @@ function Complete-ApplicationSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -88,7 +88,7 @@ function Get-ApplicationFlights
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
 
@@ -235,7 +235,7 @@ function Get-ApplicationFlight
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -428,7 +428,7 @@ function New-ApplicationFlight
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     # Convert the input into a Json body.
     $hashBody = @{}
@@ -526,7 +526,7 @@ function Remove-ApplicationFlight
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -619,7 +619,7 @@ function Get-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -804,7 +804,7 @@ function Get-ApplicationFlightSubmissionStatus
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -887,7 +887,7 @@ function Remove-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::AppId = $AppId
@@ -991,7 +991,7 @@ function New-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
     {
@@ -1279,7 +1279,7 @@ function Update-ApplicationFlightSubmission
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     Write-Log -Message "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
     if ($PSCmdlet.ShouldProcess($SubmissionDataPath, "Get-Content"))
@@ -1774,7 +1774,7 @@ function Set-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $submissionId = $UpdatedSubmission.id
     $flightId = $UpdatedSubmission.flightId
@@ -1868,7 +1868,7 @@ function Complete-ApplicationFlightSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2058,7 +2058,7 @@ function Get-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2157,7 +2157,7 @@ function Update-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2264,7 +2264,7 @@ function Stop-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {
@@ -2368,7 +2368,7 @@ function Complete-ApplicationFlightSubmissionPackageRollout
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {

--- a/StoreBroker/StoreIngestionIapApi.ps1
+++ b/StoreBroker/StoreIngestionIapApi.ps1
@@ -82,7 +82,7 @@ function Get-InAppProducts
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $params = @{
         "UriFragment" = "inappproducts/"
@@ -218,7 +218,7 @@ function Get-InAppProduct
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::IapId = $IapId }
 
@@ -388,7 +388,7 @@ function Get-ApplicationInAppProducts
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::AppId = $AppId }
 
@@ -529,7 +529,7 @@ function New-InAppProduct
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     # Convert the input into a Json body.
     $hashBody = @{}
@@ -605,7 +605,7 @@ function Remove-InAppProduct
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{ [StoreBrokerTelemetryProperty]::IapId = $IapId }
 
@@ -689,7 +689,7 @@ function Get-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::IapId = $IapId
@@ -918,7 +918,7 @@ function Get-InAppProductSubmissionStatus
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::IapId = $IapId
@@ -995,7 +995,7 @@ function Remove-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryProperties = @{
         [StoreBrokerTelemetryProperty]::IapId = $IapId
@@ -1083,7 +1083,7 @@ function New-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     if ([System.String]::IsNullOrEmpty($AccessToken))
     {
@@ -1299,7 +1299,7 @@ function Update-InAppProductSubmission
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     Write-Log -Message "Reading in the submission content from: $SubmissionDataPath" -Level Verbose
     if ($PSCmdlet.ShouldProcess($SubmissionDataPath, "Get-Content"))
@@ -1765,7 +1765,7 @@ function Set-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $submissionId = $UpdatedSubmission.id
     $body = [string]($UpdatedSubmission | ConvertTo-Json -Depth $script:jsonConversionDepth)
@@ -1851,7 +1851,7 @@ function Complete-InAppProductSubmission
         [switch] $NoStatus
     )
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     try
     {

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -500,7 +500,7 @@ function Set-TelemetryEvent
         return
     }
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog -ExcludeParameter @('Properties', 'Metrics')
 
     try
     {
@@ -603,7 +603,7 @@ function Set-TelemetryException
         return
     }
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog -ExcludeParameter @('Exception', 'Properties', 'NoFlush')
 
     try
     {
@@ -681,7 +681,7 @@ function Flush-TelemetryClient
         return
     }
 
-    Write-Log -Message "Executing: $($MyInvocation.Line)" -Level Verbose
+    Write-InvocationLog
 
     $telemetryClient = Get-TelemetryClient -NoStatus:$NoStatus
 


### PR DESCRIPTION
This ports 48a8791a2f62e57da234427410cb40b2f026b0ed from the v2 branch so that v1 can benefit from normalized invocation logging as well.

This will make future support queries easier to handle, as we'll know exactly what input was provided as well as the version of
the module actively in use.