### PR TITLE
V1 msix support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Brings backward some improvements that had been made in the v2 branch. [[pr]](ht
 
 - Silences unnecessary file access errors when testing paths with `Test-Path`.
 
-Authors:
+Author:
  * [**@HowardWolosky**](https://github.com/HowardWolosky)
 
 ## [1.20.1](https://github.com/Microsoft/StoreBroker/tree/1.20.1) - (2020/08/27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # StoreBroker PowerShell Module
 ## Changelog
 
+## [1.21.0](https://github.com/Microsoft/StoreBroker/tree/1.21.0) - (2020/12/01)
+
+Brings backward some improvements that had been made in the v2 branch. [[pr]](https://github.com/Microsoft/StoreBroker/pull/217) | [[cl]](https://github.com/microsoft/StoreBroker/commit/tbd)
+
+### Features:
+
++ Added support for `msix`, `msixbundle` and `msixupload` file extensions to `New-SubmissionPackage`.
++ Added support for the `xvc` file extension to `New-SubmissionPackage`, (although submission via
+  the v1 API remains untested).
+### Fixes
+- `New-SubmissionPackage` now properly handles packages which contain stubs.
+
+- Silences unnecessary file access errors when testing paths with `Test-Path`.
+
+Authors:
+ * [**@HowardWolosky**](https://github.com/HowardWolosky)
+
 ## [1.20.1](https://github.com/Microsoft/StoreBroker/tree/1.20.1) - (2020/08/27)
 ### Features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Brings backward some improvements that had been made in the v2 branch. [[pr]](ht
 + Added support for `msix`, `msixbundle` and `msixupload` file extensions to `New-SubmissionPackage`.
 + Added support for the `xvc` file extension to `New-SubmissionPackage`, (although submission via
   the v1 API remains untested).
+
 ### Fixes
 - `New-SubmissionPackage` now properly handles packages which contain stubs.
 

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -7,8 +7,10 @@ $script:defaultIapConfigFileName = "IapConfigTemplate.json"
 # Images will be placed in the .zip folder under the $packageImageFolderName subfolder
 $script:packageImageFolderName = "Assets"
 
-# New-SubmissionPackage supports these extensions.
-$script:supportedExtensions = ".appx", ".appxbundle", ".appxupload"
+# New-SubmissionPackage supports these extensions, but won't inspect their content due to encryption
+$script:extensionsSupportingInspection = @(".appx", ".appxbundle", ".appxupload")
+$script:extensionsNotSupportingInspection = @('.xvc')
+$script:supportedExtensions =  $script:extensionsSupportingInspection + $script:extensionsNotSupportingInspection
 
 # String constants for New-SubmissionPackage parameters
 $script:s_ConfigPath = "ConfigPath"
@@ -2450,8 +2452,8 @@ function Read-ApplicationMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) $_) { $true }
-            else { throw "$_ cannot be found or is not a supported extension: $($script:supportedExtensions -join ", ")." } })]
+            if (Test-Path -PathType Leaf -Include ($script:extensionsSupportingInspection | ForEach-Object { "*" + $_ }) $_) { $true }
+            else { throw "$_ cannot be found or is not a supported extension that supports metadata inspection: $($script:extensionsSupportingInspection -join ", ")." } })]
         [string] $AppxPath,
 
         [ref] $AppxInfo
@@ -2556,18 +2558,23 @@ function Add-AppPackagesMetadata
             $appxName = Split-Path -Leaf -Path $path
 
             # We always calculate the formatted name, even if we won't use it, in order to
-            # populate $AppxInfo with the additional metadata.
-            $appMetadata =  Read-ApplicationMetadata -AppxPath $path -AppxInfo $AppxInfo
-            if ($EnableAutoPackageNameFormatting)
-            {
-                $appxName = ($appMetadata.formattedFileName + [System.IO.Path]::GetExtension($appxName))
-            }
-
-            # Finalize the properties to be submitted
+            # populate $AppxInfo with the additional metadata, but only if the package is
+            # one that we can inspect.
             $submissionProperties = @{}
-            foreach ($property in $script:applicationMetadataProperties)
+            $packageExtension = [System.IO.Path]::GetExtension($appxName)
+            if ($packageExtension -in $script:extensionsSupportingInspection)
             {
-                $submissionProperties.$property = $appMetadata.$property
+                $appMetadata =  Read-ApplicationMetadata -AppxPath $path -AppxInfo $AppxInfo
+                if ($EnableAutoPackageNameFormatting)
+                {
+                    $appxName = ($appMetadata.formattedFileName + [System.IO.Path]::GetExtension($appxName))
+                }
+
+                # Finalize the properties to be submitted
+                foreach ($property in $script:applicationMetadataProperties)
+                {
+                    $submissionProperties.$property = $appMetadata.$property
+                }
             }
 
             $submissionProperties.fileName              = $appxName
@@ -2579,7 +2586,7 @@ function Add-AppPackagesMetadata
 
             if ($script:tempFolderExists)
             {
-                $destinationPath = Join-Path $script:tempFolderPath $appxName
+                $destinationPath = Join-Path -Path $script:tempFolderPath -ChildPath $appxName
 
                 Write-Log -Message "Copying (Item: $path) to (Target: $destinationPath)" -Level Verbose
                 Copy-Item -Path $path -Destination $destinationPath

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -2657,7 +2657,7 @@ function Remove-DeprecatedProperties
     )
 
     # No side-effects.  We'll work off of a copy of the passed-in object
-    $requestBody = DeepCopy-Object $SubmissionRequestBody
+    $requestBody = DeepCopy-Object -Object $SubmissionRequestBody
 
     # hardwareRequirements was deprecated on 5/13/2016
     # Deprecated due to business reasons.  This field is not exposed from the UI.

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -2765,7 +2765,7 @@ function Get-SubmissionRequestBody
 
     if ($AppxPath.Count -gt 0)
     {
-        $submissionRequestBody | Add-AppPackagesMetadata -PackagePath $PackagePath -AppPackageInfo $AppPackageInfo -EnableAutoPackageNameFormatting:(-not $DisableAutoPackageNameFormatting)
+        $submissionRequestBody | Add-AppPackagesMetadata -PackagePath $AppxPath -AppPackageInfo $AppPackageInfo -EnableAutoPackageNameFormatting:(-not $DisableAutoPackageNameFormatting)
     }
 
     if (-not [String]::IsNullOrWhiteSpace($PDPRootPath))

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -9,7 +9,7 @@ $script:packageImageFolderName = "Assets"
 
 # New-SubmissionPackage supports these extensions, but won't inspect their content due to encryption
 $script:extensionsSupportingInspection = @(".appx", ".appxbundle", ".appxupload")
-$script:extensionsNotSupportingInspection = @('.xvc')
+$script:extensionsNotSupportingInspection = @('.xvc', '.msix', '.msixbundle')
 $script:supportedExtensions =  $script:extensionsSupportingInspection + $script:extensionsNotSupportingInspection
 
 # String constants for New-SubmissionPackage parameters
@@ -198,7 +198,7 @@ function New-StoreBrokerInAppProductConfigFile
     )
 
     $dir = Split-Path -Parent -Path $Path
-    if (-not (Test-Path -PathType Container -Path $dir))
+    if (-not (Test-Path -PathType Container -Path $dir -ErrorAction Ignore))
     {
         Write-Log -Message "Creating directory: $dir" -Level Verbose
         New-Item -Force -ItemType Directory -Path $dir | Out-Null
@@ -426,7 +426,7 @@ function New-StoreBrokerConfigFile
     )
 
     $dir = Split-Path -Parent -Path $Path
-    if (-not (Test-Path -PathType Container -Path $dir))
+    if (-not (Test-Path -PathType Container -Path $dir -ErrorAction Ignore))
     {
         Write-Log -Message "Creating directory: $dir" -Level Verbose
         New-Item -Force -ItemType Directory -Path $dir | Out-Null
@@ -479,14 +479,14 @@ function Out-DirectoryToZip
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "Could not find directory to compress: [$_]." }
         })]
         [string] $Path,
 
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (($_ -like "*.zip") -and (Test-Path -IsValid -Path $_)) { $true }
+            if (($_ -like "*.zip") -and (Test-Path -IsValid -Path $_ -ErrorAction Ignore)) { $true }
             else { throw "Destination path is not a zip file: [$_]." }
         })]
         [string] $Destination
@@ -502,7 +502,7 @@ function Out-DirectoryToZip
             # Delete output paths if they already exist.
             foreach ($zipPath in ($tempLocalZipPath, $Destination))
             {
-                if (Test-Path -PathType Leaf -Include "*.zip" -Path $zipPath)
+                if (Test-Path -PathType Leaf -Include "*.zip" -Path $zipPath -ErrorAction Ignore)
                 {
                     Write-Log -Message "Removing zip path: [$zipPath]." -Level Verbose
                     Remove-Item -Force -Recurse -Path $zipPath
@@ -1248,14 +1248,14 @@ function Get-LocalizedMediaFile
     if (-not [string]::IsNullOrEmpty($MediaFallbackLanguage) -and ($MediaFallbackLanguage -ne $Language))
     {
         $mediaFallbackLanguageSourcePath = [System.IO.Path]::Combine($ImagesRootPath, $Release, $MediaFallbackLanguage)
-        if (-not (Test-Path -Path $mediaFallbackLanguageSourcePath -PathType Container))
+        if (-not (Test-Path -Path $mediaFallbackLanguageSourcePath -PathType Container -ErrorAction Ignore))
         {
             Write-Log -Message "A fallback language was specified [$MediaFallbackLanguage], but a folder for that language does not exist [$mediaFallbackLanguageSourcePath], so media fallback support has been disabled." -Level Warning
             $mediaFallbackLanguageSourcePath = $null
         }
     }
 
-    if (Test-Path -Path $mediaLanguageSourcePath -PathType Container)
+    if (Test-Path -Path $mediaLanguageSourcePath -PathType Container -ErrorAction Ignore)
     {
         $image = Get-ChildItem -Recurse -File -Path $mediaLanguageSourcePath -Include $Filename
         $fileRelativePackagePath = [System.IO.Path]::Combine($script:packageImageFolderName, $Language, $Filename)
@@ -1288,10 +1288,10 @@ function Get-LocalizedMediaFile
     }
 
     $fileFullPackagePath = Join-Path -Path $script:tempFolderPath -ChildPath $fileRelativePackagePath
-    if (-not (Test-Path -PathType Leaf $fileFullPackagePath))
+    if (-not (Test-Path -PathType Leaf $fileFullPackagePath -ErrorAction Ignore))
     {
         $packageMediaFullPath = Split-Path -Path $fileFullPackagePath -Parent
-        if (-not (Test-Path -PathType Container -Path $packageMediaFullPath))
+        if (-not (Test-Path -PathType Container -Path $packageMediaFullPath -ErrorAction Ignore))
         {
             New-Item -ItemType directory -Path $packageMediaFullPath | Out-Null
         }
@@ -1353,7 +1353,7 @@ function Convert-ListingsMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [string] $PDPRootPath,
 
@@ -1374,7 +1374,7 @@ function Convert-ListingsMetadata
 
         [Parameter(Mandatory)]
         [ValidateScript( {
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
@@ -1445,7 +1445,7 @@ function Convert-TrailersMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [string] $PDPRootPath,
 
@@ -1466,7 +1466,7 @@ function Convert-TrailersMetadata
 
         [Parameter(Mandatory)]
         [ValidateScript( {
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
@@ -1747,7 +1747,7 @@ function Convert-InAppProductListingsMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [string] $PDPRootPath,
 
@@ -1768,7 +1768,7 @@ function Convert-InAppProductListingsMetadata
 
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Container -Path $_) { $true }
+            if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true }
             else { throw "'$_' is not a directory or cannot be found." } })]
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
@@ -1833,7 +1833,7 @@ function Open-AppxContainer
         {
             $containerZipPath = $containerZipPathFormat -f [System.Guid]::NewGuid()
         }
-        while (Test-Path -PathType Leaf -Path $containerZipPath)
+        while (Test-Path -PathType Leaf -Path $containerZipPath -ErrorAction Ignore)
 
         Write-Log -Message "Copying (Item: $AppxContainerPath) to (Target: $containerZipPath)." -Level Verbose
         Copy-Item -Force -Path $AppxContainerPath -Destination $containerZipPath
@@ -1850,7 +1850,7 @@ function Open-AppxContainer
     }
     catch
     {
-        if ((-not [System.String]::IsNullOrEmpty($expandedContainerPath)) -and (Test-Path $expandedContainerPath))
+        if ((-not [System.String]::IsNullOrEmpty($expandedContainerPath)) -and (Test-Path -Path $expandedContainerPath -ErrorAction Ignore))
         {
             Write-Log -Message "Deleting item: $expandedContainerPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $expandedContainerPath -ErrorAction SilentlyContinue
@@ -1861,7 +1861,7 @@ function Open-AppxContainer
     }
     finally
     {
-        if ((-not [System.String]::IsNullOrEmpty($containerZipPath)) -and (Test-Path $containerZipPath))
+        if ((-not [System.String]::IsNullOrEmpty($containerZipPath)) -and (Test-Path -Path $containerZipPath -ErrorAction Ignore))
         {
             Write-Log -Message "Deleting item: $containerZipPath" -Level Verbose
             Remove-Item -Force -Recurse -Path $containerZipPath -ErrorAction SilentlyContinue
@@ -1948,7 +1948,7 @@ function Get-TargetPlatform
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "AppxManifest.xml" -Path $_) { $true }
+            if (Test-Path -PathType Leaf -Include "AppxManifest.xml" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an AppxManifest.xml." } })]
         [string] $AppxManifestPath
     )
@@ -2019,7 +2019,7 @@ function Read-AppxMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "*.appx" -Path $_) { $true }
+            if (Test-Path -PathType Leaf -Include "*.appx" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an .appx." } })]
         [string] $AppxPath,
 
@@ -2148,7 +2148,7 @@ function Read-AppxUploadMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "*.appxupload" -Path $_) { $true }
+            if (Test-Path -PathType Leaf -Include "*.appxupload" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an .appxupload." } })]
         [string] $AppxuploadPath,
 
@@ -2243,7 +2243,7 @@ function Read-AppxBundleMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "*.appxbundle" -Path $_) { $true }
+            if (Test-Path -PathType Leaf -Include "*.appxbundle" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an .appxbundle." } })]
         [string] $AppxbundlePath,
 
@@ -2452,7 +2452,7 @@ function Read-ApplicationMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include ($script:extensionsSupportingInspection | ForEach-Object { "*" + $_ }) $_) { $true }
+            if (Test-Path -PathType Leaf -Include ($script:extensionsSupportingInspection | ForEach-Object { "*" + $_ }) -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not a supported extension that supports metadata inspection: $($script:extensionsSupportingInspection -join ", ")." } })]
         [string] $AppxPath,
 
@@ -2526,9 +2526,9 @@ function Add-AppPackagesMetadata
         [ValidateScript({
             foreach ($path in $_)
             {
-                if (-not (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) -Path $path))
+                if (-not (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) -Path $path -ErrorAction Ignore))
                 {
-                    throw "$_ is not a file or cannot be found."
+                    throw "$path cannot be found or is not a supported extension: $($script:supportedExtensions -join ", ")."
                 }
             }
 
@@ -2762,7 +2762,7 @@ function Get-SubmissionRequestBody
         if (-not [System.String]::IsNullOrWhiteSpace($Release))
         {
             $pathWithRelease = Join-Path -Path $PDPRootPath -ChildPath $Release
-            if (Test-Path -PathType Container -Path $pathWithRelease)
+            if (Test-Path -PathType Container -Path $pathWithRelease -ErrorAction Ignore)
             {
                 $listingsPath = $pathWithRelease
             }
@@ -2898,7 +2898,7 @@ function Get-InAppProductSubmissionRequestBody
         if (-not [System.String]::IsNullOrWhiteSpace($Release))
         {
             $pathWithRelease = Join-Path -Path $PDPRootPath -ChildPath $Release
-            if (Test-Path -PathType Container -Path $pathWithRelease)
+            if (Test-Path -PathType Container -Path $pathWithRelease -ErrorAction Ignore)
             {
                 $listingsPath = $pathWithRelease
             }
@@ -3008,7 +3008,7 @@ function Resolve-PackageParameters
             # Resolve path parameters to full paths. Necessary in case a path contains '.' or '..'
             $ParamMap[$param] = Resolve-UnverifiedPath -Path $ParamMap[$param]
 
-            if (-not (Test-Path -PathType Container -Path $ParamMap[$param]))
+            if (-not (Test-Path -PathType Container -Path $ParamMap[$param] -ErrorAction Ignore))
             {
                 $out = "$($param): `"$($ParamMap[$param])`" is not a directory or cannot be found."
 
@@ -3125,7 +3125,7 @@ function Resolve-PackageParameters
             $validExtensions = $script:supportedExtensions | ForEach-Object { "*" + $_ }
             foreach ($path in $ConfigObject.packageParameters.AppxPath)
             {
-                if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path) -and ($path -notin $packagePaths))
+                if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path -ErrorAction Ignore) -and ($path -notin $packagePaths))
                 {
                     $packagePaths += $path
                 }
@@ -3142,11 +3142,11 @@ function Resolve-PackageParameters
                 else
                 {
                     $path = Join-Path $env:TFS_DropLocation $path
-                    if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path) -and ($path -notin $packagePaths))
+                    if ((Test-Path -PathType Leaf -Include $validExtensions -Path $path -ErrorAction Ignore) -and ($path -notin $packagePaths))
                     {
                         $packagePaths += $path
                     }
-                    elseif (Test-Path -PathType Container -Path $path)
+                    elseif (Test-Path -PathType Container -Path $path -ErrorAction Ignore)
                     {
                         $fullPaths = (Get-ChildItem -File -Include $validExtensions -Path (Join-Path $path "*.*")).FullName
                         foreach ($fullPath in $fullPaths)
@@ -3274,7 +3274,7 @@ function Convert-AppConfig
 
     param(
         [Parameter(Mandatory)]
-        [ValidateScript({ if (Test-Path -PathType Leaf $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Leaf -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [string] $ConfigPath
     )
 
@@ -3331,11 +3331,11 @@ function Join-SubmissionPackage
     [CmdletBinding(SupportsShouldProcess=$True)]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
+        [ValidateScript({if (Test-Path -Path $_ -PathType Leaf -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." }})]
         [string] $MasterJsonPath,
 
         [Parameter(Mandatory=$true)]
-        [ValidateScript({if (Test-Path -Path $_ -PathType Leaf) { $true } else { throw "$_ cannot be found." }})]
+        [ValidateScript({if (Test-Path -Path $_ -PathType Leaf -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." }})]
         [string] $AdditionalJsonPath,
 
         [Parameter(Mandatory=$true)]
@@ -3360,14 +3360,14 @@ function Join-SubmissionPackage
     {
         $errorMessage = "[{0}] already exists.  Choose a different name, or specify the -Force switch to overwrite it."
 
-        if (Test-Path -Path $OutJsonPath -PathType Leaf)
+        if (Test-Path -Path $OutJsonPath -PathType Leaf -ErrorAction Ignore)
         {
             $output = $errorMessage -f $OutJsonPath
             Write-Log -Message $output -Level Error
             throw $output
         }
 
-        if (Test-Path -Path $outZipPath -PathType Leaf)
+        if (Test-Path -Path $outZipPath -PathType Leaf -ErrorAction Ignore)
         {
             $output = $errorMessage -f $outZipPath
             Write-Log -Message $output -Level Error
@@ -3380,7 +3380,7 @@ function Join-SubmissionPackage
     # Make sure that these zip files actually exist.
     foreach ($zipFile in ($masterZipPath, $additionalZipPath))
     {
-        if (-not (Test-Path -Path $zipFile -PathType Leaf))
+        if (-not (Test-Path -Path $zipFile -PathType Leaf -ErrorAction Ignore))
         {
             throw "Could not find [$zipFile].  We expect the .json and .zip to have the same base name."
         }
@@ -3435,7 +3435,7 @@ function Join-SubmissionPackage
             if ($package.fileStatus -eq "PendingUpload")
             {
                 $destPath = Join-Path $outUnpackedZipPath $package.fileName
-                if (Test-Path $destPath -PathType Leaf)
+                if (Test-Path -Path $destPath -PathType Leaf -ErrorAction Ignore)
                 {
                     $output = "A package called [$($package.fileName)] already exists in the Master zip file."
                     Write-Log -Message $output -Level Error
@@ -3586,10 +3586,10 @@ function New-SubmissionPackage
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateScript({ if (Test-Path -PathType Leaf $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Leaf -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [string] $ConfigPath,
 
-        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [string] $PDPRootPath,
 
         [string] $Release,
@@ -3600,14 +3600,14 @@ function New-SubmissionPackage
 
         [string[]] $LanguageExclude,
 
-        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
 
         [ValidateScript({
             foreach ($path in $_)
             {
-                if (-not (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) -Path $path))
+                if (-not (Test-Path -PathType Leaf -Include ($script:supportedExtensions | ForEach-Object { "*" + $_ }) -Path $path -ErrorAction Ignore))
                 {
                     throw "$_ cannot be found or is not a supported extension: $($script:supportedExtensions -join ", ")."
                 }
@@ -3677,7 +3677,7 @@ function New-SubmissionPackage
 
         # It may not actually exist due to What-If support.
         $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and
-                                   (Test-Path -PathType Container $script:tempFolderPath)
+                                   (Test-Path -PathType Container -Path $script:tempFolderPath -ErrorAction Ignore)
 
         # Get the submission request object
         $resourceParams = $script:s_PDPRootPath, $script:s_Release, $script:s_PDPInclude, $script:s_PDPExclude, $script:s_LanguageExclude, $script:s_ImagesRootPath, $script:s_AppxPath, $script:s_DisableAutoPackageNameFormatting, $script:s_MediaFallbackLanguage
@@ -3841,10 +3841,10 @@ function New-InAppProductSubmissionPackage
     [Alias('New-IapSubmissionPackage')]
     param(
         [Parameter(Mandatory)]
-        [ValidateScript({ if (Test-Path -PathType Leaf $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Leaf -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [string] $ConfigPath,
 
-        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [string] $PDPRootPath,
 
         [string] $Release,
@@ -3855,7 +3855,7 @@ function New-InAppProductSubmissionPackage
 
         [string[]] $LanguageExclude,
 
-        [ValidateScript({ if (Test-Path -PathType Container $_) { $true } else { throw "$_ cannot be found." } })]
+        [ValidateScript({ if (Test-Path -PathType Container -Path $_ -ErrorAction Ignore) { $true } else { throw "$_ cannot be found." } })]
         [Alias('MediaRootPath')]
         [string] $ImagesRootPath,
 
@@ -3917,7 +3917,7 @@ function New-InAppProductSubmissionPackage
 
         # It may not actually exist due to What-If support.
         $script:tempFolderExists = (-not [System.String]::IsNullOrEmpty($script:tempFolderPath)) -and
-                                   (Test-Path -PathType Container $script:tempFolderPath)
+                                   (Test-Path -PathType Container -Path $script:tempFolderPath -ErrorAction Ignore)
 
         # Get the submission request object
         $resourceParams = $script:s_PDPRootPath, $script:s_Release, $script:s_PDPInclude, $script:s_PDPExclude, $script:s_LanguageExclude, $script:s_ImagesRootPath, $script:s_MediaFallbackLanguage

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -8,8 +8,8 @@ $script:defaultIapConfigFileName = "IapConfigTemplate.json"
 $script:packageImageFolderName = "Assets"
 
 # New-SubmissionPackage supports these extensions, but won't inspect their content due to encryption
-$script:extensionsSupportingInspection = @(".appx", ".appxbundle", ".appxupload")
-$script:extensionsNotSupportingInspection = @('.xvc', '.msix', '.msixbundle', '.msixupload')
+$script:extensionsSupportingInspection = @(".appx", ".appxbundle", ".appxupload", ".msix", ".msixbundle", ".msixupload")
+$script:extensionsNotSupportingInspection = @('.xvc')
 $script:supportedExtensions =  $script:extensionsSupportingInspection + $script:extensionsNotSupportingInspection
 
 # String constants for New-SubmissionPackage parameters
@@ -1789,26 +1789,26 @@ function Convert-InAppProductListingsMetadata
     return $listings
 }
 
-function Open-AppxContainer
+function Open-AppPackageContainer
 {
 <#
     .SYNOPSIS
-        Given a path to a .appxbundle, .appxupload, or .appx file, unzips that file to a directory
+        Given a path to a .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix file, unzips that file to a directory
         and returns that directory path.
 
-    .PARAMETER AppxContainerPath
-        Full path to the .appxbundle, .appxupload, or .appx file.
+    .PARAMETER AppPackageContainerPath
+        Full path to the .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix file.
 
     .OUTPUTS
         System.String.  Full path to the unzipped directory.
 
     .EXAMPLE
-        Open-AppxContainer "C:\path\App.appxbundle"
+        Open-AppPackageContainer "C:\path\App.appxbundle"
 
         Unzips contents of App.appxbundle to <env:Temp>\<guid>\App\ and returns that path.
 
     .EXAMPLE
-        Open-AppxContainer "C:\path\App.appxupload"
+        Open-AppPackageContainer "C:\path\App.appxupload"
 
         Same as Example 1 only with a .appxupload file.
 
@@ -1818,15 +1818,15 @@ function Open-AppxContainer
 #>
     param(
         [Parameter(Mandatory)]
-        [string] $AppxContainerPath
+        [string] $AppPackageContainerPath
     )
 
     try
     {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
 
-        # .appxcontainer can be either .appxbundle, .appxupload, or .appx
-        # Copy CONTAINER.appxcontainer to tempFolderPath\GUID.zip
+        # .apppackagecontainer can be either .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix
+        # Copy CONTAINER.apppackagecontainer to tempFolderPath\GUID.zip
         $containerZipPathFormat = Join-Path $env:TEMP '{0}.zip'
 
         do
@@ -1835,11 +1835,11 @@ function Open-AppxContainer
         }
         while (Test-Path -PathType Leaf -Path $containerZipPath -ErrorAction Ignore)
 
-        Write-Log -Message "Copying (Item: $AppxContainerPath) to (Target: $containerZipPath)." -Level Verbose
-        Copy-Item -Force -Path $AppxContainerPath -Destination $containerZipPath
+        Write-Log -Message "Copying (Item: $AppPackageContainerPath) to (Target: $containerZipPath)." -Level Verbose
+        Copy-Item -Force -Path $AppPackageContainerPath -Destination $containerZipPath
         Write-Log -Message "Copy complete." -Level Verbose
 
-        # Expand CONTAINER.appxcontainer.zip to CONTAINER folder
+        # Expand CONTAINER.apppackagecontainer.zip to CONTAINER folder
         $expandedContainerPath = New-TemporaryDirectory
 
         Write-Log -Message "Unzipping archive (Item: $containerZipPath) to (Target: $expandedContainerPath)." -Level Verbose
@@ -1934,14 +1934,14 @@ function Get-TargetPlatform
 
         Returns one of "Windows10", "Windows81", "Windows80", "WindowsPhone81", or $null
 
-    .PARAMETER AppxManifestPath
+    .PARAMETER AppPackageManifestPath
         A path to the AppxManifest.xml file to be processed.
 
     .OUTPUTS
         String    A string identifying the target platform, or $null if it could not be identified.
 
     .EXAMPLE
-        Get-TargetPlatform -AppxManifestPath "C:\package\AppxManifest.xml"
+        Get-TargetPlatform -AppPackageManifestPath "C:\package\AppxManifest.xml"
 
         Indentifies the target platform for the given AppxManifest.xml
 #>
@@ -1950,10 +1950,10 @@ function Get-TargetPlatform
         [ValidateScript({
             if (Test-Path -PathType Leaf -Include "AppxManifest.xml" -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not an AppxManifest.xml." } })]
-        [string] $AppxManifestPath
+        [string] $AppPackageManifestPath
     )
 
-    $manifest = [xml] (Get-Content -Path $AppxManifestPath -Encoding UTF8)
+    $manifest = [xml] (Get-Content -Path $AppPackageManifestPath -Encoding UTF8)
     $root = $manifest.DocumentElement
     if ($root.xmlns -match "^http://schemas.microsoft.com/appx/manifest/(.*/)?windows10(/.*)?$")
     {
@@ -1963,7 +1963,7 @@ function Get-TargetPlatform
     $minOSVersion = $root.Prerequisites.OSMinVersion
     if ([String]::IsNullOrEmpty($minOSVersion))
     {
-        Write-Log -Message "Could not find OSMinVersion in [$AppxManifestPath]" -Level Warning
+        Write-Log -Message "Could not find OSMinVersion in [$AppPackageManifestPath]" -Level Warning
         return $null
     }
 
@@ -1985,14 +1985,14 @@ function Get-TargetPlatform
     return $targetPlatform
 }
 
-function Read-AppxMetadata
+function Read-AppPackageMetadata
 {
 <#
     .SYNOPSIS
-        Reads various metadata properties about the input .appx file.
+        Reads various metadata properties about the input .appx or .msix file.
 
     .DESCRIPTION
-        Reads various metadata properties about the input .appx file.
+        Reads various metadata properties about the input .appx or .msix file.
 
         The metadata read is "version", "architecture", "targetPlatform", "languages",
         "capabilities", "targetDeviceFamilies", "targetDeviceFamiliesEx"
@@ -2000,10 +2000,10 @@ function Read-AppxMetadata
         part of the Store submission; some metadata is used as part of an app flighting
         workflow.
 
-    .PARAMETER AppxPath
-        A path to the .appx file to be processed.
+    .PARAMETER AppPackagePath
+        A path to the .appx or .msix file to be processed.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
@@ -2011,40 +2011,45 @@ function Read-AppxMetadata
         Hasthable    A hashtable containing the various metadata values.
 
     .EXAMPLE
-        Read-AppxMetadata -AppxPath ".\my.appx" -AppxInfo ([ref] @())
+        Read-AppPackageMetadata -AppPackagePath ".\my.appx" -AppPackageInfo ([ref] @())
 
         Returns a hashtable containing metadata about the .appx file.
+
+    .EXAMPLE
+        Read-AppPackageMetadata -AppPackagePath ".\my.msix" -AppPackageInfo ([ref] @())
+
+        Returns a hashtable containing metadata about the .msix file.
 #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "*.appx" -Path $_ -ErrorAction Ignore) { $true }
-            else { throw "$_ cannot be found or is not an .appx." } })]
-        [string] $AppxPath,
+            if (Test-Path -PathType Leaf -Include ("*.appx", "*.msix") -Path $_ -ErrorAction Ignore) { $true }
+            else { throw "$_ cannot be found or is not an .appx nor .msix." } })]
+        [string] $AppPackagePath,
 
-        [ref] $AppxInfo
+        [ref] $AppPackageInfo
     )
 
     $metadata = New-ApplicationMetadataTable
 
     try
     {
-        $expandedAppxPath = Open-AppxContainer -AppxContainerPath $AppxPath
+        $expandedAppPackagePath = Open-AppPackageContainer -AppPackageContainerPath $AppPackagePath
 
-        # Get AppxManifest.xml under the appx root.
-        $appxManifest = Join-Path -Path $expandedAppxPath -ChildPath 'AppxManifest.xml' |
+        # Get AppxManifest.xml under the appx or msix root.
+        $appPackageManifest = Join-Path -Path $expandedAppPackagePath -ChildPath 'AppxManifest.xml' |
             Get-Item -ErrorAction Ignore |
             Select-Object -ExpandProperty FullName
 
-        if ($null -eq $appxManifest)
+        if ($null -eq $appPackageManifest)
         {
-            Report-UnsupportedFile -Path $AppxPath
-            throw "`"$AppxPath`" is not a proper .appx. Could not find an AppxManifest.xml."
+            Report-UnsupportedFile -Path $AppPackagePath
+            throw "`"$AppPackagePath`" is not a proper .appx nor .msix. Could not find an AppxManifest.xml."
         }
 
-        Write-Log -Message "Opening `"$appxManifest`"." -Level Verbose
-        $manifest = [xml] (Get-Content -Path $appxManifest -Encoding UTF8)
+        Write-Log -Message "Opening `"$appPackageManifest`"." -Level Verbose
+        $manifest = [xml] (Get-Content -Path $appPackageManifest -Encoding UTF8)
 
 
         # Processing
@@ -2056,7 +2061,7 @@ function Read-AppxMetadata
             $metadata.architecture = "neutral"
         }
 
-        $metadata.targetPlatform = Get-TargetPlatform -AppxManifestPath $appxManifest
+        $metadata.targetPlatform = Get-TargetPlatform -AppPackageManifestPath $appPackageManifest
         $metadata.name           = $manifest.Package.Identity.Name -creplace '^Microsoft\.', ''
 
         $metadata.languages = @()
@@ -2082,23 +2087,23 @@ function Read-AppxMetadata
             $metadata.targetDeviceFamilies += ($script:minVersionFormatString -f $family.Name, $family.minOSVersion)
         }
 
-        # A single .appx will never have an inner package, but we will still set this property to
+        # A single .appx or .msix will never have an inner package, but we will still set this property to
         # an empty hashtable so that the value is never $null when translated to JSON
         $metadata.innerPackages = @{}
 
         # Track the info about this package for later processing.
-        $singleAppxInfo = @{}
-        $singleAppxInfo[[StoreBrokerTelemetryProperty]::AppxVersion] = $metadata.version
-        $singleAppxInfo[[StoreBrokerTelemetryProperty]::AppName] = $metadata.name
+        $singleAppPackageInfo = @{}
+        $singleAppPackageInfo[[StoreBrokerTelemetryProperty]::AppxVersion] = $metadata.version
+        $singleAppPackageInfo[[StoreBrokerTelemetryProperty]::AppName] = $metadata.name
 
-        $AppxInfo.Value += $singleAppxInfo
+        $AppPackageInfo.Value += $singleAppPackageInfo
     }
     finally
     {
-        if (-not [String]::IsNullOrWhiteSpace($expandedAppxPath))
+        if (-not [String]::IsNullOrWhiteSpace($expandedAppPackagePath))
         {
-            Write-Log -Message "Deleting item: $expandedAppxPath" -Level Verbose
-            Remove-Item -Force -Recurse -Path $expandedAppxPath -ErrorAction SilentlyContinue | Out-Null
+            Write-Log -Message "Deleting item: $expandedAppPackagePath" -Level Verbose
+            Remove-Item -Force -Recurse -Path $expandedAppPackagePath -ErrorAction SilentlyContinue | Out-Null
             Write-Log -Message "Deletion complete." -Level Verbose
         }
     }
@@ -2106,14 +2111,14 @@ function Read-AppxMetadata
     return $metadata
 }
 
-function Read-AppxUploadMetadata
+function Read-AppPackageUploadMetadata
 {
 <#
     .SYNOPSIS
-        Reads various metadata properties about the input .appxupload.
+        Reads various metadata properties about the input .appxupload or .msixupload.
 
     .DESCRIPTION
-        Reads various metadata properties about the input .appxupload.
+        Reads various metadata properties about the input .appxupload or .msixupload.
 
         The metadata read is "version", "architecture", "targetPlatform", "languages",
         "capabilities", "targetDeviceFamilies", "targetDeviceFamiliesEx"
@@ -2121,14 +2126,14 @@ function Read-AppxUploadMetadata
         part of the Store submission; some metadata is used as part of an app flighting
         workflow.
 
-        As part of processing the .appxupload, the file is opened to read metadata from
-        the inner .appx or .appxbundle file.  There must be exactly one inner .appx
-        or .appxbundle.
+        As part of processing the .appxupload/.msixupload, the file is opened to read metadata from
+        the inner .appx/.msix or .appxbundle/.msixbundle file.  There must be exactly one inner .appx/.msix
+        or .appxbundle/.msixbundle.
 
-    .PARAMETER AppxuploadPath
-        A path to the .appxupload to be processed.
+    .PARAMETER AppPackageUploadPath
+        A path to the .appxupload/.msixupload to be processed.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
@@ -2136,9 +2141,14 @@ function Read-AppxUploadMetadata
         Hasthable    A hashtable containing the various metadata values.
 
     .EXAMPLE
-        Read-AppxUploadMetadata -AppxbundlePath ".\my.appxupload" -AppxInfo ([ref] @())
+        Read-AppPackageUploadMetadata -AppPackageUploadPath ".\my.appxupload" -AppPackageInfo ([ref] @())
 
         Returns a hashtable containing metadata about the inner .appx file.
+
+    .EXAMPLE
+        Read-AppPackageUploadMetadata -AppPackageUploadPath ".\my.msixupload" -AppPackageInfo ([ref] @())
+
+        Returns a hashtable containing metadata about the inner .msix file.
 
     .NOTES
         An .appxupload file is just a .zip containing an .appxsym file and a
@@ -2148,50 +2158,50 @@ function Read-AppxUploadMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "*.appxupload" -Path $_ -ErrorAction Ignore) { $true }
-            else { throw "$_ cannot be found or is not an .appxupload." } })]
-        [string] $AppxuploadPath,
+            if (Test-Path -PathType Leaf -Include ("*.appxupload", "*.msixupload") -Path $_ -ErrorAction Ignore) { $true }
+            else { throw "$_ cannot be found or is not an .appxupload nor .msixupload." } })]
+        [string] $AppPackageUploadPath,
 
-        [ref] $AppxInfo
+        [ref] $AppPackageInfo
     )
 
     try
     {
-        $throwFormat = "`"$AppxuploadPath`" is not a proper .appxupload. There must be exactly one {0} inside the file."
+        $throwFormat = "`"$AppPackageUploadPath`" is not a proper .appxupload nor .msixupload. There must be exactly one {0} inside the file."
 
-        Write-Log -Message "Opening `"$AppxuploadPath`"." -Level Verbose
-        $expandedContainerPath = Open-AppxContainer -AppxContainerPath $AppxPath
+        Write-Log -Message "Opening `"$AppPackageUploadPath`"." -Level Verbose
+        $expandedContainerPath = Open-AppPackageContainer -AppPackageContainerPath $AppPackageUploadPath
 
-        $appxFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include "*.appx").FullName
-        if ($null -ne $appxFilePath)
+        $appPackageFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include ("*.appx", "*.msix")).FullName
+        if ($null -ne $appPackageFilePath)
         {
-            if ($appxFilePath.Count -ne 1)
+            if ($appPackageFilePath.Count -ne 1)
             {
-                Report-UnsupportedFile -Path $AppxuploadPath
+                Report-UnsupportedFile -Path $AppPackageUploadPath
 
-                $error = $throwFormat -f ".appx"
-                Write-Log -Message $error -Level Error
-                throw $error
+                $out = $throwFormat -f ".appx or .msix"
+                Write-Log -Message $out -Level Error
+                throw $out
             }
             else
             {
-                return Read-AppxMetadata -AppxPath $appxFilePath -AppxInfo $AppxInfo
+                return Read-AppPackageMetadata -AppPackagePath $appPackageFilePath -AppPackageInfo $AppPackageInfo
             }
         }
 
         # Could not find an .appx inside. Maybe there is an .appxbundle.
-        $appxbundleFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include "*.appxbundle").FullName
-        if (($null -eq $appxbundleFilePath) -or ($appxbundleFilePath.Count -ne 1))
+        $appPackageBundleFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include ("*.appxbundle", "*.msixbundle")).FullName
+        if (($null -eq $appPackageBundleFilePath) -or (1 -ne $appPackageBundleFilePath.Count))
         {
-            Report-UnsupportedFile -Path $AppxuploadPath
+            Report-UnsupportedFile -Path $AppPackageUploadPath
 
-            $error = $throwFormat -f ".appx or .appxbundle"
-            Write-Log -Message $error -Level Error
-            throw $error
+            $out = $throwFormat -f ".appx, .appxbundle, .msix, or .msixbundle"
+            Write-Log -Message $out -Level Error
+            throw $out
         }
         else
         {
-            return Read-AppxBundleMetadata -AppxbundlePath $appxbundleFilePath -AppxInfo $AppxInfo
+            return Read-AppPackageBundleMetadata -AppPackagebundlePath $appPackageBundleFilePath -AppPackageInfo $AppPackageInfo
         }
     }
     finally
@@ -2205,14 +2215,14 @@ function Read-AppxUploadMetadata
     }
 }
 
-function Read-AppxBundleMetadata
+function Read-AppPackageBundleMetadata
 {
 <#
     .SYNOPSIS
-        Reads various metadata properties about the input .appxbundle.
+        Reads various metadata properties about the input .appxbundle or .msixbundle.
 
     .DESCRIPTION
-        Reads various metadata properties about the input .appxbundle.
+        Reads various metadata properties about the input .appxbundle or .msixbundle.
 
         The metadata read is "version", "architecture", "targetPlatform", "languages",
         "capabilities", "targetDeviceFamilies", "targetDeviceFamiliesEx"
@@ -2220,13 +2230,13 @@ function Read-AppxBundleMetadata
         part of the Store submission; some metadata is used as part of an app flighting
         workflow.
 
-        As part of processing the .appxbundle, the file is opened to read metadata from
-        the inner .appx files.
+        As part of processing the .appxbundle/.msixbundle, the file is opened to read metadata from
+        the inner .appx/.msix files.
 
-    .PARAMETER AppxbundlePath
-        A path to the .appxbundle to be processed.
+    .PARAMETER AppPackageBundlePath
+        A path to the .appxbundle/.msixbundle to be processed.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
@@ -2234,7 +2244,7 @@ function Read-AppxBundleMetadata
         Hasthable    A hashtable containing the various metadata values.
 
     .EXAMPLE
-        Read-AppxBundleMetadata -AppxbundlePath ".\my.appxbundle" -AppxInfo ([ref] @())
+        Read-AppPackageBundleMetadata -AppPackageBundlePath ".\my.appxbundle" -AppPackageInfo ([ref] @())
 
         Returns a hashtable containing metadata about the .appxbundle and .appx files inside
         that bundle.
@@ -2243,18 +2253,18 @@ function Read-AppxBundleMetadata
     param(
         [Parameter(Mandatory)]
         [ValidateScript({
-            if (Test-Path -PathType Leaf -Include "*.appxbundle" -Path $_ -ErrorAction Ignore) { $true }
-            else { throw "$_ cannot be found or is not an .appxbundle." } })]
-        [string] $AppxbundlePath,
+            if (Test-Path -PathType Leaf -Include ("*.appxbundle", "*.msixbundle") -Path $_ -ErrorAction Ignore) { $true }
+            else { throw "$_ cannot be found or is not an .appxbundle or .msixbundle." } })]
+        [string] $AppPackageBundlePath,
 
-        [ref] $AppxInfo
+        [ref] $AppPackageInfo
     )
 
     $metadata = New-ApplicationMetadataTable
 
     try
     {
-        $expandedContainerPath = Open-AppxContainer -AppxContainerPath $AppxbundlePath
+        $expandedContainerPath = Open-AppPackageContainer -AppPackageContainerPath $AppPackageBundlePath
 
         # Get AppxBundleManifest.xml under the AppxMetadata folder.
         $bundleManifestPath = Join-Path -Path $expandedContainerPath -ChildPath 'AppxMetadata\AppxBundleManifest.xml' |
@@ -2263,8 +2273,8 @@ function Read-AppxBundleMetadata
 
         if ($null -eq $bundleManifestPath)
         {
-            Report-UnsupportedFile -Path $AppxbundlePath
-            throw "`"$AppxbundlePath`" is not a proper .appxbundle. Could not find an AppxBundleManifest.xml."
+            Report-UnsupportedFile -Path $AppPackageBundlePath
+            throw "`"$AppPackageBundlePath`" is not a proper .appxbundle nor .msixbundle. Could not find an AppxBundleManifest.xml."
         }
 
         Write-Log -Message "Opening `"$bundleManifestPath`"." -Level Verbose
@@ -2296,23 +2306,24 @@ function Read-AppxBundleMetadata
         $applications = ($manifest.Bundle.Packages.ChildNodes | Where-Object Type -like "application").FileName
         foreach ($application in $applications)
         {
-            $appxFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include $application).FullName
-            $appxMetadata = Read-AppxMetadata -AppxPath $appxFilePath -AppxInfo $AppxInfo
+            $appPackageFilePath = (Get-ChildItem -Recurse -Path $expandedContainerPath -Include $application).FullName
+            Write-Log -Message "Opening `"$appPackageFilePath`"." -Indent 2 -Level Verbose
+            $appPackageMetadata = Read-AppPackageMetadata -AppPackagePath $appPackageFilePath -AppPackageInfo $AppPackageInfo
 
             # targetPlatform will always be the values of the last .appx processed.
-            $metadata.targetPlatform  = $appxMetadata.targetPlatform
+            $metadata.targetPlatform  = $appPackageMetadata.targetPlatform
 
-            $capabilities            += $appxMetadata.capabilities
-            $targetDeviceFamilies    += $appxMetadata.targetDeviceFamilies
-            $targetDeviceFamiliesEx  += $appxMetadata.targetDeviceFamiliesEx
+            $capabilities            += $appPackageMetadata.capabilities
+            $targetDeviceFamilies    += $appPackageMetadata.targetDeviceFamilies
+            $targetDeviceFamiliesEx  += $appPackageMetadata.targetDeviceFamiliesEx
 
-            $metadata.innerPackages.$($appxMetadata.architecture) = @{
-                version                = $appxMetadata.version;
-                targetDeviceFamiliesEx = $appxMetadata.targetDeviceFamiliesEx
-                targetDeviceFamilies   = $appxMetadata.targetDeviceFamiliesEx | ForEach-Object { $script:minVersionFormatString -f $_.name, $_.minOSVersion }
-                languages              = $appxMetadata.languages;
-                capabilities           = $appxMetadata.capabilities;
-                targetPlatform         = $appxMetadata.targetPlatform;
+            $metadata.innerPackages.$($appPackageMetadata.architecture) = @{
+                version                = $appPackageMetadata.version;
+                targetDeviceFamiliesEx = $appPackageMetadata.targetDeviceFamiliesEx
+                targetDeviceFamilies   = $appPackageMetadata.targetDeviceFamiliesEx | ForEach-Object { $script:minVersionFormatString -f $_.name, $_.minOSVersion }
+                languages              = $appPackageMetadata.languages;
+                capabilities           = $appPackageMetadata.capabilities;
+                targetPlatform         = $appPackageMetadata.targetPlatform;
             }
         }
 
@@ -2346,21 +2357,21 @@ function Get-FormattedFilename
 <#
     .SYNOPSIS
         Gets the ManifestType_AppName_Version_Architecture formatted filename for the
-        specified .appxbundle, .appxupload, or .appx.
+        specified .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix.
 
     .DESCRIPTION
         Gets the ManifestType_AppName_Version_Architecture formatted filename for the
-        specified .appxbundle, .appxupload, or .appx.
+        specified .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix.
 
-        ManifestType is specified by each .appx and includes "Desktop", "Mobile", "Universal", "Team".
+        ManifestType is specified by each .appx/.msix and includes "Desktop", "Mobile", "Universal", "Team".
         AppName is specified in the Identity element of the AppxManifest.xml file.
         Version is specified in the Identity element of the AppxManifest.xml file.
         Architecture is specified in the Identity element of the AppxManifest.xml file.
 
     .PARAMETER Metadata
         A hashtable with "targetDeviceFamiliesEx", "name", "version", and "architecture".
-        If the metadata table corresponds to an .appxbundle, there will likely be an "innerPackages"
-        value with metadata from the inner .appx files.
+        If the metadata table corresponds to an .appxbundle or .msixbundle, there will likely be an "innerPackages"
+        value with metadata from the inner .appx or .msix files.
 
     .OUTPUTS
         System.String. The ManifestType_AppName_Version_Architecture string.
@@ -2391,7 +2402,7 @@ function Get-FormattedFilename
     $version = $Metadata.version
     if ($Metadata.innerPackages.Count -gt 0)
     {
-        # For .appxbundle packages, we will use the architectures from the individual .appx files.
+        # For .appxbundle/.msixbundle packages, we will use the architectures from the individual .appx/.msix files.
         # The Keys of the innerPackages object are the supported architectures.
         $architectureTag = ($Metadata.innerPackages.Keys | Sort-Object) -join '.'
 
@@ -2417,10 +2428,10 @@ function Read-ApplicationMetadata
 {
 <#
     .SYNOPSIS
-        Reads metadata used for submission of an .appx, .appxbundle, or appxupload.
+        Reads metadata used for submission of an .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix.
 
     .DESCRIPTION
-        Reads metadata used for submission of an .appx, .appxbundle, or appxupload.
+        Reads metadata used for submission of an .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix.
 
         The metadata read is "version", "architecture", "targetPlatform", "languages",
         "capabilities", "targetDeviceFamilies", "targetDeviceFamiliesEx",
@@ -2432,17 +2443,23 @@ function Read-ApplicationMetadata
         formatted name for the input package when it is stored in the StoreBroker .zip
         output.
 
-    .PARAMETER AppxPath
-        The path to the .appx, .appxbundle, or .appxupload to process.
+    .PARAMETER AppPackagePath
+        The path to the .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix to process.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
     .EXAMPLE
-        Read-ApplicationMetadata -AppxPath ".\my.appxbundle" -AppxInfo ([ref] @())
+        Read-ApplicationMetadata -AppPackagePath ".\my.appxbundle" -AppPackageInfo ([ref] @())
 
         Returns a hashtable containing metadata about the .appxbundle and .appx files inside
+        that bundle.
+
+    .EXAMPLE
+        Read-ApplicationMetadata -AppPackagePath ".\my.msixbundle" -AppPackageInfo ([ref] @())
+
+        Returns a hashtable containing metadata about the .msixbundle and .msix files inside
         that bundle.
 
     .OUTPUTS
@@ -2454,29 +2471,29 @@ function Read-ApplicationMetadata
         [ValidateScript({
             if (Test-Path -PathType Leaf -Include ($script:extensionsSupportingInspection | ForEach-Object { "*" + $_ }) -Path $_ -ErrorAction Ignore) { $true }
             else { throw "$_ cannot be found or is not a supported extension that supports metadata inspection: $($script:extensionsSupportingInspection -join ", ")." } })]
-        [string] $AppxPath,
+        [string] $AppPackagePath,
 
-        [ref] $AppxInfo
+        [ref] $AppPackageInfo
     )
 
-    if ($PSCmdlet.ShouldProcess($AppxPath))
+    if ($PSCmdlet.ShouldProcess($AppPackagePath))
     {
         $metadata = $null
-        switch ([System.IO.Path]::GetExtension($AppxPath))
+        switch -Regex ([System.IO.Path]::GetExtension($AppPackagePath))
         {
-            ".appxbundle"
+            "^\.(appx|msix)bundle$"
             {
-                $metadata = Read-AppxBundleMetadata -AppxbundlePath $AppxPath -AppxInfo $AppxInfo
+                $metadata = Read-AppPackageBundleMetadata -AppPackageBundlePath $AppPackagePath -AppPackageInfo $AppPackageInfo
             }
 
-            ".appxupload"
+            "^\.(appx|msix)upload$"
             {
-                $metadata = Read-AppxUploadMetadata -AppxuploadPath $AppxPath -AppxInfo $AppxInfo
+                $metadata = Read-AppPackageUploadMetadata -AppPackageUploadPath $AppPackagePath -AppPackageInfo $AppPackageInfo
             }
 
-            ".appx"
+            "^\.(appx|msix)$"
             {
-                $metadata = Read-AppxMetadata -AppxPath $AppxPath -AppxInfo $AppxInfo
+                $metadata = Read-AppPackageMetadata -AppPackagePath $AppPackagePath -AppPackageInfo $AppPackageInfo
             }
         }
 
@@ -2491,17 +2508,17 @@ function Add-AppPackagesMetadata
 <#
     .SYNOPSIS
         Adds a property to the SubmissionObject with metadata about the
-        various .appxbundle, .appxupload, or .appx files being submitted.
+        various .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix files being submitted.
 
-    .PARAMETER AppxPath
-        Array of full paths to the .appxbundle, .appxupload, or .appx
+    .PARAMETER PackagePath
+        Array of full paths to the .appxbundle, .appxupload, .appx, .msixbundle, .msixupload, or .msix
         files that will be uploaded as the new submission.
 
     .PARAMETER SubmissionObject
         A PSCustomObj representing the application submission request body.  This function
-        will add a property to this object with metadata about the .appx files being uploaded.
+        will add a property to this object with metadata about the .appx/.msix files being uploaded.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
@@ -2510,12 +2527,12 @@ function Add-AppPackagesMetadata
         embeds the application name, version, as well as targeted platform and architecture.
 
     .EXAMPLE
-        Add-AppPackagesMetadata -AppxPath "C:\App.appxbundle" -SubmissionObject $object
+        Add-AppPackagesMetadata -PackagePath "C:\App.appxbundle" -SubmissionObject $object
 
         Adds metadata about "C:\App.appxbundle" to the $object object.
 
     .EXAMPLE
-        $object | Add-AppPackagesMetadata -AppxPath "C:\x86\App_x86.appxbundle"
+        $object | Add-AppPackagesMetadata -PackagePath "C:\x86\App_x86.appxbundle"
 
         Same as Example 1 except the $object object is piped in to the function and the appxbundle
         used is for x86 architecture.
@@ -2534,40 +2551,40 @@ function Add-AppPackagesMetadata
 
             return $true
         })]
-        [string[]] $AppxPath,
+        [string[]] $PackagePath,
 
         [Parameter(
             Mandatory,
             ValueFromPipeline)]
         [PSCustomObject] $SubmissionObject,
 
-        [ref] $AppxInfo,
+        [ref] $AppPackageInfo,
 
         [switch] $EnableAutoPackageNameFormatting
     )
 
     $SubmissionObject | Add-Member -MemberType NoteProperty -Name "applicationPackages" -Value ([System.Array]::CreateInstance([Object], 0))
 
-    foreach ($path in $AppxPath)
+    foreach ($path in $PackagePath)
     {
         if ($PSCmdlet.ShouldProcess($path))
         {
 
             Write-Log -Message "Processing [$path]" -Level Verbose
 
-            $appxName = Split-Path -Leaf -Path $path
+            $appPackageName = Split-Path -Leaf -Path $path
 
             # We always calculate the formatted name, even if we won't use it, in order to
             # populate $AppxInfo with the additional metadata, but only if the package is
             # one that we can inspect.
             $submissionProperties = @{}
-            $packageExtension = [System.IO.Path]::GetExtension($appxName)
+            $packageExtension = [System.IO.Path]::GetExtension($appPackageName)
             if ($packageExtension -in $script:extensionsSupportingInspection)
             {
-                $appMetadata =  Read-ApplicationMetadata -AppxPath $path -AppxInfo $AppxInfo
+                $appMetadata =  Read-ApplicationMetadata -AppPackagePath $path -AppPackageInfo $AppPackageInfo
                 if ($EnableAutoPackageNameFormatting)
                 {
-                    $appxName = ($appMetadata.formattedFileName + [System.IO.Path]::GetExtension($appxName))
+                    $appPackageName = ($appMetadata.formattedFileName + [System.IO.Path]::GetExtension($appPackageName))
                 }
 
                 # Finalize the properties to be submitted
@@ -2577,7 +2594,7 @@ function Add-AppPackagesMetadata
                 }
             }
 
-            $submissionProperties.fileName              = $appxName
+            $submissionProperties.fileName              = $appPackageName
             $submissionProperties.fileStatus            = "PendingUpload"
             $submissionProperties.minimumDirectXVersion = "None"
             $submissionProperties.minimumSystemRam      = "None"
@@ -2586,7 +2603,7 @@ function Add-AppPackagesMetadata
 
             if ($script:tempFolderExists)
             {
-                $destinationPath = Join-Path -Path $script:tempFolderPath -ChildPath $appxName
+                $destinationPath = Join-Path -Path $script:tempFolderPath -ChildPath $appPackageName
 
                 Write-Log -Message "Copying (Item: $path) to (Target: $destinationPath)" -Level Verbose
                 Copy-Item -Path $path -Destination $destinationPath
@@ -2645,7 +2662,7 @@ function Get-SubmissionRequestBody
         Creates a PSCustomObject representing the JSON that will be sent with an
         application submission request.  Some property values are taken from the
         config file, some are given static values, some depend on the arch-specific
-        .appx files being submitted, and some are retrieved from localized metadata.
+        .appx/.msix files being submitted, and some are retrieved from localized metadata.
 
     .PARAMETER ConfigObj
         A PSCustomObject representing this tool's configuration file.  Some values of the
@@ -2677,7 +2694,7 @@ function Get-SubmissionRequestBody
     .PARAMETER AppxPath
         A list of file paths to be included in the package.
 
-    .PARAMETER AppxInfo
+    .PARAMETER AppPackageInfo
         If provided, will be updated to maintain information about the app being packaged
         (like AppName and Version) if the information can be determined.
 
@@ -2736,7 +2753,7 @@ function Get-SubmissionRequestBody
 
         [string[]] $AppxPath,
 
-        [ref] $AppxInfo,
+        [ref] $AppPackageInfo,
 
         [switch] $DisableAutoPackageNameFormatting,
 
@@ -2748,7 +2765,7 @@ function Get-SubmissionRequestBody
 
     if ($AppxPath.Count -gt 0)
     {
-        $submissionRequestBody | Add-AppPackagesMetadata -AppxPath $AppxPath -AppxInfo $AppxInfo -EnableAutoPackageNameFormatting:(-not $DisableAutoPackageNameFormatting)
+        $submissionRequestBody | Add-AppPackagesMetadata -PackagePath $PackagePath -AppPackageInfo $AppPackageInfo -EnableAutoPackageNameFormatting:(-not $DisableAutoPackageNameFormatting)
     }
 
     if (-not [String]::IsNullOrWhiteSpace($PDPRootPath))
@@ -3687,8 +3704,8 @@ function New-SubmissionPackage
         $params = Get-Variable -Name $resourceParams -ErrorAction SilentlyContinue |
                   ForEach-Object { $m = @{} } { $m[$_.Name] = $_.Value } { $m } # foreach begin{} process{} end{}
 
-        $AppxInfo = @()
-        $submissionBody = Get-SubmissionRequestBody -ConfigObject $config -AppxInfo ([ref]$AppxInfo) @params
+        $AppPackageInfo = @()
+        $submissionBody = Get-SubmissionRequestBody -ConfigObject $config -AppPackageInfo ([ref]$AppPackageInfo) @params
 
         Write-SubmissionRequestBody -JsonObject $submissionBody -OutFilePath (Join-Path $OutPath ($OutName + '.json'))
 

--- a/StoreBroker/PackageTool.ps1
+++ b/StoreBroker/PackageTool.ps1
@@ -9,7 +9,7 @@ $script:packageImageFolderName = "Assets"
 
 # New-SubmissionPackage supports these extensions, but won't inspect their content due to encryption
 $script:extensionsSupportingInspection = @(".appx", ".appxbundle", ".appxupload")
-$script:extensionsNotSupportingInspection = @('.xvc', '.msix', '.msixbundle')
+$script:extensionsNotSupportingInspection = @('.xvc', '.msix', '.msixbundle', '.msixupload')
 $script:supportedExtensions =  $script:extensionsSupportingInspection + $script:extensionsNotSupportingInspection
 
 # String constants for New-SubmissionPackage parameters

--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.20.1'
+    ModuleVersion = '1.21.0'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'


### PR DESCRIPTION
Adds PackageTool support for the `msix*` file extensions by cherry-picking the following commits from the v2 branch:

94d98dffcd8d3b0f3d0c895828bb3a592da2ef0d
d7d1a4c73b3f2ea5e3d414525da16e44fe4dc704
bc7396f408a1a8fec1ef46c54a51cdefd3ff0467
cf2379a8b6e60032f6c1fd1cd17ae27bd7b2318f
c414efd76f9959b0040877649ecb8844f876357e

This combination of commits does the following:

* Adds support for `.msix`, `.msixbundle`, `.mxixupload` package file extensions
* Proper handling of container files which contain stub packages
* Also adds support for creating submission pacakges for `.xvc` files (Xbox packages).  Submitting those packages using the v1 API however remains untested.
* Makes all `Test-Path` commands use `-ErrorAction Ignore` to avoid any erroneous errors being reported due to lack of file access (all we care about is getting a `$true` or `$false` response from those function calls).

Resolves #216