### PR TITLE
Proper fix for DeepCopy-Object

### DIFF
--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -275,7 +275,7 @@ function DeepCopy-Object
         [PSCustomObject] $Object
     )
 
-    $serialData = [System.Management.Automation.PSSerializer]::Serialize($InputObject, 64)
+    $serialData = [System.Management.Automation.PSSerializer]::Serialize($Object, 64)
     return [System.Management.Automation.PSSerializer]::Deserialize($serialData)
 }
 


### PR DESCRIPTION
The previous fix (#241) for #240 accidentally referenced the parameter as `$InputObject` instead of `$Object`.