### PR TITLE
Reintroduce deep copy fix

### DIFF
--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.20'
+    ModuleVersion = '2.1.22'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker.psd1
+++ b/StoreBroker.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = 'Copyright (C) Microsoft Corporation.  All rights reserved.'
 
-    ModuleVersion = '2.1.21'
+    ModuleVersion = '2.1.20'
     Description = 'Provides command-line access to the Windows Store Submission REST API.'
 
     RootModule = 'StoreBroker/StoreIngestionApi.psm1'

--- a/StoreBroker/Helpers.ps1
+++ b/StoreBroker/Helpers.ps1
@@ -669,10 +669,13 @@ function Copy-InputObjectForLogging
     <#
     .SYNOPSIS
         Creates a copy of the InputObject and redacts some of its contents for logging.
+
     .DESCRIPTION
         Creates a copy of the InputObject and redacts some of its contents for logging.
+
     .PARAMETER InputObject
         Object to replace.
+
     .EXAMPLE
         $redactedObject = Copy-InputObjectForLogging -InputObject $MyObject
     
@@ -723,7 +726,7 @@ function Copy-InputObjectForLogging
         return $replacedInputObject;
     }
     else
-    {  
+    {
         # Unsupported object type, return null;
         return $null;
     }


### PR DESCRIPTION
In #263 we used DeepCopy-Object to create a copy of hashtables and pscustomobjects. This caused enums to be treated as PSCustomObjects and would later throw exceptions when Convert-EnumToString would call the copy() function on it.

My initial thought to fix was to call Convert-EnumToString before doing the deep-copy. However I noticed Convert-EnumToString is accomplishing the same thing we want to do and instead of using DeepCopy it does a shallow copy with Copy() and Clone() and then recursively makes more shallow copies.

We can modify our original solution to do the same thing since we are also calling child objects recursively if we plan on modifying them.
