### PR TITLE
Fix Partner Center URL's

### DIFF
--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1348,7 +1348,7 @@ function Start-SubmissionMonitor
                 else
                 {
                     $body += "Dev Portal URL"
-                    $body += "    https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$SubmissionId/"
+                    $body += "    https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$SubmissionId/"
                     $body += "StoreBroker command"
                     if ($isFlightingSubmission)
                     {
@@ -1447,6 +1447,9 @@ function Open-DevPortal
     .PARAMETER ShowFlight
         If provided, will show the flight UI as opposed to the flight submission UI.
 
+        NOTE: This feature appears to have been deprecated from Partner Center and thus
+        this switch no longer does anything.
+
     .EXAMPLE
         Open-DevPortal 0ABCDEF12345
 
@@ -1498,9 +1501,9 @@ function Open-DevPortal
 
     Write-Log -Message "Opening Dev Portal in default web browser."
 
-    $appUrl        = "https://partner.microsoft.com/en-us/dashboard/apps/$AppId"
-    $submissionUrl = "https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$SubmissionId/"
-    $flightUrl     = "https://partner.microsoft.com/en-us/dashboard/Application/GetFlight?appId=$AppId&submissionId=$SubmissionId"
+    $appUrl        = "https://partner.microsoft.com/en-us/dashboard/products/$AppId"
+    $submissionUrl = "https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$SubmissionId/"
+    $flightUrl     = $submissionUrl # this feature appears to have been deprecated from Partner Center
 
     if ($ShowFlight)
     {

--- a/StoreBroker/StoreIngestionApplicationApi.ps1
+++ b/StoreBroker/StoreIngestionApplicationApi.ps1
@@ -1285,7 +1285,7 @@ function Update-ApplicationSubmission
         Write-Log -Message @(
             "Successfully cloned the existing submission and modified its content.",
             "You can view it on the Dev Portal here:",
-            "    https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "    https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$submissionId/",
             "or by running this command:",
             "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission",
             "",
@@ -1971,7 +1971,7 @@ function Complete-ApplicationSubmission
             "This is just the beginning though.",
             "It still has multiple phases of validation to get through, and there's no telling how long that might take.",
             "You can view the progress of the submission validation on the Dev Portal here:",
-            "    https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "    https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$submissionId/",
             "or by running this command:",
             "    Get-ApplicationSubmission -AppId $AppId -SubmissionId $submissionId | Format-ApplicationSubmission",
             "You can automatically monitor this submission with this command:",

--- a/StoreBroker/StoreIngestionFlightingApi.ps1
+++ b/StoreBroker/StoreIngestionFlightingApi.ps1
@@ -1395,7 +1395,7 @@ function Update-ApplicationFlightSubmission
         Write-Log -Message @(
             "Successfully cloned the existing submission and modified its content.",
             "You can view it on the Dev Portal here:",
-            "    https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "    https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$submissionId/",
             "or by running this command:",
             "    Get-ApplicationFlightSubmission -AppId $AppId -FlightId $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission",
             "",
@@ -1895,7 +1895,7 @@ function Complete-ApplicationFlightSubmission
             "This is just the beginning though.",
             "It still has multiple phases of validation to get through, and there's no telling how long that might take.",
             "You can view the progress of the submission validation on the Dev Portal here:",
-            "    https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$submissionId/",
+            "    https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$submissionId/",
             "or by running this command:",
             "    Get-ApplicationFlightSubmission -AppId $AppId -Flight $FlightId -SubmissionId $submissionId | Format-ApplicationFlightSubmission",
             "You can automatically monitor this submission with this command:",


### PR DESCRIPTION
Partner Center changed its URL scheme, and so some of the generated
URL's that StoreBroker uses needed to be updated.

This also deprecates the `ShowFlight` switch for `Open-DevPortal` as
there no longer appears to be an equivalent destination in the updated
Partner Center.

Fixes #195