### PR TITLE
v2 New-SubmissionPackage: Fix PowerShell 6+ compatibility

### DIFF
--- a/StoreBroker/PackageConfig.ps1
+++ b/StoreBroker/PackageConfig.ps1
@@ -404,7 +404,7 @@ function Get-Config
     $configSchemaVersion = if ($null -eq $configObj.$VersionProperty) { 1 }
                            else { $configObj.$VersionProperty }
 
-    if ($configSchemaVersion -isnot [int])
+    if ($configSchemaVersion -isnot [int32] -and $configSchemaVersion -isnot [int64])
     {
         $out = @()
         $out += "For the config: [$ConfigPath]."


### PR DESCRIPTION
PowerShell 6+'s JSON deserializer deserializes numbers as `int64`. By checking for both, we can grow PS6+ compatibility and keep PS<=5.1 compatibility.