### PR TITLE
Fix exception shown during Telemetry

### DIFF
--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -184,10 +184,7 @@ function Get-BaseTelemetryEvent
 
     if ($null -eq $script:SBBaseTelemetryEvent)
     {
-        if (-not (Get-GitHubConfiguration -Name SuppressTelemetryReminder))
-        {
-            Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information."
-        }
+        Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information."
 
         $username = Get-PiiSafeString -PlainText $env:USERNAME
 


### PR DESCRIPTION
When #201 brought over the raw telemetry work from PowerShellForGitHub,
it erroneously left in a `Get-GitHubConfiguration` call which should
have been removed.