### PR TITLE
Replace BinaryFormatter with PSSerializer

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -325,14 +325,8 @@ function DeepCopy-Object
         [PSCustomObject] $InputObject
     )
 
-    $memoryStream = New-Object System.IO.MemoryStream
-    $binaryFormatter = New-Object System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-    $binaryFormatter.Serialize($memoryStream, $InputObject)
-    $memoryStream.Position = 0
-    $deepCopiedObject = $binaryFormatter.Deserialize($memoryStream)
-    $memoryStream.Close()
-
-    return $deepCopiedObject
+    $serialData = [System.Management.Automation.PSSerializer]::Serialize($InputObject, 64)
+    return [System.Management.Automation.PSSerializer]::Deserialize($serialData)
 }
 
 function Get-SHA512Hash


### PR DESCRIPTION
BinaryFormatter has been removed from PowerShell 7.4 (since it was removed from .NET 7), so replacing with PSSerializer which can accomplish the same thing.