### PR TITLE
Return new HttpResponseMessage instead of one from the service call in EndPoint.cs

### DIFF
--- a/RESTProxy/Models/Endpoint.cs
+++ b/RESTProxy/Models/Endpoint.cs
@@ -333,11 +333,17 @@ namespace Microsoft.Windows.Source.StoreBroker.RestProxy.Models
             }
             catch (WebException ex)
             {
-                // Even though WebException stores the response as a simple WebResponse, in our scenario
-                // it should actually be an HttpWebResponse.  We'd prefer that one, since HttpWebResponse
-                // exposes a StatusCode property.
                 HttpWebResponse httpResponse = ex.Response as HttpWebResponse;
-                return this.GetResponseMessage(httpResponse);
+
+                // Get just the status code; don't expose internal headers or other raw info.
+                HttpStatusCode statusCode = httpResponse?.StatusCode 
+                                            ?? HttpStatusCode.InternalServerError;
+
+                // Return or log only sanitized information.
+                return new HttpResponseMessage(statusCode)
+                {
+                    ReasonPhrase = "An error occurred while calling the web service." 
+                };
             }
         }
 


### PR DESCRIPTION
Prevents any information exposure from the APIs being forwarded.

Note: This change will lose client-side access to correlationId for RestProxy, consider a better method of not exposing additional information in the future.