### PR TITLE
Import global settings from environment

### DIFF
--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -105,7 +105,7 @@ values of these variables will be honored if they already exist, otherwise they 
 
  **`$global:SBAutoRetryErrorCodes`** - [int[]] Some error status codes indicate that a retry is
    likely to be met with success.  StoreBroker will use an exponential back-off strategy for
-   the status codes contained within this list of values.  Defaults to `@(429, 503)`.
+   the status codes contained within this list of values.  Defaults to `@()`. Possible useful values:
 
   * `429` - The Submission API limits a Tenant to 20 requests per minute.  Any requests exceeding
        that will receive this error code until that minute has expired.

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -128,32 +128,76 @@ function Initialize-StoreIngestionApiGlobalVariables
     # SilentlyContinue would cause it to go into the global $Error array, Ignore prevents that as well.
     if (!(Get-Variable -Name SBDefaultProxyEndpoint -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBDefaultProxyEndpoint = $null
+        if ($env:SBDefaultProxyEndpoint)
+        {
+            $global:SBDefaultProxyEndpoint = [string]$env:SBDefaultProxyEndpoint
+        }
+        else
+        {
+            $global:SBDefaultProxyEndpoint = $null
+        }
+        
     }
 
     if (!(Get-Variable -Name SBAutoRetryErrorCodes -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBAutoRetryErrorCodes = @()
+        if ($env:SBAutoRetryErrorCodes)
+        {
+            $global:SBAutoRetryErrorCodes = $env:SBAutoRetryErrorCodes.Split(',') | ForEach-Object { [int]$_ }
+        }
+        else
+        {
+            $global:SBAutoRetryErrorCodes = @()
+        }
     }
 
     if (!(Get-Variable -Name SBGetRequestAutoRetryErrorCodes -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBGetRequestAutoRetryErrorCodes = @(429, 500, 502, 503)
+        if ($env:SBGetRequestAutoRetryErrorCodes)
+        {
+            $global:SBGetRequestAutoRetryErrorCodes = `
+                $env:SBGetRequestAutoRetryErrorCodes.Split(',') | ForEach-Object { [int]$_ }
+        }
+        else
+        {
+            $global:SBGetRequestAutoRetryErrorCodes = @(429, 500, 502, 503)
+        }
     }
 
     if (!(Get-Variable -Name SBMaxAutoRetries -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBMaxAutoRetries = 5
+        if ($env:SBMaxAutoRetries)
+        {
+            $global:SBMaxAutoRetries = [int]$env:SBMaxAutoRetries
+        }
+        else
+        {
+            $global:SBMaxAutoRetries = 5
+        }
     }
 
     if (!(Get-Variable -Name SBStoreBrokerClientName -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBStoreBrokerClientName = $null
+        if ($env:SBStoreBrokerClientName)
+        {
+            $global:SBStoreBrokerClientName = [string]$env:SBStoreBrokerClientName
+        }
+        else
+        {
+            $global:SBStoreBrokerClientName = $null
+        }
     }
 
     if (!(Get-Variable -Name SBDefaultTransferConnectionLimit -Scope Global -ValueOnly -ErrorAction Ignore))
     {
-        $global:SBDefaultTransferConnectionLimit = [Environment]::ProcessorCount * 8
+        if ($env:SBDefaultTransferConnectionLimit)
+        {
+            $global:SBDefaultTransferConnectionLimit = [int]$env:SBDefaultTransferConnectionLimit
+        }
+        else
+        {
+            $global:SBDefaultTransferConnectionLimit = [Environment]::ProcessorCount * 8
+        }
     }
 }
 


### PR DESCRIPTION
When they're unset, take the ingestion config options from environment variables if available. If not, fill in hard-coded defaults like normal.