### PR TITLE
Fix Partner Center URL's

### DIFF
--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -1390,7 +1390,7 @@ function Start-SubmissionMonitor
                 $body += "To view the full submission"
                 $body += "---------------------------"
                 $body += "Dev Portal URL"
-                $body += "    https://partner.microsoft.com/en-us/dashboard/apps/$appId/submissions/$SubmissionId/"
+                $body += "    https://partner.microsoft.com/en-us/dashboard/products/$appId/submissions/$SubmissionId/"
                 $body += "StoreBroker command"
                 $body += "    Get-Submission -ProductId $productId -SubmissionId $SubmissionId"
 
@@ -1503,6 +1503,9 @@ function Open-DevPortal
     .PARAMETER ShowFlight
         If provided, will show the flight UI as opposed to the flight submission UI.
 
+        NOTE: This feature appears to have been deprecated from Partner Center and thus
+        this switch no longer does anything.
+
     .EXAMPLE
         Open-DevPortal -AppId 0ABCDEF12345
 
@@ -1596,9 +1599,9 @@ function Open-DevPortal
 
     Write-Log -Message "Opening Dev Portal in default web browser."
 
-    $appUrl        = "https://partner.microsoft.com/en-us/dashboard/apps/$AppId"
-    $submissionUrl = "https://partner.microsoft.com/en-us/dashboard/apps/$AppId/submissions/$SubmissionId/"
-    $flightUrl     = "https://partner.microsoft.com/en-us/dashboard/Application/GetFlight?appId=$AppId&submissionId=$SubmissionId"
+    $appUrl        = "https://partner.microsoft.com/en-us/dashboard/products/$AppId"
+    $submissionUrl = "https://partner.microsoft.com/en-us/dashboard/products/$AppId/submissions/$SubmissionId/"
+    $flightUrl     = $submissionUrl # this feature appears to have been deprecated from Partner Center
 
     if ($ShowFlight)
     {

--- a/StoreBroker/StoreIngestionSubmissionApi.ps1
+++ b/StoreBroker/StoreIngestionSubmissionApi.ps1
@@ -1371,7 +1371,7 @@ function Submit-Submission
             "This is just the beginning though.",
             "It still has multiple phases of validation to get through, and there's no telling how long that might take.",
             "You can view the progress of the submission validation on the Dev Portal here:",
-            "    https://partner.microsoft.com/en-us/dashboard/apps/$appId/submissions/$submissionId/",
+            "    https://partner.microsoft.com/en-us/dashboard/products/$appId/submissions/$submissionId/",
             "or by running this command:",
             "    Get-Submission -ProductId $ProductId -SubmissionId $submissionId",
             "You can automatically monitor this submission with this command:",
@@ -1912,7 +1912,7 @@ function Update-Submission
         Write-Log -Message @(
             "Successfully cloned the existing submission and modified its content.",
             "You can view it on the Dev Portal here:",
-            "    https://partner.microsoft.com/en-us/dashboard/apps/$appId/submissions/$SubmissionId/")
+            "    https://partner.microsoft.com/en-us/dashboard/products/$appId/submissions/$SubmissionId/")
 
         if ($AutoSubmit)
         {


### PR DESCRIPTION
Partner Center changed its URL scheme, and so some of the generated
URL's that StoreBroker uses needed to be updated.

This also deprecates the `ShowFlight` switch for `Open-DevPortal` as
there no longer appears to be an equivalent destination in the updated
Partner Center.

Resolves #195