### PR TITLE
Add option to suppress telemetry reminder

### DIFF
--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -1041,11 +1041,10 @@ employed during execution of commands within this module (via Application Insigh
 information, refer to the [Privacy Policy](../README.md#privacy-policy) and
 [Terms of Use](../README.md#terms-of-use).
 
-> You may notice some needed assemblies for communicating with Application Insights being
-> downloaded on first run of a StoreBroker command within each PowerShell session.  The
-> [automatic dependency downloads](SETUP.md#automatic-dependency-downloads) section of the setup
-> documentation describes how you can avoid having to always re-download the telemetry assemblies
-> in the future.
+With every new PowerShell session, StoreBroker will show you a reminder that telemetry is being
+used.  You can suppress this reminder in the future by setting the following:
+
+    $global:SBSuppressTelemetryReminder = $true
 
 We recommend that you always leave the telemetry feature enabled, but a situation may arise where
 it must be disabled for some reason.  In this scenario, you can disable telemetry by setting

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -158,6 +158,11 @@ function Initialize-TelemetryGlobalVariables
         $global:SBDisableTelemetry = $false
     }
 
+    if (!(Get-Variable -Name SBSuppressTelemetryReminder -Scope Global -ValueOnly -ErrorAction Ignore))
+    {
+        $global:SBSuppressTelemetryReminder = $false
+    }
+
     if (!(Get-Variable -Name SBDisablePiiProtection -Scope Global -ValueOnly -ErrorAction Ignore))
     {
         $global:SBDisablePiiProtection = $false
@@ -245,7 +250,10 @@ function Get-BaseTelemetryEvent
 
     if ($null -eq $script:SBBaseTelemetryEvent)
     {
-        Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information."
+        if (-not $global:SBSuppressTelemetryReminder)
+        {
+            Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information.  Stop seeing this message in the future by setting `"`$global:SBSuppressTelemetryReminder=`$true`""
+        }
 
         $username = Get-PiiSafeString -PlainText $env:USERNAME
 


### PR DESCRIPTION
Adds a new global variable that users can set to keep telemetry enabled
but suppress the per-session reminder that telemetry is enabled.

> This is a port of #206 from v1