### PR TITLE
Only resolve MediaRootPath if it's necessary

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.14'
+    ModuleVersion = '2.1.15'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionListingImageApi.ps1
+++ b/StoreBroker/StoreIngestionListingImageApi.ps1
@@ -462,8 +462,6 @@ function Update-ListingImage
     {
         $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-        $MediaRootPath = Resolve-UnverifiedPath -Path $MediaRootPath
-
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
@@ -484,6 +482,8 @@ function Update-ListingImage
 
         if (-not $RemoveOnly)
         {
+            $MediaRootPath = Resolve-UnverifiedPath -Path $MediaRootPath
+
             # Then we proceed with adding/uploading all of the current images
             Write-Log -Message "Creating [$LanguageCode] listing images." -Level Verbose
             foreach ($image in $SubmissionData.listings.$LanguageCode.baseListing.images)


### PR DESCRIPTION
When `Update-Listing` calls into `Update-ListingImage` to remove unneeded images, it calls that with `-RemoveOnly` and doesn't bother passing in a `MediaRootPath`.  However, we still tried to resolve the `MediaRootPath`, and that could cause an exception since the path being resolved was blank.

https://github.com/microsoft/StoreBroker/blob/6e70140246592a37a9156a1c4000b87d37de7055/StoreBroker/StoreIngestionListingApi.ps1#L827-L843

https://github.com/microsoft/StoreBroker/blob/6e70140246592a37a9156a1c4000b87d37de7055/StoreBroker/StoreIngestionListingImageApi.ps1#L465

This updates `Update-ListImage` to only resolve `MediaRootPath` if we're going to use it (meaning that `RemoveOnly` wasn't specified).