### PR TITLE
Refactor logic to exclude logging of fileSasUri in parameter objects

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.19'
+    ModuleVersion = '2.1.20'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'


### PR DESCRIPTION
Need to not log filesas objects in Write-InvocationLog when they are the properties of PSCustomObjects or Hashtables that are part of the passed in parameters.

Factor out the existing logic in Write-InputObject into a helper function that only does the copy & replace of the object.

Use that in Write-InvocationLog whenever a parameter is a PSCustomObject or Hashtable.