### PR TITLE
Fix telemetry failure for long-running sessions

### DIFF
--- a/StoreBroker/StoreBroker.psd1
+++ b/StoreBroker/StoreBroker.psd1
@@ -6,7 +6,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '1.21.0'
+    ModuleVersion = '1.21.1'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreIngestionApi'

--- a/StoreBroker/Telemetry.ps1
+++ b/StoreBroker/Telemetry.ps1
@@ -1,9 +1,7 @@
 ﻿# Copyright (C) Microsoft Corporation.  All rights reserved.
 
-# Singleton. Don't directly access this though....always get it
-# by calling Get-BaseTelemetryEvent to ensure that it has been initialized and that you're always
-# getting a fresh copy.
-$script:SBBaseTelemetryEvent = $null
+# Maintain a consistent ID for this PowerShell session that we'll use as our telemetry's session ID.
+$script:TelemetrySessionId = [System.GUID]::NewGuid().ToString()
 
 Add-Type -TypeDefinition @"
    public enum StoreBrokerTelemetryProperty
@@ -187,40 +185,35 @@ function Get-BaseTelemetryEvent
     [CmdletBinding()]
     param()
 
-    if ($null -eq $script:SBBaseTelemetryEvent)
+    if (-not $global:SBSuppressTelemetryReminder)
     {
-        if (-not $global:SBSuppressTelemetryReminder)
-        {
-            Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information.  Stop seeing this message in the future by setting `"`$global:SBSuppressTelemetryReminder=`$true`""
+        Write-Log -Message "Telemetry is currently enabled.  It can be disabled by setting ""`$global:SBDisableTelemetry = `$true"". Refer to USAGE.md#telemetry for more information.  Stop seeing this message in the future by setting `"`$global:SBSuppressTelemetryReminder=`$true`""
+    }
+
+    $username = Get-PiiSafeString -PlainText $env:USERNAME
+
+    return [PSCustomObject] @{
+        'name' = 'Microsoft.ApplicationInsights.66d83c523070489b886b09860e05e78a.Event'
+        'time' = (Get-Date).ToUniversalTime().ToString("O")
+        'iKey' = $global:SBApplicationInsightsKey
+        'tags' = [PSCustomObject] @{
+            'ai.user.id' = $username
+            'ai.session.id' = $script:TelemetrySessionId
+            'ai.application.ver' = $MyInvocation.MyCommand.Module.Version.ToString()
+            'ai.internal.sdkVersion' = '2.0.1.33027' # The version this schema was based off of.
         }
 
-        $username = Get-PiiSafeString -PlainText $env:USERNAME
-
-        $script:SBBaseTelemetryEvent = [PSCustomObject] @{
-            'name' = 'Microsoft.ApplicationInsights.66d83c523070489b886b09860e05e78a.Event'
-            'time' = (Get-Date).ToUniversalTime().ToString("O")
-            'iKey' = $global:SBApplicationInsightsKey
-            'tags' = [PSCustomObject] @{
-                'ai.user.id' = $username
-                'ai.session.id' = [System.GUID]::NewGuid().ToString()
-                'ai.application.ver' = $MyInvocation.MyCommand.Module.Version.ToString()
-                'ai.internal.sdkVersion' = '2.0.1.33027' # The version this schema was based off of.
-            }
-
-            'data' = [PSCustomObject] @{
-                'baseType' = 'EventData'
-                'baseData' = [PSCustomObject] @{
-                    'ver' = 2
-                    'properties' = [PSCustomObject] @{
-                        'DayOfWeek' = (Get-Date).DayOfWeek.ToString()
-                        'Username' = $username
-                    }
+        'data' = [PSCustomObject] @{
+            'baseType' = 'EventData'
+            'baseData' = [PSCustomObject] @{
+                'ver' = 2
+                'properties' = [PSCustomObject] @{
+                    'DayOfWeek' = (Get-Date).DayOfWeek.ToString()
+                    'Username' = $username
                 }
             }
         }
     }
-
-    return $script:SBBaseTelemetryEvent.PSObject.Copy() # Get a new instance, not a reference
 }
 
 function Invoke-SendTelemetryEvent


### PR DESCRIPTION
The telemetry code was creating a singleton base telemetry event the first time that telemetry was being sent.  That base event included the date.  If a PowerShell session lasted multiple days, the telemetry reporting would eventually start to fail because the date being reported for the event was too old.

We now just create a new telemetry event every time one is requested (this also ensures that it honors changes to the `ApplicationInsightsKey`), and now we only cache a GUID that we use to represent the "session" ID which we consider to be the duration of the current PowerShell session.