### PR TITLE
Allow authorization using a certificate with Set-StoreBrokerCertificateAuthentication

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -141,6 +141,7 @@
         'Open-DevPortal',
         'Open-Store',
         'Set-StoreBrokerAuthentication',
+        'Set-StoreBrokerCertificateAuthentication',
         'Set-StoreFile',
         'Start-ApplicationFlightSubmissionMonitor',
         'Start-InAppProductSubmissionMonitor',

--- a/StoreBroker/StoreIngestionApi.psm1
+++ b/StoreBroker/StoreIngestionApi.psm1
@@ -579,12 +579,11 @@ function Get-AccessToken
         $clientId = $script:clientId
 
         $scopes = [string[]]@("https://api.partner.microsoft.com/.default")
-        
         $DllPath = Get-MsalDllPath
         Add-Type -Path $DllPath
 
-		try
-		{
+        try
+        {
             $appBuilder = [Microsoft.Identity.Client.ConfidentialClientApplicationBuilder]::Create($clientId)
             $null = $appBuilder.WithCertificate($Certificate)
 
@@ -721,7 +720,7 @@ function Get-AccessToken
 
                 if ($remoteErrors.Count -gt 0)
                 {
-                throw $remoteErrors[0].Exception
+                    throw $remoteErrors[0].Exception
                 }
             }
 


### PR DESCRIPTION
Adds a new Set-StoreBrokerCertificateAuthentication function that allows users to pass a X509Certificate2 object to use for authorization instead of a client id/secret.

Get-AccessToken was updated to use the Certificate for authentication. It will  download the Microsoft Authentication Library if it was not already present on the machine.  Microsoft.Identity.Client.ConfidentialClientApplicationBuilder is then used to authenticate using the Certificate. In the future we can consider using MSAL for client id/secret authentication too further merging the two forks  of code.