### PR TITLE
Fix issues when removing a listing from a new submission

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.15'
+    ModuleVersion = '2.1.16'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/StoreIngestionListingApi.ps1
+++ b/StoreBroker/StoreIngestionListingApi.ps1
@@ -836,9 +836,9 @@ function Update-Listing
             Write-Log -Message 'Now removing listings for languages that were cloned by the submission but don''t have current user data.' -Level Verbose
             foreach ($langCode in $listingsToDelete)
             {
-                $null = Remove-Listing @commonParams -LanguageCode $langCode
                 $null = Update-ListingImage @commonParams -LanguageCode $langCode -RemoveOnly
                 $null = Update-ListingVideo @commonParams -LanguageCode $langCode -RemoveOnly
+                $null = Remove-Listing @commonParams -LanguageCode $langCode
             }
         }
 

--- a/StoreBroker/StoreIngestionListingVideoApi.ps1
+++ b/StoreBroker/StoreIngestionListingVideoApi.ps1
@@ -482,8 +482,6 @@ function Update-ListingVideo
     {
         $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-        $MediaRootPath = Resolve-UnverifiedPath -Path $MediaRootPath
-
         $params = @{
             'ProductId' = $ProductId
             'SubmissionId' = $SubmissionId
@@ -504,6 +502,8 @@ function Update-ListingVideo
 
         if (-not $RemoveOnly)
         {
+            $MediaRootPath = Resolve-UnverifiedPath -Path $MediaRootPath
+
             # Then we proceed with adding/uploading all of the current videos
             Write-Log -Message "Creating [$LanguageCode] listing videos." -Level Verbose
             foreach ($trailer in $SubmissionData.trailers)


### PR DESCRIPTION
When a new submission is cloned that does not include a listing for a language that was the previously included, the code path to removing the listing for this language has a couple of issues:

- We delete the listing first, and then we try to remove the images/videos. This results in a 404 error in the latter API calls since the listing has already been removed at that point. We should remove the images/videos first and then do the API call to delete the entire listing.
- We try to verify $MediaRootPath when calling Update-ListingVideo with the -RemoveOnly flag causing an error since $MediaRootPath would be null in this scenario